### PR TITLE
Add Randoms for using same seed random with jqwik engine SourceOfRandomness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ subprojects {
 
     dependencies {
         api("com.google.code.findbugs:jsr305:3.0.2")
+        implementation("com.google.code.findbugs:findbugs-annotations:3.0.1")
         compileOnly("org.slf4j:slf4j-api:1.7.25")
         testImplementation("ch.qos.logback:logback-classic:1.2.3")
     }

--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -9,6 +9,7 @@ plugins {
 
 dependencies {
     api("org.apiguardian:apiguardian-api:1.1.2")
+    compileOnly("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/Randoms.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/Randoms.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.api.seed;
+package com.navercorp.fixturemonkey.api.random;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -28,10 +28,13 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.JqwikException;
 import net.jqwik.engine.SourceOfRandomness;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Reference jqwik SourceOfRandomness
  */
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
 public class Randoms {
 	private static final boolean USE_JQWIK_ENGINE;
 	private static final Supplier<Random> RNG = ThreadLocalRandom::current;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
@@ -89,6 +89,10 @@ public class Randoms {
 			: CURRENT.get();
 	}
 
+	public static int nextInt(int bound) {
+		return current().nextInt(bound);
+	}
+
 	/**
 	 * A faster but not thread safe implementation of {@linkplain java.util.Random}.
 	 * It also has a period of 2^n - 1 and better statistical randomness.

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
@@ -74,13 +74,13 @@ public class Randoms {
 	public static Random newRandom() {
 		return USE_JQWIK_ENGINE
 			? SourceOfRandomness.newRandom()
-			: new XORShiftRandom();
+			: new XorShiftRandom();
 	}
 
 	public static Random newRandom(final long seed) {
 		return USE_JQWIK_ENGINE
 			? SourceOfRandomness.newRandom(seed)
-			: new XORShiftRandom(seed);
+			: new XorShiftRandom(seed);
 	}
 
 	public static Random current() {
@@ -106,15 +106,15 @@ public class Randoms {
 	 *     <li>nextBytes(int)</li>
 	 * </ul>
 	 */
-	private static class XORShiftRandom extends Random {
+	private static class XorShiftRandom extends Random {
 		private long seed;
 
-		private XORShiftRandom() {
+		private XorShiftRandom() {
 			this(System.nanoTime());
 		}
 
-		private XORShiftRandom(long seed) {
-			if (seed == 0l) {
+		private XorShiftRandom(long seed) {
+			if (seed == 0L) {
 				throw new IllegalArgumentException("0L is not an allowed seed value");
 			}
 			this.seed = seed;
@@ -122,9 +122,9 @@ public class Randoms {
 
 		@Override
 		protected int next(int nbits) {
-			long x = nextLong();
-			x &= ((1L << nbits) - 1);
-			return (int) x;
+			long value = nextLong();
+			value &= ((1L << nbits) - 1);
+			return (int)value;
 		}
 
 		/**
@@ -132,12 +132,12 @@ public class Randoms {
 		 */
 		@Override
 		public long nextLong() {
-			long x = this.seed;
-			x ^= (x << 21);
-			x ^= (x >>> 35);
-			x ^= (x << 4);
-			this.seed = x;
-			return x;
+			long value = this.seed;
+			value ^= (value << 21);
+			value ^= (value >>> 35);
+			value ^= (value << 4);
+			this.seed = value;
+			return value;
 		}
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/seed/Randoms.java
@@ -1,0 +1,139 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.seed;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.JqwikException;
+import net.jqwik.engine.SourceOfRandomness;
+
+/**
+ * Reference jqwik SourceOfRandomness
+ */
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public class Randoms {
+	private static final boolean USE_JQWIK_ENGINE;
+	private static final Supplier<Random> RNG = ThreadLocalRandom::current;
+	private static final ThreadLocal<Random> CURRENT = ThreadLocal.withInitial(Randoms::newRandom);
+
+	static {
+		boolean useJqwikEngine;
+		try {
+			Class.forName("net.jqwik.engine.SourceOfRandomness");
+			useJqwikEngine = true;
+		} catch (ClassNotFoundException e) {
+			useJqwikEngine = false;
+		}
+		USE_JQWIK_ENGINE = useJqwikEngine;
+	}
+
+	private Randoms() {
+	}
+
+	public static String createRandomSeed() {
+		return USE_JQWIK_ENGINE
+			? SourceOfRandomness.createRandomSeed()
+			: Long.toString(RNG.get().nextLong());
+	}
+
+	public static Random create(String seed) {
+		if (USE_JQWIK_ENGINE) {
+			return SourceOfRandomness.create(seed);
+		}
+
+		try {
+			Random random = newRandom(Long.parseLong(seed));
+			CURRENT.set(random);
+			return random;
+		} catch (NumberFormatException nfe) {
+			throw new JqwikException(String.format("[%s] is not a valid random seed.", seed));
+		}
+	}
+
+	public static Random newRandom() {
+		return USE_JQWIK_ENGINE
+			? SourceOfRandomness.newRandom()
+			: new XORShiftRandom();
+	}
+
+	public static Random newRandom(final long seed) {
+		return USE_JQWIK_ENGINE
+			? SourceOfRandomness.newRandom(seed)
+			: new XORShiftRandom(seed);
+	}
+
+	public static Random current() {
+		return USE_JQWIK_ENGINE
+			? SourceOfRandomness.current()
+			: CURRENT.get();
+	}
+
+	/**
+	 * A faster but not thread safe implementation of {@linkplain java.util.Random}.
+	 * It also has a period of 2^n - 1 and better statistical randomness.
+	 *
+	 * See for details: https://www.javamex.com/tutorials/random_numbers/xorshift.shtml
+	 *
+	 * <p>
+	 * For further performance improvements within jqwik, consider to override:
+	 * <ul>
+	 *     <li>nextDouble()</li>
+	 *     <li>nextBytes(int)</li>
+	 * </ul>
+	 */
+	private static class XORShiftRandom extends Random {
+		private long seed;
+
+		private XORShiftRandom() {
+			this(System.nanoTime());
+		}
+
+		private XORShiftRandom(long seed) {
+			if (seed == 0l) {
+				throw new IllegalArgumentException("0L is not an allowed seed value");
+			}
+			this.seed = seed;
+		}
+
+		@Override
+		protected int next(int nbits) {
+			long x = nextLong();
+			x &= ((1L << nbits) - 1);
+			return (int) x;
+		}
+
+		/**
+		 * Will never generate 0L
+		 */
+		@Override
+		public long nextLong() {
+			long x = this.seed;
+			x ^= (x << 21);
+			x ^= (x >>> 35);
+			x ^= (x << 4);
+			this.seed = x;
+			return x;
+		}
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
-import com.navercorp.fixturemonkey.api.seed.Randoms;
+import com.navercorp.fixturemonkey.api.random.Randoms;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 
 public final class ArbitrarySpecAny implements BuilderManipulator {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
@@ -22,10 +22,9 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.api.seed.Randoms;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 
 public final class ArbitrarySpecAny implements BuilderManipulator {
@@ -42,7 +41,7 @@ public final class ArbitrarySpecAny implements BuilderManipulator {
 			return;
 		}
 
-		ExpressionSpec spec = specs.get(ThreadLocalRandom.current().nextInt(specs.size()));
+		ExpressionSpec spec = specs.get(Randoms.current().nextInt(specs.size()));
 		List<BuilderManipulator> specArbitraryManipulators = spec.getBuilderManipulators();
 		arbitraryBuilder.apply(specArbitraryManipulators);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySpecAny.java
@@ -41,7 +41,7 @@ public final class ArbitrarySpecAny implements BuilderManipulator {
 			return;
 		}
 
-		ExpressionSpec spec = specs.get(Randoms.current().nextInt(specs.size()));
+		ExpressionSpec spec = specs.get(Randoms.nextInt(specs.size()));
 		List<BuilderManipulator> specArbitraryManipulators = spec.getBuilderManipulators();
 		arbitraryBuilder.apply(specArbitraryManipulators);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
@@ -21,9 +21,9 @@ package com.navercorp.fixturemonkey.arbitrary;
 import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
 import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 import javax.annotation.Nullable;
+
+import com.navercorp.fixturemonkey.api.seed.Randoms;
 
 public final class ContainerSizeConstraint {
 	@Nullable
@@ -60,7 +60,7 @@ public final class ContainerSizeConstraint {
 			return minSize;
 		}
 
-		int size = ThreadLocalRandom.current().nextInt(maxSize - minSize);
+		int size = Randoms.current().nextInt(maxSize - minSize);
 		return minSize + size;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
@@ -23,7 +23,7 @@ import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 
 import javax.annotation.Nullable;
 
-import com.navercorp.fixturemonkey.api.seed.Randoms;
+import com.navercorp.fixturemonkey.api.random.Randoms;
 
 public final class ContainerSizeConstraint {
 	@Nullable

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeConstraint.java
@@ -60,7 +60,7 @@ public final class ContainerSizeConstraint {
 			return minSize;
 		}
 
-		int size = Randoms.current().nextInt(maxSize - minSize);
+		int size = Randoms.nextInt(maxSize - minSize);
 		return minSize + size;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -23,9 +23,10 @@ import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import com.navercorp.fixturemonkey.api.seed.Randoms;
 
 final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	private static final String EMPTY_FIELD = "";
@@ -222,7 +223,7 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 			return minSize;
 		}
 
-		return ThreadLocalRandom.current().nextInt(maxSize - minSize);
+		return Randoms.current().nextInt(maxSize - minSize);
 	}
 
 	private static class IterableSpecSet<T> {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import com.navercorp.fixturemonkey.api.seed.Randoms;
+import com.navercorp.fixturemonkey.api.random.Randoms;
 
 final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	private static final String EMPTY_FIELD = "";

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -223,7 +223,7 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 			return minSize;
 		}
 
-		return Randoms.current().nextInt(maxSize - minSize);
+		return Randoms.nextInt(maxSize - minSize);
 	}
 
 	private static class IterableSpecSet<T> {


### PR DESCRIPTION
jqwik 의 Random 과 같은 seed 로 Random 생성을 하기 위해 fixture-monkey-api 에 Randoms 를 추가합니다.
Randoms 는 jqwik-engine 의 SourceOfRandomness 를 같이 사용합니다.
그리고 ThreadLocalRandom 을 사용하던 코드들을 새로 추가한 Randoms 를 사용하도록 수정합니다.

다음 작업으로 seed 를 고정 셋팅할 수 있는 설정 기능을 추가합니다.