### PR TITLE
Refactor ArbitraryValue methods return Arbitrary

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTree.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -127,10 +128,10 @@ public final class ArbitraryTree<T> {
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public Arbitrary<T> result(
 		Supplier<Arbitrary<T>> generateArbitrary,
-		ArbitraryValidator<T> validator,
+		ArbitraryValidator validator,
 		boolean validOnly
 	) {
-		return new ArbitraryValue(generateArbitrary, validator, validOnly);
+		return new ArbitraryValue(generateArbitrary, validator, validOnly, new ConcurrentHashMap<>());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
@@ -274,19 +274,6 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	public synchronized Stream<T> sampleStream() {
 		try {
 			return getArbitrary().sampleStream();
-		} catch (TooManyFilterMissesException ex) {
-			StringBuilder builder = new StringBuilder();
-			this.violations.values().forEach(violation -> builder
-				.append("- violation: ").append(violation.getMessage())
-				.append(", type: ").append(violation.getRootBeanClass())
-				.append(", property: ").append(violation.getPropertyPath())
-				.append(", invalidValue: ").append(violation.getInvalidValue())
-				.append("\n"));
-
-			log.error("Fail to create valid arbitrary."
-				+ "\n\nFixture factory Constraint Violation messages. \n\n" + builder, lastException);
-
-			throw ex;
 		} finally {
 			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.arbitrary;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,20 +56,24 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	private final Supplier<Arbitrary<T>> generateArbitrary;
 	private Arbitrary<T> arbitrary;
 	private final boolean validOnly;
-	private final ArbitraryValidator<T> validator;
 	@SuppressWarnings("rawtypes")
-	private final Map<String, ConstraintViolation> violations = new HashMap<>();
+	private final ArbitraryValidator validator;
+	@SuppressWarnings("rawtypes")
+	private final Map<String, ConstraintViolation> violations;
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	private Exception lastException;
 
+	@SuppressWarnings("rawtypes")
 	public ArbitraryValue(
 		Supplier<Arbitrary<T>> generateArbitrary,
-		ArbitraryValidator<T> validator,
-		boolean validOnly
+		ArbitraryValidator validator,
+		boolean validOnly,
+		Map<String, ConstraintViolation> violations
 	) {
 		this.generateArbitrary = generateArbitrary;
 		this.validator = validator;
 		this.validOnly = validOnly;
+		this.violations = violations;
 	}
 
 	@Override
@@ -83,12 +86,13 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	}
 
 	@Override
-	public synchronized Arbitrary<Object> asGeneric() {
-		try {
-			return getArbitrary().asGeneric();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Object> asGeneric() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().asGeneric(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
@@ -142,57 +146,63 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	}
 
 	@Override
-	public synchronized Arbitrary<T> filter(Predicate<T> filterPredicate) {
-		try {
-			return getArbitrary().filter(filterPredicate);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> filter(Predicate<T> filterPredicate) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().filter(filterPredicate),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized <U> Arbitrary<U> map(Function<T, U> mapper) {
-		try {
-			return getArbitrary().map(mapper);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public <U> Arbitrary<U> map(Function<T, U> mapper) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().map(mapper),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized <U> Arbitrary<U> flatMap(Function<T, Arbitrary<U>> mapper) {
-		try {
-			return getArbitrary().flatMap(mapper);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public <U> Arbitrary<U> flatMap(Function<T, Arbitrary<U>> mapper) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().flatMap(mapper),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> injectNull(double nullProbability) {
-		try {
-			return getArbitrary().injectNull(nullProbability);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> injectNull(double nullProbability) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().injectNull(nullProbability),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> unique() {
-		try {
-			return getArbitrary().unique();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> unique() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().unique(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> fixGenSize(int genSize) {
-		try {
-			return getArbitrary().fixGenSize(genSize);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> fixGenSize(int genSize) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().fixGenSize(genSize),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
@@ -241,27 +251,42 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	}
 
 	@Override
-	public synchronized Arbitrary<Optional<T>> optional() {
-		try {
-			return getArbitrary().optional();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Optional<T>> optional() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().optional(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<List<T>> collect(Predicate<List<T>> until) {
-		try {
-			return getArbitrary().collect(until);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<List<T>> collect(Predicate<List<T>> until) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().collect(until),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
 	public synchronized Stream<T> sampleStream() {
 		try {
 			return getArbitrary().sampleStream();
+		} catch (TooManyFilterMissesException ex) {
+			StringBuilder builder = new StringBuilder();
+			this.violations.values().forEach(violation -> builder
+				.append("- violation: ").append(violation.getMessage())
+				.append(", type: ").append(violation.getRootBeanClass())
+				.append(", property: ").append(violation.getPropertyPath())
+				.append(", invalidValue: ").append(violation.getInvalidValue())
+				.append("\n"));
+
+			log.error("Fail to create valid arbitrary."
+				+ "\n\nFixture factory Constraint Violation messages. \n\n" + builder, lastException);
+
+			throw ex;
 		} finally {
 			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
 		}
@@ -290,84 +315,93 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 	}
 
 	@Override
-	public synchronized Arbitrary<T> injectDuplicates(double duplicateProbability) {
-		try {
-			return getArbitrary().injectDuplicates(duplicateProbability);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> injectDuplicates(double duplicateProbability) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().injectDuplicates(duplicateProbability),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<Tuple1<T>> tuple1() {
-		try {
-			return getArbitrary().tuple1();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Tuple1<T>> tuple1() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().tuple1(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<Tuple2<T, T>> tuple2() {
-		try {
-			return getArbitrary().tuple2();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Tuple2<T, T>> tuple2() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().tuple2(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<Tuple3<T, T, T>> tuple3() {
-		try {
-			return getArbitrary().tuple3();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Tuple3<T, T, T>> tuple3() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().tuple3(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<Tuple4<T, T, T, T>> tuple4() {
-		try {
-			return getArbitrary().tuple4();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Tuple4<T, T, T, T>> tuple4() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().tuple4(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<Tuple5<T, T, T, T, T>> tuple5() {
-		try {
-			return getArbitrary().tuple5();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<Tuple5<T, T, T, T, T>> tuple5() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().tuple5(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> ignoreException(Class<? extends Throwable> exceptionType) {
-		try {
-			return getArbitrary().ignoreException(exceptionType);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> ignoreException(Class<? extends Throwable> exceptionType) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().ignoreException(exceptionType),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> dontShrink() {
-		try {
-			return getArbitrary().dontShrink();
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> dontShrink() {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().dontShrink(),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@Override
-	public synchronized Arbitrary<T> edgeCases(Consumer<Config<T>> configurator) {
-		try {
-			return getArbitrary().edgeCases(configurator);
-		} finally {
-			this.arbitrary = null; // in order to getting new value whenever sampling, set arbitrary as null
-		}
+	public Arbitrary<T> edgeCases(Consumer<Config<T>> configurator) {
+		return new ArbitraryValue<>(
+			() -> getArbitrary().edgeCases(configurator),
+			this.validator,
+			this.validOnly,
+			this.violations
+		);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -391,7 +425,7 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 			}
 
 			try {
-				validator.validate((T)fixture);
+				validator.validate(fixture);
 				return true;
 			} catch (ConstraintViolationException ex) {
 				ex.getConstraintViolations().forEach(violation ->

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryValue.java
@@ -279,10 +279,13 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public synchronized T sample() {
 		try {
-			return getArbitrary().sample();
+			return (T)getArbitrary()
+				.filter(this.validateFilter(validOnly))
+				.sample();
 		} catch (TooManyFilterMissesException ex) {
 			StringBuilder builder = new StringBuilder();
 			this.violations.values().forEach(violation -> builder
@@ -391,11 +394,9 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 		);
 	}
 
-	@SuppressWarnings("unchecked")
 	private synchronized Arbitrary<T> getArbitrary() {
 		if (this.arbitrary == null) {
-			this.arbitrary = generateArbitrary.get()
-				.filter((Predicate<T>)this.validateFilter(validOnly));
+			this.arbitrary = generateArbitrary.get();
 		}
 		return this.arbitrary;
 	}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.test;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -42,10 +43,15 @@ import javax.validation.constraints.Positive;
 
 import org.junit.platform.commons.util.StringUtils;
 
+import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Example;
 import net.jqwik.api.Property;
 import net.jqwik.api.TooManyFilterMissesException;
+import net.jqwik.api.Tuple.Tuple1;
+import net.jqwik.api.Tuple.Tuple2;
+import net.jqwik.api.Tuple.Tuple3;
+import net.jqwik.api.arbitraries.SetArbitrary;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -310,7 +316,8 @@ class FixtureMonkeyTest {
 	}
 
 	@Example
-	void giveMeBuilderInvalidThenSampleTooManyFilterMissesException() {
+	void giveMeBuilderBuildInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
 		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
 			.set("value", "")
 			.build();
@@ -320,13 +327,362 @@ class FixtureMonkeyTest {
 	}
 
 	@Example
-	void giveMeBuilderInvalidThenSampleStreamTooManyFilterMissesException() {
+	void giveMeBuilderBuildInvalidThenSampleStreamThrowsTooManyFilterMissesException() {
+		// when
 		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
 			.set("value", "")
 			.build();
 
+		//noinspection ResultOfMethodCallIgnored
 		thenThrownBy(() -> sut.sampleStream().limit(5).collect(toList()))
 			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeBuilderBuildUniqueInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.unique();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeArbitraryUnique() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.unique();
+
+		thenNoException()
+			.isThrownBy(sut::sample);
+	}
+
+	@Example
+	void giveMeBuilderBuildFixGenSizeInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.fixGenSize(5);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeBuilderBuildOptionalInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<Optional<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+				.set("value", "")
+				.build()
+				.optional();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryOptional() {
+		// given
+		Arbitrary<Optional<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+				.optional();
+
+		// when
+		Optional<StringWithNotBlankWrapperClass> actual = sut.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildCollectInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<List<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+				.set("value", "")
+				.build()
+				.collect(List::isEmpty);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryCollect() {
+		// given
+		Arbitrary<List<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+				.collect(List::isEmpty);
+
+		// when
+		List<StringWithNotBlankWrapperClass> actual = sut.sample();
+
+		then(actual).isEmpty();
+	}
+
+	@Example
+	void giveMeBuilderBuildInjectDuplicatesInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut =
+			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+				.set("value", "")
+				.build()
+				.injectDuplicates(1);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeArbitraryInjectDuplicates() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.injectDuplicates(1);
+
+		thenNoException()
+			.isThrownBy(sut::sample);
+	}
+
+	@Example
+	void giveMeBuilderBuildTuple1InvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<Tuple1<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+				.set("value", "")
+				.build()
+				.tuple1();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryTuple1() {
+		// given
+		Arbitrary<Tuple1<StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+				.tuple1();
+
+		// when
+		Tuple1<StringWithNotBlankWrapperClass> sample = sut.sample();
+
+		then(sample).isNotNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildTuple2InvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<Tuple2<StringWithNotBlankWrapperClass, StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+				.set("value", "")
+				.build()
+				.tuple2();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryTuple2() {
+		// given
+		Arbitrary<Tuple2<StringWithNotBlankWrapperClass, StringWithNotBlankWrapperClass>> sut =
+			this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+				.tuple2();
+
+		// when
+		Tuple2<StringWithNotBlankWrapperClass, StringWithNotBlankWrapperClass> sample = sut.sample();
+
+		then(sample).isNotNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildIgnoreExceptionInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.ignoreException(NullPointerException.class);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryIgnoreException() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.ignoreException(NullPointerException.class);
+
+		thenNoException()
+			.isThrownBy(sut::sample);
+	}
+
+	@Example
+	void giveMeBuilderBuildDontShrinkInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.dontShrink();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryDontShrink() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.dontShrink();
+
+		thenNoException()
+			.isThrownBy(sut::sample);
+	}
+
+	@Example
+	void giveMeBuilderBuildEdgeCasesInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.edgeCases(it -> {
+			});
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryEdgeCases() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.edgeCases(it -> {
+			});
+
+		thenNoException()
+			.isThrownBy(sut::sample);
+	}
+
+	@Example
+	void giveMeBuilderBuildInjectNullInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.injectNull(0);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeArbitraryInjectNull() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.injectNull(1);
+
+		StringWithNotBlankWrapperClass actual = sut.sample();
+
+		then(actual).isNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildFlatMapInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<String> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.flatMap(it -> Arbitraries.just("String"));
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Example
+	void giveMeArbitraryFlatMap() {
+		// given
+		Arbitrary<String> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.flatMap(it -> Arbitraries.just("String"));
+
+		String actual = sut.sample();
+
+		then(actual).isEqualTo("String");
+	}
+
+	@Example
+	void giveMeBuilderBuildMapInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.map(it -> it);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryMap() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.map(it -> it);
+
+		// when
+		StringWithNotBlankWrapperClass actual = sut.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildFilterInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.filter(it -> true);
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryFilter() {
+		// given
+		Arbitrary<StringWithNotBlankWrapperClass> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.filter(it -> true);
+
+		// when
+		StringWithNotBlankWrapperClass actual = sut.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@Example
+	void giveMeBuilderBuildAsGenericInvalidThenSampleThrowsTooManyFilterMissesException() {
+		// when
+		Arbitrary<Object> sut = this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
+			.set("value", "")
+			.build()
+			.asGeneric();
+
+		thenThrownBy(sut::sample)
+			.isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void giveMeArbitraryAsGeneric() {
+		// given
+		Arbitrary<Object> sut = this.sut.giveMeArbitrary(StringWithNotBlankWrapperClass.class)
+			.asGeneric();
+
+		// when
+		Object actual = sut.sample();
+
+		then(actual).isNotNull();
 	}
 
 	@Property

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -50,8 +50,6 @@ import net.jqwik.api.Property;
 import net.jqwik.api.TooManyFilterMissesException;
 import net.jqwik.api.Tuple.Tuple1;
 import net.jqwik.api.Tuple.Tuple2;
-import net.jqwik.api.Tuple.Tuple3;
-import net.jqwik.api.arbitraries.SetArbitrary;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -404,8 +402,7 @@ class FixtureMonkeyTest {
 		Arbitrary<List<StringWithNotBlankWrapperClass>> sut =
 			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
 				.set("value", "")
-				.build()
-				.collect(it -> !it.isEmpty());
+				.build().collect(it -> !it.isEmpty());
 
 		thenThrownBy(sut::sample)
 			.isExactlyInstanceOf(TooManyFilterMissesException.class);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -405,7 +405,7 @@ class FixtureMonkeyTest {
 			this.sut.giveMeBuilder(StringWithNotBlankWrapperClass.class)
 				.set("value", "")
 				.build()
-				.collect(List::isEmpty);
+				.collect(it -> !it.isEmpty());
 
 		thenThrownBy(sut::sample)
 			.isExactlyInstanceOf(TooManyFilterMissesException.class);


### PR DESCRIPTION
우선 Arbitrary를 반환값으로 가지는 경우만 처리했습니다.
Arbitrary를 반환할 때 ArbitraryValue를 반환해서 `sample`, `sampleStream`을 실행하는 시점을 추적합니다.
값을 반환하는 `sample`, `sampleStream`를 실행하는 시점에서 내부 동작은 모두 Lazy하고 모든 연산이 실행됩니다.

Validation 실패 원인을 로깅하기 위해 같은 ArbitraryValue 객체들은 violations를 공유합니다.
동시에 실행하는 경우는 거이 없겠지만, 있을 수도 있으므로 ConcurrentHashMap을 구현체로 사용합니다.
공유하더라도 Validation 실패하는 경우이므로 문제가 없습니다.