### PR TITLE
Fix apply only last size manipulation

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -56,6 +56,7 @@ import com.navercorp.fixturemonkey.arbitrary.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryTree;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryType;
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+import com.navercorp.fixturemonkey.arbitrary.ContainerSizeConstraint;
 import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
@@ -464,16 +465,15 @@ public final class ArbitraryBuilder<T> {
 
 		if (manipulator instanceof ContainerSizeManipulator) {
 			ContainerSizeManipulator containerSizeManipulator = ((ContainerSizeManipulator)manipulator);
-			Integer min = containerSizeManipulator.getMin();
-			Integer max = containerSizeManipulator.getMax();
 
 			Collection<ArbitraryNode> foundNodes = this.findNodesByExpression(arbitraryExpression);
 			for (ArbitraryNode foundNode : foundNodes) {
 				if (!foundNode.getType().isContainer()) {
 					throw new IllegalArgumentException("Only Container can set size");
 				}
-				foundNode.setContainerMinSize(min);
-				foundNode.setContainerMaxSize(max);
+				foundNode.setContainerSizeConstraint(
+					new ContainerSizeConstraint(containerSizeManipulator.getMin(), containerSizeManipulator.getMax())
+				);
 				traverser.traverse(foundNode, false, generator); // regenerate subtree
 			}
 		} else {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -173,24 +173,6 @@ public final class ArbitraryNode<T> {
 		this.getStatus().setActive(active);
 	}
 
-	public void setContainerMinSize(@Nullable Integer minSize) {
-		FixtureNodeStatus<T> status = this.getStatus();
-		if (status.getContainerSizeConstraint() == null) {
-			status.setContainerSizeConstraint(new ContainerSizeConstraint(minSize, null));
-			return;
-		}
-		status.setContainerSizeConstraint(status.getContainerSizeConstraint().withMinSize(minSize));
-	}
-
-	public void setContainerMaxSize(@Nullable Integer maxSize) {
-		FixtureNodeStatus<T> status = this.getStatus();
-		if (status.getContainerSizeConstraint() == null) {
-			status.setContainerSizeConstraint(new ContainerSizeConstraint(null, maxSize));
-			return;
-		}
-		status.setContainerSizeConstraint(status.getContainerSizeConstraint().withMaxSize(maxSize));
-	}
-
 	public void setContainerSizeConstraint(ContainerSizeConstraint containerSizeConstraint) {
 		this.getStatus().setContainerSizeConstraint(containerSizeConstraint);
 	}
@@ -288,6 +270,7 @@ public final class ArbitraryNode<T> {
 		return getStatus().isFixed();
 	}
 
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	public boolean isLeafNode() {
 		return this.getChildren().isEmpty() && this.getArbitrary() != null;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
@@ -30,26 +30,10 @@ public final class ContainerSizeConstraint {
 	private final Integer minSize;
 	@Nullable
 	private final Integer maxSize;
-	private final boolean minManipulated;
-	private final boolean maxManipulated;
 
 	public ContainerSizeConstraint(@Nullable Integer minSize, @Nullable Integer maxSize) {
 		this.minSize = minSize;
 		this.maxSize = maxSize;
-		this.minManipulated = false;
-		this.maxManipulated = false;
-	}
-
-	public ContainerSizeConstraint(
-		@Nullable Integer minSize,
-		@Nullable Integer maxSize,
-		boolean minManipulated,
-		boolean maxManipulated
-	) {
-		this.minSize = minSize;
-		this.maxSize = maxSize;
-		this.minManipulated = minManipulated;
-		this.maxManipulated = maxManipulated;
 	}
 
 	public int getMinSize() {
@@ -71,22 +55,5 @@ public final class ContainerSizeConstraint {
 
 	public int getArbitraryElementSize() {
 		return Arbitraries.integers().between(getMinSize(), getMaxSize()).sample();
-	}
-
-	public ContainerSizeConstraint withMinSize(@Nullable Integer minSize) {
-		Integer manipulatedMaxSize = this.maxManipulated ? this.maxSize : null;
-		if (minSize == null && this.minSize != null) {
-			return new ContainerSizeConstraint(this.minSize, manipulatedMaxSize, true, this.maxManipulated);
-		}
-		return new ContainerSizeConstraint(minSize, manipulatedMaxSize, true, this.maxManipulated);
-	}
-
-	public ContainerSizeConstraint withMaxSize(@Nullable Integer maxSize) {
-		Integer manipulatedMinSize = this.minManipulated ? this.minSize : null;
-		if (maxSize == null && this.maxSize != null) {
-			return new ContainerSizeConstraint(manipulatedMinSize, this.maxSize, this.minManipulated, true);
-		}
-		return new ContainerSizeConstraint(manipulatedMinSize, maxSize, this.minManipulated, true);
-
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.ArrayList;
@@ -445,25 +446,25 @@ public class SimpleManipulatorTest {
 	}
 
 	@Property
-	void giveMeSizeMaxSizeBeforeMinSizeIsZero() {
+	void giveMeSizeMaxSizeBeforeMinSizeThenMinSizeWorks() {
 		// when
 		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
 			.maxSize("values", 15)
 			.minSize("values", 14)
 			.sample();
 
-		then(actual.values.size()).isBetween(14, 15);
+		then(actual.values).hasSizeGreaterThanOrEqualTo(14);
 	}
 
 	@Property
-	void giveMeSizeMinSizeBeforeMaxSizeIsZero() {
+	void giveMeSizeMinSizeBeforeMaxSizeThenMaxSizeWorks() {
 		// when
 		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
 			.minSize("values", 14)
 			.maxSize("values", 15)
 			.sample();
 
-		then(actual.values.size()).isBetween(14, 15);
+		then(actual.values).hasSizeLessThanOrEqualTo(15);
 	}
 
 	@Property
@@ -756,13 +757,105 @@ public class SimpleManipulatorTest {
 	}
 
 	@Property
-	void giveMeSizeZeroReturnsEmpty(){
+	void giveMeSizeZeroReturnsEmpty() {
 		// when
 		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
 			.size("values", 0)
 			.sample();
 
 		then(actual.values).isEmpty();
+	}
+
+	@Property
+	void giveMeSizeMinSizeBiggerThanDefaultMaxSize() {
+		// given
+		int minSize = DEFAULT_ELEMENT_MAX_SIZE + 1;
+
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", minSize)
+			.sample();
+
+		then(actual.values).hasSizeGreaterThanOrEqualTo(minSize);
+	}
+
+	@Property
+	void giveMeMaxSizeLessThanFixedMinSize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 2)
+			.maxSize("values", 3)
+			.fixed()
+			.maxSize("values", 1)
+			.sample();
+
+		then(actual.values).hasSizeLessThanOrEqualTo(1);
+	}
+
+	@Property
+	void giveMeMaxSizeLessThanFixedMaxSize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 1)
+			.maxSize("values", 3)
+			.fixed()
+			.maxSize("values", 2)
+			.sample();
+
+		then(actual.values).hasSizeLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void giveMeSizeInFixedArbitrarySize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 1)
+			.maxSize("values", 3)
+			.fixed()
+			.size("values", 2)
+			.sample();
+
+		then(actual.values).hasSize(2);
+	}
+
+	@Property
+	void giveMeMinSizeLessThenFixedMaxSize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 1)
+			.maxSize("values", 3)
+			.fixed()
+			.minSize("values", 2)
+			.sample();
+
+		then(actual.values).hasSizeGreaterThanOrEqualTo(2);
+	}
+
+	@Property
+	void giveMeMinSizeGreaterThanFixedMaxSize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 1)
+			.maxSize("values", 3)
+			.fixed()
+			.minSize("values", 4)
+			.sample();
+
+		then(actual.values).hasSizeGreaterThanOrEqualTo(4);
+	}
+
+	@Property
+	void giveMeIncludeFixedArbitrarySize() {
+		// when
+		IntegerListWrapperClass actual = this.sut.giveMeBuilder(IntegerListWrapperClass.class)
+			.minSize("values", 1)
+			.maxSize("values", 3)
+			.fixed()
+			.minSize("values", 0)
+			.maxSize("values", 4)
+			.sample();
+
+		then(actual.values).hasSizeBetween(0, 4);
 	}
 
 	@Data


### PR DESCRIPTION
size에 관련된 연산들 (size, minSize, maxSize) 는 더이상 중첩되지 않고 마지막에 선언한 연산만 적용합니다.
Breaking change라 주문서에 영향이 있을 수 있습니다. 

ex)
```
minSize("values",  2);
maxSize("values", 3);
```
예시와 같은 경우에는 maxSize만 적용됩니다.