### PR TITLE
Refactor StringAnnotatedArbitraryGenerator

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import net.jqwik.api.Arbitrary;
+
 import com.navercorp.fixturemonkey.ArbitraryOption.FixtureOptionsBuilder;
 import com.navercorp.fixturemonkey.arbitrary.ContainerArbitraryNodeGenerator;
 import com.navercorp.fixturemonkey.arbitrary.InterfaceSupplier;
@@ -39,6 +41,7 @@ public class FixtureMonkeyBuilder {
 	private ArbitraryGenerator defaultGenerator = new BeanArbitraryGenerator();
 	private Map<Class<?>, ArbitraryGenerator> generatorMap = new HashMap<>();
 	private Map<Class<?>, ArbitraryCustomizer<?>> customizerMap = new HashMap<>();
+	private Map<Class<?>, Arbitrary<?>> defaultArbitraryMap = new HashMap<>();
 	@SuppressWarnings("rawtypes")
 	private ArbitraryValidator validator = new CompositeArbitraryValidator();
 	private ArbitraryCustomizers arbitraryCustomizers = new ArbitraryCustomizers();
@@ -166,6 +169,11 @@ public class FixtureMonkeyBuilder {
 		ContainerArbitraryNodeGenerator containerArbitraryNodeGenerator
 	) {
 		this.optionsBuilder.putContainerArbitraryNodeGenerator(clazz, containerArbitraryNodeGenerator);
+		return this;
+	}
+
+	public FixtureMonkeyBuilder putDefaultArbitrary(Class<?> clazz, Arbitrary<?> arbitrary) {
+		this.optionsBuilder.putDefaultArbitrary(clazz, arbitrary);
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTraverser.java
@@ -201,13 +201,17 @@ public final class ArbitraryTraverser {
 			clazz = type.getType();
 		}
 
-		AnnotationSource annotationSource = new AnnotationSource(type.getAnnotations());
+		AnnotationSource<T> annotationSource = new AnnotationSource<>(
+			clazz,
+			arbitraryOption.getDefaultArbitrary(clazz),
+			type.getAnnotations()
+		);
 
 		Map<Class<?>, AnnotatedArbitraryGenerator<?>> annotatedArbitraryMap =
 			arbitraryOption.getAnnotatedArbitraryMap();
 
-		return (Arbitrary<T>)Optional.ofNullable(annotatedArbitraryMap.get(clazz))
-			.map(arbitraryGenerator -> arbitraryGenerator.generate(annotationSource))
+		return Optional.ofNullable(annotatedArbitraryMap.get(clazz))
+			.map(arbitraryGenerator -> ((AnnotatedArbitraryGenerator<T>)arbitraryGenerator).generate(annotationSource))
 			.orElseThrow(() -> new IllegalArgumentException("Class is not registered " + clazz.getName()));
 	}
 
@@ -263,7 +267,7 @@ public final class ArbitraryTraverser {
 			}
 
 			boolean hasNotNullAnnotations = arbitraryType.getAnnotations().stream()
-				.noneMatch(it -> arbitraryOption.isNonNullAnnotation((Annotation)it));
+				.noneMatch(arbitraryOption::isNonNullAnnotation);
 
 			if (!hasNotNullAnnotations) {
 				return false;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AbstractAnnotatedArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AbstractAnnotatedArbitraryGenerator.java
@@ -18,39 +18,25 @@
 
 package com.navercorp.fixturemonkey.generator;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-import java.util.Optional;
-
 import net.jqwik.api.Arbitrary;
 
-public final class AnnotationSource<T> {
-	private final Class<T> clazz;
-	private final Arbitrary<T> arbitrary;
-	private final List<Annotation> annotations;
-
-	public AnnotationSource(
-		Class<T> clazz,
-		Arbitrary<T> arbitrary,
-		List<Annotation> annotations
-	) {
-		this.clazz = clazz;
-		this.arbitrary = arbitrary;
-		this.annotations = annotations;
+public abstract class AbstractAnnotatedArbitraryGenerator<T> implements AnnotatedArbitraryGenerator<T> {
+	protected Arbitrary<T> generateDefaultArbitrary(AnnotationSource<T> annotationSource) {
+		return annotationSource.getArbitrary();
 	}
 
-	public Arbitrary<T> getArbitrary() {
-		return arbitrary;
-	}
+	abstract Arbitrary<T> applyConstraint(Arbitrary<T> arbitrary, AnnotatedGeneratorConstraint constraint);
 
-	public Class<T> getClazz() {
-		return clazz;
-	}
+	abstract AnnotatedGeneratorConstraint getConstraint(AnnotationSource<T> annotationSource);
 
 	@SuppressWarnings("unchecked")
-	public <U extends Annotation> Optional<U> findAnnotation(Class<U> annotationClass) {
-		return (Optional<U>)annotations.stream()
-			.filter(it -> it.annotationType() == annotationClass)
-			.findAny();
+	protected <U extends Arbitrary<T>> U map(Arbitrary<T> arbitrary){
+		return (U)arbitrary;
+	}
+
+	@Override
+	public Arbitrary<T> generate(AnnotationSource<T> annotationSource) {
+		Arbitrary<T> arbitrary = generateDefaultArbitrary(annotationSource);
+		return map(applyConstraint(arbitrary, getConstraint(annotationSource)));
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AbstractAnnotatedArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AbstractAnnotatedArbitraryGenerator.java
@@ -25,18 +25,16 @@ public abstract class AbstractAnnotatedArbitraryGenerator<T> implements Annotate
 		return annotationSource.getArbitrary();
 	}
 
-	abstract Arbitrary<T> applyConstraint(Arbitrary<T> arbitrary, AnnotatedGeneratorConstraint constraint);
-
-	abstract AnnotatedGeneratorConstraint getConstraint(AnnotationSource<T> annotationSource);
-
 	@SuppressWarnings("unchecked")
-	protected <U extends Arbitrary<T>> U map(Arbitrary<T> arbitrary){
+	protected <U extends Arbitrary<T>> U map(Arbitrary<T> arbitrary) {
 		return (U)arbitrary;
 	}
+
+	protected abstract Arbitrary<T> applyArbitrary(Arbitrary<T> arbitrary, AnnotationSource<T> annotationSource);
 
 	@Override
 	public Arbitrary<T> generate(AnnotationSource<T> annotationSource) {
 		Arbitrary<T> arbitrary = generateDefaultArbitrary(annotationSource);
-		return map(applyConstraint(arbitrary, getConstraint(annotationSource)));
+		return map(applyArbitrary(arbitrary, annotationSource));
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedArbitraryGenerator.java
@@ -22,5 +22,5 @@ import net.jqwik.api.Arbitrary;
 
 @FunctionalInterface
 public interface AnnotatedArbitraryGenerator<T> {
-	Arbitrary<T> generate(AnnotationSource annotationSource);
+	Arbitrary<T> generate(AnnotationSource<T> annotationSource);
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedGeneratorConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedGeneratorConstraint.java
@@ -20,23 +20,34 @@ package com.navercorp.fixturemonkey.generator;
 
 import java.math.BigDecimal;
 
+import javax.annotation.Nullable;
+
 final class AnnotatedGeneratorConstraint {
+	@Nullable
 	private final BigDecimal min;
+	@Nullable
 	private final BigDecimal max;
 	private final boolean minInclusive;
 	private final boolean maxInclusive;
 
-	public AnnotatedGeneratorConstraint(BigDecimal min, BigDecimal max, boolean minInclusive, boolean maxInclusive) {
+	public AnnotatedGeneratorConstraint(
+		@Nullable BigDecimal min,
+		@Nullable BigDecimal max,
+		boolean minInclusive,
+		boolean maxInclusive
+	) {
 		this.min = min;
 		this.max = max;
 		this.minInclusive = minInclusive;
 		this.maxInclusive = maxInclusive;
 	}
 
+	@Nullable
 	public BigDecimal getMin() {
 		return min;
 	}
 
+	@Nullable
 	public BigDecimal getMax() {
 		return max;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedGeneratorConstraints.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotatedGeneratorConstraints.java
@@ -48,7 +48,7 @@ import com.navercorp.fixturemonkey.TypeSupports;
 final class AnnotatedGeneratorConstraints {
 	public static AnnotatedGeneratorConstraint findConstraintByClass(
 		Class<?> clazz,
-		AnnotationSource annotationSource
+		AnnotationSource<?> annotationSource
 	) {
 		if (TypeSupports.isNumberType(clazz)) {
 			return findNumberConstraint(clazz, annotationSource);
@@ -88,7 +88,7 @@ final class AnnotatedGeneratorConstraints {
 
 	private static AnnotatedGeneratorConstraint findNumberConstraint(
 		Class<?> clazz,
-		AnnotationSource annotationSource
+		AnnotationSource<?> annotationSource
 	) {
 		BigDecimal min = null;
 		BigDecimal max = null;
@@ -195,7 +195,7 @@ final class AnnotatedGeneratorConstraints {
 
 	private static AnnotatedGeneratorConstraint findStringConstraint(
 		Class<?> clazz,
-		AnnotationSource annotationSource
+		AnnotationSource<?> annotationSource
 	) {
 		BigDecimal min = null;
 		BigDecimal max = null;
@@ -223,7 +223,7 @@ final class AnnotatedGeneratorConstraints {
 
 	private static AnnotatedGeneratorConstraint findDateConstraint(
 		Class<?> clazz,
-		AnnotationSource annotationSource
+		AnnotationSource<?> annotationSource
 	) {
 		BigDecimal now = BigDecimal.valueOf(Instant.now().toEpochMilli());
 		BigDecimal min = null;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotationIntrospector.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/AnnotationIntrospector.java
@@ -1,0 +1,7 @@
+package com.navercorp.fixturemonkey.generator;
+
+import net.jqwik.api.Arbitrary;
+
+public interface AnnotationIntrospector<T> {
+	Arbitrary<T> getArbitrary(Arbitrary<T> arbitrary, AnnotationSource<T> annotationSource);
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/NewStringAnnotatedArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/NewStringAnnotatedArbitraryGenerator.java
@@ -48,9 +48,7 @@ public class NewStringAnnotatedArbitraryGenerator implements AnnotatedArbitraryG
 	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
 
 	@Override
-	public Arbitrary<String> generate(
-		AnnotationSource<String> annotationSource
-	) {
+	public Arbitrary<String> generate(AnnotationSource<String> annotationSource) {
 		Arbitrary<String> defaultArbitrary = generateDefaultArbitrary(annotationSource);
 		return stringAnnotationIntrospector.getArbitrary(defaultArbitrary, annotationSource);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/NewStringAnnotatedArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/NewStringAnnotatedArbitraryGenerator.java
@@ -1,0 +1,178 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.generator;
+
+import static java.util.stream.Collectors.toList;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.EmailArbitrary;
+import net.jqwik.api.arbitraries.StringArbitrary;
+
+public class NewStringAnnotatedArbitraryGenerator extends AbstractAnnotatedArbitraryGenerator<String> {
+	public static final NewStringAnnotatedArbitraryGenerator INSTANCE = new NewStringAnnotatedArbitraryGenerator();
+	private static final java.util.regex.Pattern EMPTY_PATTERN = java.util.regex.Pattern.compile("");
+	private static final java.util.regex.Pattern SPACE_PATTERN = java.util.regex.Pattern.compile(" ");
+	private static final java.util.regex.Pattern BLANK_PATTERN = java.util.regex.Pattern.compile("[\n\t ]");
+	private static final java.util.regex.Pattern CONTROL_BLOCK_PATTERN =
+		java.util.regex.Pattern.compile("[\u0000-\u001f\u007f]");
+	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
+
+	private boolean isNotBlank(String value) {
+		return value != null && value.trim().length() > 0;
+	}
+
+	@Override
+	public Arbitrary<String> generate(
+		AnnotationSource<String> annotationSource
+	) {
+		Optional<Pattern> pattern = annotationSource.findAnnotation(Pattern.class);
+		if (pattern.isPresent()) {
+			AnnotatedGeneratorConstraint constraint = getConstraint(annotationSource);
+			BigDecimal min = constraint.getMin();
+			BigDecimal max = constraint.getMax();
+			Integer minIntValue = min != null ? min.intValue() : null;
+			Integer maxIntValue = max != null ? max.intValue() : null;
+			List<String> values = REGEX_GENERATOR.generateAll(
+				pattern.get(),
+				minIntValue,
+				maxIntValue
+			);
+
+			boolean notBlank = min != null && min.compareTo(BigDecimal.ONE) >= 0;
+			if (notBlank) {
+				values = values.stream()
+					.filter(this::isNotBlank)
+					.collect(toList());
+			}
+			return Arbitraries.of(values);
+		}
+
+		return super.generate(annotationSource);
+	}
+
+	@Override
+	protected Arbitrary<String> generateDefaultArbitrary(
+		AnnotationSource<String> annotationSource
+	) {
+		Arbitrary<String> arbitrary = annotationSource.getArbitrary();
+		if (annotationSource.findAnnotation(Email.class).isPresent()) {
+			return Arbitraries.emails();
+		} else if (arbitrary instanceof StringArbitrary) {
+			StringArbitrary stringArbitrary = (StringArbitrary)arbitrary;
+			if (annotationSource.findAnnotation(Digits.class).isPresent()) {
+				stringArbitrary = stringArbitrary.numeric();
+			} else {
+				stringArbitrary = stringArbitrary.ascii();
+			}
+			arbitrary = stringArbitrary;
+		}
+
+		return arbitrary;
+	}
+
+	@Override
+	Arbitrary<String> applyConstraint(
+		Arbitrary<String> arbitrary,
+		AnnotatedGeneratorConstraint constraint
+	) {
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+
+		if (arbitrary instanceof EmailArbitrary) {
+			if (min != null) {
+				int emailMinLength = min.intValue();
+				arbitrary = arbitrary.filter(it -> it != null && it.length() >= emailMinLength);
+			}
+			if (max != null) {
+				int emailMaxLength = max.intValue();
+				arbitrary = arbitrary.filter(it -> it != null && it.length() <= emailMaxLength);
+			}
+		} else if (arbitrary instanceof StringArbitrary) {
+			StringArbitrary stringArbitrary = (StringArbitrary)arbitrary;
+
+			if (min != null) {
+				stringArbitrary = stringArbitrary.ofMinLength(min.intValue());
+			}
+			if (max != null) {
+				stringArbitrary = stringArbitrary.ofMaxLength(max.intValue());
+			}
+			arbitrary = stringArbitrary;
+		}
+
+		return arbitrary.map(value -> {
+			boolean notBlank = min != null && min.compareTo(BigDecimal.ONE) >= 0;
+			int originalLength = value.length();
+			if (notBlank && !isNotBlank(value)) {
+				value = EMPTY_PATTERN.matcher(value).replaceAll("a");
+				value = SPACE_PATTERN.matcher(value).replaceAll("b");
+				value = BLANK_PATTERN.matcher(value).replaceAll("c");
+				value = CONTROL_BLOCK_PATTERN.matcher(value).replaceAll("d");
+			}
+			return value.substring(0, originalLength);
+		});
+	}
+
+	@Override
+	AnnotatedGeneratorConstraint getConstraint(
+		AnnotationSource<String> annotationSource
+	) {
+		BigDecimal min = null;
+		BigDecimal max = null;
+		if (annotationSource.findAnnotation(NotBlank.class).isPresent()
+			|| annotationSource.findAnnotation(NotEmpty.class).isPresent()) {
+			min = BigDecimal.ONE;
+		}
+
+		Optional<Digits> digitsAnnotations = annotationSource.findAnnotation(Digits.class);
+		if (digitsAnnotations.isPresent()) {
+			int digitInteger = digitsAnnotations.get().integer();
+			min = BigDecimal.valueOf(digitInteger);
+			max = BigDecimal.valueOf(digitInteger);
+		}
+
+		Optional<Size> size = annotationSource.findAnnotation(Size.class);
+		if (size.isPresent()) {
+			BigDecimal minValue = BigDecimal.valueOf(size.map(Size::min).get());
+			if (min == null) {
+				min = minValue;
+			} else if (min.compareTo(minValue) < 0) {
+				min = minValue;
+			}
+
+			max = BigDecimal.valueOf(size.map(Size::max).get());
+		}
+		return AnnotatedGeneratorConstraint.builder()
+			.max(max)
+			.min(min)
+			.build();
+	}
+}
+

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/AnnotatedArbitraryGeneratorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/AnnotatedArbitraryGeneratorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.domains.Domain;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithDigit;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithEmail;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithNotBlank;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithNotEmpty;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithPattern;
+import com.navercorp.fixturemonkey.test.AnnotatedArbitraryGeneratorTestSpecs.StringWithSize;
+
+public class AnnotatedArbitraryGeneratorTest {
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void string(@ForAll String actual) {
+		then(actual).isNotNull();
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithPattern(@ForAll StringWithPattern actual) {
+		then(actual.getValue()).matches(Pattern.compile("\\d"));
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithNotBlank(@ForAll StringWithNotBlank actual) {
+		then(actual.getValue()).isNotBlank();
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithNotEmpty(@ForAll StringWithNotEmpty actual) {
+		then(actual.getValue()).isNotEmpty();
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithSize(@ForAll StringWithSize actual) {
+		then(actual.getValue()).hasSizeBetween(3, 7);
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithDigit(@ForAll StringWithDigit actual) {
+		then(actual.getValue()).isBetween("00", "99");
+	}
+
+	@Property
+	@Domain(AnnotatedArbitraryGeneratorTestSpecs.class)
+	void stringWithEmail(@ForAll StringWithEmail actual) {
+		then(actual.getValue()).contains("@");
+	}
+
+	@Property
+	void stringWithDefaultArbitrary() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.putDefaultArbitrary(String.class, Arbitraries.of("test"))
+			.build();
+
+		List<String> actual = sut.giveMe(String.class, 5);
+
+		then(actual).allMatch(it -> it.equals("test"));
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/AnnotatedArbitraryGeneratorTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/AnnotatedArbitraryGeneratorTestSpecs.java
@@ -1,0 +1,124 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.test;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.AbstractDomainContextBase;
+
+import lombok.Data;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+
+public class AnnotatedArbitraryGeneratorTestSpecs extends AbstractDomainContextBase {
+	public static final FixtureMonkey SUT = FixtureMonkey.builder().build();
+
+	public AnnotatedArbitraryGeneratorTestSpecs() {
+		registerArbitrary(String.class, string());
+		registerArbitrary(StringWithPattern.class, stringWithPattern());
+		registerArbitrary(StringWithNotBlank.class, stringWithNotBlank());
+		registerArbitrary(StringWithNotEmpty.class, stringWithNotEmpty());
+		registerArbitrary(StringWithSize.class, stringWithSize());
+		registerArbitrary(StringWithDigit.class, stringWithDigit());
+		registerArbitrary(StringWithEmail.class, stringWithEmail());
+	}
+
+	@Provide
+	Arbitrary<String> string() {
+		return SUT.giveMeArbitrary(String.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithPattern> stringWithPattern() {
+		return SUT.giveMeArbitrary(StringWithPattern.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithNotBlank> stringWithNotBlank() {
+		return SUT.giveMeArbitrary(StringWithNotBlank.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithNotEmpty> stringWithNotEmpty() {
+		return SUT.giveMeArbitrary(StringWithNotEmpty.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithSize> stringWithSize() {
+		return SUT.giveMeArbitrary(StringWithSize.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithDigit> stringWithDigit() {
+		return SUT.giveMeArbitrary(StringWithDigit.class);
+	}
+
+	@Provide
+	Arbitrary<StringWithEmail> stringWithEmail() {
+		return SUT.giveMeArbitrary(StringWithEmail.class);
+	}
+
+	@Data
+	public static class StringWithPattern {
+		@Pattern(regexp = "\\d")
+		@NotBlank
+		private String value;
+	}
+
+	@Data
+	public static class StringWithNotBlank {
+		@NotBlank
+		private String value;
+	}
+
+	@Data
+	public static class StringWithNotEmpty {
+		@NotEmpty
+		private String value;
+	}
+
+	@Data
+	public static class StringWithSize {
+		@Size(min = 3, max = 7)
+		@NotNull
+		private String value;
+	}
+
+	@Data
+	public static class StringWithDigit {
+		@Digits(integer = 2, fraction = 0)
+		@NotNull
+		private String value;
+	}
+
+	@Data
+	public static class StringWithEmail {
+		@Email
+		@NotNull
+		private String value;
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
-import static org.assertj.core.api.BDDAssumptions.given;
 
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
AnnotatedArbitraryGenerator 구조를 변경합니다.
불필요하게 반복하는 로직들을 제거하고 AnnotatedArbitraryGenerator로 등록한 타입들의 기본 Arbitrary를 지정할 수 있도록 설정합니다.

커밋을 잘라 `refactor-annotated-arbitrary-generator` 브랜치에 전부 적용한 이후에 main에 push할 예정입니다.
첫 번째로 StringAnnotatedArbitraryGenerator를 수정하였습니다.