### PR TITLE
Fix clear decomposed ContainerSizeConstraint if not manipulated

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
@@ -30,14 +30,26 @@ public final class ContainerSizeConstraint {
 	private final Integer minSize;
 	@Nullable
 	private final Integer maxSize;
-	private boolean minManipulated;
-	private boolean maxManipulated;
+	private final boolean minManipulated;
+	private final boolean maxManipulated;
 
-	public ContainerSizeConstraint(@Nullable Integer minSize, @Nullable Integer maxSize) {
+	public ContainerSizeConstraint(@Nullable Integer minSize, @Nullable Integer maxSize){
 		this.minSize = minSize;
 		this.maxSize = maxSize;
 		this.minManipulated = false;
 		this.maxManipulated = false;
+	}
+
+	public ContainerSizeConstraint(
+		@Nullable Integer minSize,
+		@Nullable Integer maxSize,
+		boolean minManipulated,
+		boolean maxManipulated
+	) {
+		this.minSize = minSize;
+		this.maxSize = maxSize;
+		this.minManipulated = minManipulated;
+		this.maxManipulated = maxManipulated;
 	}
 
 	public int getMinSize() {
@@ -62,21 +74,19 @@ public final class ContainerSizeConstraint {
 	}
 
 	public ContainerSizeConstraint withMinSize(@Nullable Integer minSize) {
-		minManipulated = true;
-		Integer maxSize = maxManipulated ? this.maxSize : null;
+		Integer maxSize = this.maxManipulated ? this.maxSize : null;
 		if (minSize == null && this.minSize != null) {
-			return new ContainerSizeConstraint(this.minSize, maxSize);
+			return new ContainerSizeConstraint(this.minSize, maxSize, true, this.maxManipulated);
 		}
-		return new ContainerSizeConstraint(minSize, maxSize);
+		return new ContainerSizeConstraint(minSize, maxSize, true, this.maxManipulated);
 	}
 
 	public ContainerSizeConstraint withMaxSize(@Nullable Integer maxSize) {
-		maxManipulated = true;
-		Integer minSize = minManipulated ? this.minSize : null;
+		Integer minSize = this.minManipulated ? this.minSize : null;
 		if (maxSize == null && this.maxSize != null) {
-			return new ContainerSizeConstraint(minSize, this.maxSize);
+			return new ContainerSizeConstraint(minSize, this.maxSize, this.minManipulated, true);
 		}
-		return new ContainerSizeConstraint(minSize, maxSize);
+		return new ContainerSizeConstraint(minSize, maxSize, this.minManipulated, true);
 
 	}
 }


### PR DESCRIPTION
decompose 결과 maxSize가 0이 된 리스트 필드가 있고 해당 리스트 필드에 minSize 1이상을 설정할 경우 (1,0) 발생하는 문제를 해결합니다.

manipulator로 설정된 ContainerSizeConstraint일 경우에만 min,max 값을 유지하고, decompose로 설정된 값은 초기화합니다.