### PR TITLE
Add CallbackOperation for better extension

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -94,7 +94,7 @@ public final class ArbitraryBuilder<T> {
 		ArbitraryValidator validator,
 		ArbitraryCustomizers arbitraryCustomizers,
 		Map<Class<?>, ArbitraryGenerator> generatorMap,
-		Consumer<BuilderManipulator> onManipulated
+		CallbackOperation<BuilderManipulator> onManipulated
 	) {
 		this(
 			new ArbitraryTree<>(
@@ -122,7 +122,7 @@ public final class ArbitraryBuilder<T> {
 		ArbitraryValidator validator,
 		ArbitraryCustomizers arbitraryCustomizers,
 		Map<Class<?>, ArbitraryGenerator> generatorMap,
-		Consumer<BuilderManipulator> onManipulated
+		CallbackOperation<BuilderManipulator> onManipulated
 	) {
 		this(
 			new ArbitraryTree<>(
@@ -441,8 +441,7 @@ public final class ArbitraryBuilder<T> {
 			this.validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(manipulator) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -456,8 +455,7 @@ public final class ArbitraryBuilder<T> {
 			this.validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(manipulator) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -476,8 +474,7 @@ public final class ArbitraryBuilder<T> {
 			this.validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(manipulator) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -498,8 +495,7 @@ public final class ArbitraryBuilder<T> {
 			this.validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(manipulator) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -521,8 +517,7 @@ public final class ArbitraryBuilder<T> {
 			this.validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(manipulator) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
@@ -30,7 +30,7 @@ public final class CallbackOperation<T extends BuilderManipulator> {
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	public final static class CallbackOperationBuilder<T extends BuilderManipulator> {
+	public static final class CallbackOperationBuilder<T extends BuilderManipulator> {
 		private Consumer<T> callback = t -> {
 		};
 		private Consumer<AbstractArbitrarySet> callbackIfSet = null;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
@@ -1,0 +1,90 @@
+package com.navercorp.fixturemonkey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+
+public final class CallbackOperation<T extends BuilderManipulator> {
+	private final Consumer<T> consumer;
+	private final Function<T, List<T>> transformer;
+
+	CallbackOperation(Consumer<T> callback, Function<T, List<T>> transformer) {
+		this.consumer = callback;
+		this.transformer = transformer;
+	}
+
+	public void accept(T value) {
+		consumer.accept(value);
+	}
+
+	public List<T> apply(T value) {
+		return transformer.apply(value);
+	}
+
+	public static <U extends BuilderManipulator> CallbackOperationBuilder<U> builder() {
+		return new CallbackOperationBuilder<>();
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public final static class CallbackOperationBuilder<T extends BuilderManipulator> {
+		private Consumer<T> callback = t -> {
+		};
+		private Consumer<AbstractArbitrarySet> callbackIfSet = null;
+		private Function<T, List<T>> transformer = t -> {
+			List<T> list = new ArrayList<>();
+			list.add(t);
+			return list;
+		};
+		private Function<AbstractArbitrarySet, List<AbstractArbitrarySet>> transformerIfSet = null;
+
+		public CallbackOperationBuilder<T> callback(Consumer<T> callback) {
+			this.callback = callback;
+			return this;
+		}
+
+		public CallbackOperationBuilder<T> callbackIfSet(Consumer<AbstractArbitrarySet> callback) {
+			this.callbackIfSet = callback;
+			return this;
+		}
+
+		public CallbackOperationBuilder<T> transformer(Function<T, List<T>> transformer) {
+			this.transformer = transformer;
+			return this;
+		}
+
+		public CallbackOperationBuilder<T> transformerIfSet(
+			Function<AbstractArbitrarySet, List<AbstractArbitrarySet>> transformer
+		) {
+			this.transformerIfSet = transformer;
+
+			return this;
+		}
+
+		public CallbackOperation<T> build() {
+			return new CallbackOperation<>(combineCallback(), combineTransformer());
+		}
+
+		private Consumer<T> combineCallback() {
+			return t -> {
+				if (callbackIfSet != null && t instanceof AbstractArbitrarySet) {
+					callbackIfSet.accept((AbstractArbitrarySet)t);
+				} else {
+					callback.accept(t);
+				}
+			};
+		}
+
+		private Function<T, List<T>> combineTransformer() {
+			return t -> {
+				if (transformerIfSet != null && t instanceof AbstractArbitrarySet) {
+					return (List)transformerIfSet.apply((AbstractArbitrarySet)t);
+				}
+				return transformer.apply(t);
+			};
+		}
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/CallbackOperation.java
@@ -17,11 +17,11 @@ public final class CallbackOperation<T extends BuilderManipulator> {
 		this.transformer = transformer;
 	}
 
-	public void accept(T value) {
+	void accept(T value) {
 		consumer.accept(value);
 	}
 
-	public List<T> apply(T value) {
+	List<T> apply(T value) {
 		return transformer.apply(value);
 	}
 
@@ -60,7 +60,6 @@ public final class CallbackOperation<T extends BuilderManipulator> {
 			Function<AbstractArbitrarySet, List<AbstractArbitrarySet>> transformer
 		) {
 			this.transformerIfSet = transformer;
-
 			return this;
 		}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -23,12 +23,10 @@ import static java.util.stream.Collectors.toList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import net.jqwik.api.Arbitrary;
 
-import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpressionManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizer;
@@ -106,7 +104,7 @@ public class FixtureMonkey {
 
 	public <T> ArbitraryBuilder<T> giveMeBuilder(
 		Class<T> clazz,
-		Consumer<BuilderManipulator> onManipulated
+		CallbackOperation<BuilderManipulator> onManipulated
 	) {
 		return this.giveMeBuilder(
 			clazz,
@@ -128,8 +126,7 @@ public class FixtureMonkey {
 			validator,
 			this.arbitraryCustomizers,
 			this.generatorMap,
-			(it) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -153,8 +150,7 @@ public class FixtureMonkey {
 			clazz,
 			option,
 			customizers,
-			(it) -> {
-			}
+			CallbackOperation.builder().build()
 		);
 	}
 
@@ -162,7 +158,7 @@ public class FixtureMonkey {
 		Class<T> clazz,
 		ArbitraryOption option,
 		ArbitraryCustomizers customizers,
-		Consumer<BuilderManipulator> onManipulated
+		CallbackOperation<BuilderManipulator> onManipulated
 	) {
 		ArbitraryBuilder<T> defaultArbitraryBuilder = option.getDefaultArbitraryBuilder(clazz);
 		if (defaultArbitraryBuilder != null) {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -1509,30 +1509,32 @@ class FixtureMonkeyTest {
 					.transformerIfSet(set -> {
 						List<AbstractArbitrarySet> list = new ArrayList<>();
 						ArbitraryExpression expression = set.getArbitraryExpression();
-						if (expression.equals(ArbitraryExpression.from("value1.value"))
-							&& set.getValue().equals("test")) {
+						if (expression.equals(ArbitraryExpression.from("value1.value"))) {
 							list.add(set);
 						}
 						return list;
 					})
 					.transformer(manipulator -> {
 						List<BuilderManipulator> manipulators = new ArrayList<>();
-						if (manipulator instanceof ContainerSizeManipulator) {
-							ContainerSizeManipulator containerSizeManipulator = (ContainerSizeManipulator)manipulator;
+						if (manipulator instanceof ContainerSizeManipulator
+							&& ((ContainerSizeManipulator)manipulator).getArbitraryExpression()
+							.equals(ArbitraryExpression.from("value2.value"))) {
 							manipulators.add(
-								new ContainerSizeManipulator(containerSizeManipulator.getArbitraryExpression(), 1, 1)
+								new ArbitrarySet<>(((ContainerSizeManipulator)manipulator).getArbitraryExpression(), 1)
 							);
 						}
 						return manipulators;
 					})
 					.build()
 			)
-			.set("value1.value", "value");
+			.set("value1.value", "value")
+			.size("value2.value", 100);
 
 		// when
 		StringAndInt actual = sut.sample();
 
 		then(actual.getValue1().getValue()).isEqualTo("value");
+		then(actual.getValue2().getValue()).isEqualTo(1);
 	}
 
 	@Property


### PR DESCRIPTION
callback 연산을 캡슐화한 CallbackOperation을 추가합니다.

이전에 @acktsap 님이 의견 주셨던 내용 반영해서 CallbackOperationBuilder에서 연산 종류에 따라 별도로 처리할 수 있는 빌더 메소드를 추가했습니다.

연산을 변환하는 transform도 추가했습니다.