### PR TITLE
Introduce FixtureMonkeySessionExtension for jupiter

### DIFF
--- a/fixture-monkey-autoparams/build.gradle
+++ b/fixture-monkey-autoparams/build.gradle
@@ -10,7 +10,9 @@ plugins {
 dependencies {
     api(project(":fixture-monkey"))
     api("io.github.javaunit:autoparams:0.3.0")
+    compileOnly(project(":fixture-monkey-engine"))
 
+    testImplementation(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.18.1")

--- a/fixture-monkey-autoparams/src/test/java/com/navercorp/fixturemonkey/autoparams/test/FixtureMonkeyValueCustomizerTest.java
+++ b/fixture-monkey-autoparams/src/test/java/com/navercorp/fixturemonkey/autoparams/test/FixtureMonkeyValueCustomizerTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import net.jqwik.api.Arbitrary;
@@ -38,7 +39,9 @@ import lombok.NoArgsConstructor;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.autoparams.FixtureMonkeyAutoSource;
+import com.navercorp.fixturemonkey.engine.jupiter.extension.FixtureMonkeySessionExtension;
 
+@ExtendWith(FixtureMonkeySessionExtension.class)
 class FixtureMonkeyValueCustomizerTest {
 	@ParameterizedTest
 	@FixtureMonkeyAutoSource

--- a/fixture-monkey-engine/build.gradle
+++ b/fixture-monkey-engine/build.gradle
@@ -8,7 +8,8 @@ plugins {
 }
 
 dependencies {
-    api("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
+    implementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
+    implementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     api("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
 
     testImplementation("org.assertj:assertj-core:3.18.1")

--- a/fixture-monkey-engine/src/main/java/com/navercorp/fixturemonkey/engine/jupiter/extension/FixtureMonkeySessionExtension.java
+++ b/fixture-monkey-engine/src/main/java/com/navercorp/fixturemonkey/engine/jupiter/extension/FixtureMonkeySessionExtension.java
@@ -1,0 +1,32 @@
+package com.navercorp.fixturemonkey.engine.jupiter.extension;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import net.jqwik.api.sessions.JqwikSession;
+
+public final class FixtureMonkeySessionExtension implements BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		if (!JqwikSession.isActive()) {
+			JqwikSession.start();
+		}
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) {
+		if (JqwikSession.isActive()) {
+			JqwikSession.finishTry();
+		}
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		if (JqwikSession.isActive()) {
+			JqwikSession.finish();
+		}
+	}
+}

--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -9,6 +9,7 @@ plugins {
 
 dependencies {
     api(project(":fixture-monkey"))
+    api(project(":fixture-monkey-engine"))
     api("ch.qos.logback:logback-classic:1.2.3")
     api("org.hibernate.validator:hibernate-validator:6.2.0.Final")
     api("org.glassfish:jakarta.el:3.0.3")

--- a/fixture-monkey-starter/src/test/java/com/navercorp/fixturemonkey/starter/FixtureMonkeyStarterTest.java
+++ b/fixture-monkey-starter/src/test/java/com/navercorp/fixturemonkey/starter/FixtureMonkeyStarterTest.java
@@ -15,11 +15,14 @@ import javax.validation.constraints.PastOrPresent;
 import javax.validation.constraints.Size;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import lombok.Data;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.engine.jupiter.extension.FixtureMonkeySessionExtension;
 
+@ExtendWith(FixtureMonkeySessionExtension.class)
 class FixtureMonkeyStarterTest {
 	@Data   // lombok getter, setter
 	public static class Order {

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api("javax.validation:validation-api:2.0.1.Final")
     api("com.github.mifmif:generex:1.0.2")
 
+    testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.18.1")


### PR DESCRIPTION
- jupiter 테스트에서 사용할 `FixtureMonkeySessionExtension` 을 추가
- JUnit 5 의 @ExtendWith 로 선언해서 사용 가능
- `FixtureMonkeySessionExtension` 는 테스트 시작과 끝의 라이프 사이클에 JqwikSession 라이프 사이클을 적용
- `FixtureMonkeySessionExtension` 선언하지 않아도 테스트 동작에 문제는 없지만, JqwikSession 라이프 사이클을 적용할 경우 불필요한 내부 static cache 를 비워주기 때문에 Fixture Monkey 로 객체 생성하는 테스트가 많을 수록 성능적으로 유리함
- 또한 JqwikSesssion 라이프 사이클을 사용해서 jqwik 의 statistics reporting 기능 확장도 추가로 가능