### PR TITLE
Fix give me builder iterator cursor

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/IteratorBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/IteratorBuilder.java
@@ -29,6 +29,6 @@ final class IteratorBuilder {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	<T> Arbitrary<T> build(List<ArbitraryNode> nodes) {
-		return (Arbitrary<T>)ListBuilder.INSTANCE.build(nodes).map(it -> ((List)it).iterator());
+		return (Arbitrary<T>)ListBuilder.INSTANCE.build(nodes).map(it -> ((List)it).listIterator());
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -196,6 +196,56 @@ class FixtureMonkeyTest {
 		then(actual.values.next()).isEqualTo(1);
 	}
 
+	@Example
+	void giveMeIteratorToBuilderCursorNotChanged() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultGenerator(BuilderArbitraryGenerator.INSTANCE)
+			.build();
+		IntegerIteratorWrapperClass expected = sut.giveMeBuilder(IntegerIteratorWrapperClass.class)
+			.size("values", 3)
+			.set("values[0]", 1)
+			.set("values[1]", 2)
+			.set("values[2]", 3)
+			.sample();
+
+		// when
+		IntegerIteratorWrapperClass actual = sut.giveMeBuilder(expected).sample();
+
+		then(actual.values.next()).isEqualTo(1);
+		then(actual.values.next()).isEqualTo(2);
+		then(actual.values.next()).isEqualTo(3);
+
+		then(expected.values.next()).isEqualTo(1);
+		then(expected.values.next()).isEqualTo(2);
+		then(expected.values.next()).isEqualTo(3);
+	}
+
+	@Example
+	void giveMeListIteratorToBuilderCursorMovedNotChanged() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultGenerator(BuilderArbitraryGenerator.INSTANCE)
+			.build();
+		IntegerIteratorWrapperClass expected = sut.giveMeBuilder(IntegerIteratorWrapperClass.class)
+			.size("values", 3)
+			.set("values[0]", 1)
+			.set("values[1]", 2)
+			.set("values[2]", 3)
+			.sample();
+		expected.values.next();
+
+		// when
+		IntegerIteratorWrapperClass actual = sut.giveMeBuilder(expected).sample();
+
+		then(actual.values.next()).isEqualTo(1);
+		then(actual.values.next()).isEqualTo(2);
+		then(actual.values.next()).isEqualTo(3);
+
+		then(expected.values.next()).isEqualTo(2);
+		then(expected.values.next()).isEqualTo(3);
+	}
+
 	@Property
 	void giveMeStreamToBuilder() {
 		// given


### PR DESCRIPTION
- giveMeBuilder 에서 Iterator 커서가 변경되는 부분을 수정합니다.
- DefaultContainerArbitraryNodeGenerator 의 generator 에서 lazyValue 가 Iterator 일때 next 로 이동을 하면서 새로운 ArbitraryNode 를 생성합니다.
- 기존의 Iterator 가 next 로 이동을 해버리는 문제가 발생합니다.
- ListIterator  가 아닌 Iterator 는 복사를 하거나 Cursor 를 돌릴 방법이 없다.
- Iterator 는 known issue 로 남겨두고 ListIterator 는 복사 후 Cursor 를 되돌리는 작업을 수행한다.
- IteratorBuilder 의 기본 Iterator 도 listIterator 로 생성하도록 변경한다.