### PR TITLE
Introduce ArbitraryIntrospector interfaces

### DIFF
--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -10,6 +10,8 @@ plugins {
 dependencies {
     api("org.apiguardian:apiguardian-api:1.1.2")
     compileOnly("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
+    compileOnly("net.jqwik:jqwik-api:${JQWIK_VERSION}")
+    compileOnly("net.jqwik:jqwik-time:${JQWIK_VERSION}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospector.java
@@ -1,0 +1,60 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.BigDecimalArbitrary;
+import net.jqwik.api.arbitraries.BigIntegerArbitrary;
+import net.jqwik.api.arbitraries.ByteArbitrary;
+import net.jqwik.api.arbitraries.CharacterArbitrary;
+import net.jqwik.api.arbitraries.DoubleArbitrary;
+import net.jqwik.api.arbitraries.FloatArbitrary;
+import net.jqwik.api.arbitraries.IntegerArbitrary;
+import net.jqwik.api.arbitraries.LongArbitrary;
+import net.jqwik.api.arbitraries.ShortArbitrary;
+import net.jqwik.api.arbitraries.StringArbitrary;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public interface ArbitraryIntrospector {
+	Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Character> characters(CharacterArbitrary characterArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Short> shorts(ShortArbitrary shortArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Byte> bytes(ByteArbitrary byteArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Double> doubles(DoubleArbitrary doubleArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Float> floats(FloatArbitrary floatArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Integer> integers(IntegerArbitrary integerArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Long> longs(LongArbitrary longArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<BigInteger> bigIntegers(BigIntegerArbitrary bigIntegerArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<BigDecimal> bigDecimals(BigDecimalArbitrary bigDecimalArbitrary, ArbitraryIntrospectorContext context);
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorContext.java
@@ -1,0 +1,77 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.util.List;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ArbitraryIntrospectorContext {
+	private final Class<?> type;
+	private final String propertyName;
+	private final AnnotatedType annotatedType;
+	private final List<Annotation> annotations;
+	private double nullInject;
+
+	public ArbitraryIntrospectorContext(
+		Class<?> type,
+		String propertyName,
+		AnnotatedType annotatedType,
+		List<Annotation> annotations,
+		double nullInject
+	) {
+		this.type = type;
+		this.propertyName = propertyName;
+		this.annotatedType = annotatedType;
+		this.annotations = annotations;
+		this.nullInject = nullInject;
+	}
+
+	public Class<?> getType() {
+		return this.type;
+	}
+
+	public String getPropertyName() {
+		return this.propertyName;
+	}
+
+	public AnnotatedType getAnnotatedType() {
+		return this.annotatedType;
+	}
+
+	public List<Annotation> getAnnotations() {
+		return this.annotations;
+	}
+
+	public double getNullInject() {
+		return this.nullInject;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends Annotation> Optional<T> findAnnotation(Class<T> annotationClass) {
+		return (Optional<T>)annotations.stream()
+			.filter(it -> it.annotationType() == annotationClass)
+			.findAny();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospector.java
@@ -1,0 +1,29 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public interface ArbitraryTypeIntrospector {
+	Arbitrary<Object> introspect(ArbitraryIntrospectorContext context);
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntropector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntropector.java
@@ -1,0 +1,97 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.time.api.arbitraries.CalendarArbitrary;
+import net.jqwik.time.api.arbitraries.DateArbitrary;
+import net.jqwik.time.api.arbitraries.InstantArbitrary;
+import net.jqwik.time.api.arbitraries.LocalDateArbitrary;
+import net.jqwik.time.api.arbitraries.LocalDateTimeArbitrary;
+import net.jqwik.time.api.arbitraries.LocalTimeArbitrary;
+import net.jqwik.time.api.arbitraries.MonthDayArbitrary;
+import net.jqwik.time.api.arbitraries.OffsetDateTimeArbitrary;
+import net.jqwik.time.api.arbitraries.OffsetTimeArbitrary;
+import net.jqwik.time.api.arbitraries.PeriodArbitrary;
+import net.jqwik.time.api.arbitraries.YearArbitrary;
+import net.jqwik.time.api.arbitraries.YearMonthArbitrary;
+import net.jqwik.time.api.arbitraries.ZoneOffsetArbitrary;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public interface TimeArbitraryIntropector {
+	Arbitrary<Calendar> calendars(CalendarArbitrary calendarArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Date> dates(DateArbitrary dateArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Instant> instants(InstantArbitrary instantArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<LocalDate> localDates(LocalDateArbitrary localDateArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<LocalDateTime> localDateTimes(
+		LocalDateTimeArbitrary localDateTimeArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<LocalTime> localTimes(
+		LocalTimeArbitrary localTimeArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<MonthDay> monthDays(
+		MonthDayArbitrary monthDayArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<OffsetDateTime> offsetDateTimes(
+		OffsetDateTimeArbitrary offsetDateTimeArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<OffsetTimeArbitrary> offsetTimes(
+		OffsetTimeArbitrary offsetTimeArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<PeriodArbitrary> periods(PeriodArbitrary periodArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<Year> years(YearArbitrary yearArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<YearMonthArbitrary> yearMonths(
+		YearMonthArbitrary yearMonthArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+
+	Arbitrary<ZoneOffsetArbitrary> zoneOffsets(
+		ZoneOffsetArbitrary zoneOffsetArbitrary,
+		ArbitraryIntrospectorContext context
+	);
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntrospector.java
@@ -47,7 +47,7 @@ import net.jqwik.time.api.arbitraries.YearMonthArbitrary;
 import net.jqwik.time.api.arbitraries.ZoneOffsetArbitrary;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public interface TimeArbitraryIntropector {
+public interface TimeArbitraryIntrospector {
 	Arbitrary<Calendar> calendars(CalendarArbitrary calendarArbitrary, ArbitraryIntrospectorContext context);
 
 	Arbitrary<Date> dates(DateArbitrary dateArbitrary, ArbitraryIntrospectorContext context);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TimeArbitraryIntrospector.java
@@ -34,6 +34,7 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.time.api.arbitraries.CalendarArbitrary;
 import net.jqwik.time.api.arbitraries.DateArbitrary;
+import net.jqwik.time.api.arbitraries.DurationArbitrary;
 import net.jqwik.time.api.arbitraries.InstantArbitrary;
 import net.jqwik.time.api.arbitraries.LocalDateArbitrary;
 import net.jqwik.time.api.arbitraries.LocalDateTimeArbitrary;
@@ -82,6 +83,8 @@ public interface TimeArbitraryIntrospector {
 	);
 
 	Arbitrary<PeriodArbitrary> periods(PeriodArbitrary periodArbitrary, ArbitraryIntrospectorContext context);
+
+	Arbitrary<DurationArbitrary> durations(DurationArbitrary durationArbitrary, ArbitraryIntrospectorContext context);
 
 	Arbitrary<Year> years(YearArbitrary yearArbitrary, ArbitraryIntrospectorContext context);
 


### PR DESCRIPTION
- ArbitraryIntrospector 인터페이스를 추가합니다.
- 타입에 따른 기본 Arbitrary 를 받아 Annotation 을 포함한 정보들을 읽어서 추가적인 제약 및 조작을 부여할 수 있습니다.
- 이후 PR 로 기본 형태가 지원될 것이며, 이 기본 형태를 사용자가 확장해서 custom 할 수 있습니다.
