### PR TITLE
Add fixture-monkey-starter module

### DIFF
--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -8,15 +8,15 @@ plugins {
 }
 
 dependencies {
-    api("net.jqwik:jqwik:${JQWIK_VERSION}")
-    compileOnly("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
-    api("javax.validation:validation-api:2.0.1.Final")
-    api("com.github.mifmif:generex:1.0.2")
+    api(project(":fixture-monkey"))
+    api("ch.qos.logback:logback-classic:1.2.3")
+    api("org.hibernate.validator:hibernate-validator:6.2.0.Final")
+    api("org.glassfish:jakarta.el:3.0.3")
 
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.0")
     testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("org.projectlombok:lombok:1.18.16")
-    testImplementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    testImplementation("org.glassfish:jakarta.el:3.0.3")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.16")
 }
 
@@ -25,9 +25,7 @@ editorconfig {
 }
 
 test {
-    useJUnitPlatform {
-        includeEngines "jqwik"
-    }
+    useJUnitPlatform()
 }
 
 check.dependsOn editorconfigCheck
@@ -101,6 +99,7 @@ jacocoTestCoverageVerification {
     }
 }
 check.dependsOn jacocoTestCoverageVerification
+
 
 jar {
     manifest {

--- a/fixture-monkey-starter/gradle.properties
+++ b/fixture-monkey-starter/gradle.properties
@@ -1,0 +1,4 @@
+artifactId=fixture-monkey-starter
+artifactName=Fixture Monkey Starter
+artifactDescription=Fixture Monkey dependency package for simple starting.
+artifactVersion=0.3.0

--- a/fixture-monkey-starter/src/main/resources/logback.xml
+++ b/fixture-monkey-starter/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/fixture-monkey-starter/src/test/java/com/navercorp/fixturemonkey/starter/FixtureMonkeyStarterTest.java
+++ b/fixture-monkey-starter/src/test/java/com/navercorp/fixturemonkey/starter/FixtureMonkeyStarterTest.java
@@ -1,0 +1,66 @@
+package com.navercorp.fixturemonkey.starter;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Size;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.Data;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+
+class FixtureMonkeyStarterTest {
+	@Data   // lombok getter, setter
+	public static class Order {
+		@NotNull
+		private Long id;
+
+		@NotBlank
+		private String orderNo;
+
+		@Size(min = 2, max = 10)
+		private String productName;
+
+		@Min(1)
+		@Max(100)
+		private int quantity;
+
+		@Min(0)
+		private long price;
+
+		@Size(max = 3)
+		private List<@NotBlank @Size(max = 10) String> items = new ArrayList<>();
+
+		@PastOrPresent
+		private Instant orderedAt;
+
+		@Email
+		private String sellerEmail;
+	}
+
+	@Test
+	void test() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.create();
+
+		// when
+		Order actual = sut.giveMeOne(Order.class);
+
+		// then
+		then(actual.getId()).isNotNull();
+		then(actual.getOrderNo()).isNotBlank();
+		then(actual.getQuantity()).isBetween(1, 100);
+		then(actual.getPrice()).isGreaterThanOrEqualTo(0L);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,4 @@ include "fixture-monkey-kotlin"
 include "fixture-monkey-jackson"
 include "fixture-monkey-autoparams"
 include "fixture-monkey-mockito"
-
+include "fixture-monkey-starter"


### PR DESCRIPTION
- starter dependency 로 바로 시작할 수 있는 starter 모듈을 추가합니다.
- 빈 프로젝트에서 fixture-monkey dependency 만 추가해서 바로 해보려니까 logger 구현체가 없어서 에러가 나네요
- logger 구현체도 직접 추가해줘야 되고, Validation 을 적용하기 위해서는 Validator 구현체도 직접 지정해줘야 되는 불편함이 있어서 이들의 dependency 를 바로 적용할 수 있는 fixture-monkey-starter 모듈을 추가합니다.
- logback 의존성이나 validator 구현체를 다른걸로 사용하고 싶은 사용자는 starter 를 의존하지 않고 직접 지정하면 됩니다.