### PR TITLE
Add fixture-monkey-api module for spi interfaces

### DIFF
--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -8,28 +8,11 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(project(":fixture-monkey-engine"))
-    api(project(":fixture-monkey-api"))
-
-    api("net.jqwik:jqwik:${JQWIK_VERSION}")
-    api("javax.validation:validation-api:2.0.1.Final")
-    api("com.github.mifmif:generex:1.0.2")
-
-    testImplementation("org.assertj:assertj-core:3.18.1")
-    testImplementation("org.projectlombok:lombok:1.18.16")
-    testImplementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    testImplementation("org.glassfish:jakarta.el:3.0.3")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.16")
+    api("org.apiguardian:apiguardian-api:1.1.0")
 }
 
 editorconfig {
     excludes = ["build"]
-}
-
-test {
-    useJUnitPlatform {
-        includeEngines "jqwik"
-    }
 }
 
 check.dependsOn editorconfigCheck
@@ -103,6 +86,7 @@ jacocoTestCoverageVerification {
     }
 }
 check.dependsOn jacocoTestCoverageVerification
+
 
 jar {
     manifest {

--- a/fixture-monkey-api/gradle.properties
+++ b/fixture-monkey-api/gradle.properties
@@ -1,0 +1,4 @@
+artifactId=fixture-monkey-api
+artifactName=Fixture Monkey API
+artifactDescription=Fixture Monkey SPI interfaces.
+artifactVersion=0.3.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = "fixture-monkey-parent"
 
+include "fixture-monkey-api"
 include "fixture-monkey-engine"
 include "fixture-monkey"
 include "fixture-monkey-kotlin"


### PR DESCRIPTION
확장을 지원할 spi Interface 들을 제공하는 fixture-monkey-api 모듈을 추가합니다.
fixture-monkey 에서 확장을 지원할 인터페이스는 여기에 추가하고, 기존 인터페이스는 @Deprecated 처리합니다.
fixture-monkey-jackson, fixture-monkey-mockito 도 fixture-monkey 를 바로 의존하는 것이 아니라 fixture-monkey-api 를 의존하고 필요한 구현체를 제공하도록 수정합니다.

Deprecated 된 fixture-monkey 의 인터페이스는 0.5.0 에서 제거합니다.