### PR TITLE
Add fixture-monkey-engine to split junit/jqwik engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,13 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
 
     ext {
+        JUNIT_ENGINE_VERSION = "1.7.0"
         JQWIK_VERSION = "1.3.9"
     }
 
     dependencies {
         api("com.google.code.findbugs:jsr305:3.0.2")
-        compileOnly("org.slf4j:slf4j-api:1.7.30")
+        compileOnly("org.slf4j:slf4j-api:1.7.25")
         testCompile("ch.qos.logback:logback-classic:1.2.3")
     }
 

--- a/fixture-monkey-autoparams/build.gradle
+++ b/fixture-monkey-autoparams/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     api(project(":fixture-monkey"))
     api("io.github.javaunit:autoparams:0.3.0")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
     testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("org.projectlombok:lombok:1.18.16")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.16")

--- a/fixture-monkey-engine/build.gradle
+++ b/fixture-monkey-engine/build.gradle
@@ -8,16 +8,11 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(project(":fixture-monkey-engine"))
-
-    api("net.jqwik:jqwik:${JQWIK_VERSION}")
-    api("javax.validation:validation-api:2.0.1.Final")
-    api("com.github.mifmif:generex:1.0.2")
+    api("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
+    api("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
 
     testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("org.projectlombok:lombok:1.18.16")
-    testImplementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    testImplementation("org.glassfish:jakarta.el:3.0.3")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.16")
 }
 
@@ -102,6 +97,7 @@ jacocoTestCoverageVerification {
     }
 }
 check.dependsOn jacocoTestCoverageVerification
+
 
 jar {
     manifest {

--- a/fixture-monkey-engine/gradle.properties
+++ b/fixture-monkey-engine/gradle.properties
@@ -1,0 +1,4 @@
+artifactId=fixture-monkey-engine
+artifactName=Fixture Monkey Engine
+artifactDescription=Fixture Monkey Test Engine.
+artifactVersion=0.3.0

--- a/fixture-monkey-mockito/build.gradle
+++ b/fixture-monkey-mockito/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     api(project(":fixture-monkey"))
     api("org.mockito:mockito-core:3.9.0")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
     testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("org.projectlombok:lombok:1.18.16")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.16")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = "fixture-monkey-parent"
 
+include "fixture-monkey-engine"
 include "fixture-monkey"
 include "fixture-monkey-kotlin"
 include "fixture-monkey-jackson"


### PR DESCRIPTION
- fixture-monkey-engine 모듈을 추가하고 junit-plateform-engine 및 jqwik-engine 을 의존시킵니다.
- 우선 라이브러리 의존만 정리하고, 다음 단계로 engine 과 관련된 로직을 이동시킵니다.
- 0.4.0 반영 합니다.