### PR TITLE
Substitute deprecated BuilderCombinator with new one

### DIFF
--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/generator/JacksonArbitraryGenerator.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/generator/JacksonArbitraryGenerator.java
@@ -28,11 +28,9 @@ import java.util.List;
 import java.util.Map;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -81,7 +79,7 @@ public final class JacksonArbitraryGenerator extends AbstractArbitraryGenerator 
 
 		this.arbitraryCustomizers.customizeFields(type.getType(), fieldArbitraries);
 
-		BuilderCombinator<Map<String, Object>> builderCombinator = Combinators.withBuilder(HashMap::new);
+		Builders.BuilderCombinator<Map<String, Object>> builderCombinator = Builders.withBuilder(HashMap::new);
 		for (Map.Entry<String, Arbitrary> entry : fieldArbitraries.entrySet()) {
 			String fieldName = entry.getKey();
 			Arbitrary<?> parameterArbitrary = entry.getValue();

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/PrimaryConstructorArbitraryGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/PrimaryConstructorArbitraryGenerator.kt
@@ -29,9 +29,9 @@ import com.navercorp.fixturemonkey.generator.ArbitraryGenerator
 import com.navercorp.fixturemonkey.generator.FieldArbitraries
 import com.navercorp.fixturemonkey.kotlin.customizer.customizeFields
 import com.navercorp.fixturemonkey.property.DefaultPropertyNameResolver
-import net.jqwik.api.Arbitrary
-import net.jqwik.api.Combinators
 import java.lang.reflect.Field
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.Builders
 import kotlin.jvm.internal.Reflection
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
@@ -62,7 +62,7 @@ class PrimaryConstructorArbitraryGenerator(
 
         val constructor = requireNotNull(clazz.primaryConstructor) { "No primary constructor provided for $clazz" }
 
-        var builderCombinator = Combinators.withBuilder { mutableMapOf<KParameter, Any?>() }
+        var builderCombinator = Builders.withBuilder { mutableMapOf<KParameter, Any?>() }
         for (parameter in constructor.parameters) {
             val parameterArbitrary = fieldArbitraries.getArbitrary(parameter.name)
             builderCombinator = builderCombinator.use(parameterArbitrary).`in` { map, value ->

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArrayBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArrayBuilder.java
@@ -23,8 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 
@@ -33,8 +32,8 @@ final class ArrayBuilder {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public <T> Arbitrary<T> build(Class<T> clazz, List<ArbitraryNode> nodes) {
-		BuilderCombinator<ArrayBuilderFrame> builder =
-			Combinators.withBuilder(() -> new ArrayBuilderFrame(clazz, nodes.size()));
+		Builders.BuilderCombinator<ArrayBuilderFrame> builder =
+			Builders.withBuilder(() -> new ArrayBuilderFrame(clazz, nodes.size()));
 
 		if (nodes.isEmpty()) {
 			return (Arbitrary<T>)builder.build(ArrayBuilderFrame::build);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BeanArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BeanArbitraryGenerator.java
@@ -34,7 +34,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
@@ -75,8 +75,7 @@ public final class BeanArbitraryGenerator extends AbstractArbitraryGenerator
 		this.arbitraryCustomizers.customizeFields(clazz, fieldArbitraries);
 
 		Map<String, PropertyDescriptor> propertyDescriptorMap = this.getPropertyDescriptorsByName(clazz);
-		Combinators.BuilderCombinator builderCombinator = Combinators.withBuilder(
-			() -> ReflectionUtils.newInstance(clazz));
+		Builders.BuilderCombinator builderCombinator = Builders.withBuilder(() -> ReflectionUtils.newInstance(clazz));
 		for (Map.Entry<String, Arbitrary> entry : fieldArbitraries.entrySet()) {
 			String fieldName = entry.getKey();
 			PropertyDescriptor propertyDescriptor = propertyDescriptorMap.get(fieldName);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BuilderArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BuilderArbitraryGenerator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Builders;
 import net.jqwik.api.Combinators;
 
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
@@ -82,8 +83,8 @@ public final class BuilderArbitraryGenerator extends AbstractArbitraryGenerator 
 
 		Method builderMethod = BUILDER_CACHE.get(clazz);
 		Class<?> builderType = this.getBuilderType(clazz);
-		Combinators.BuilderCombinator builderCombinator = Combinators.withBuilder(() ->
-			ReflectionUtils.invokeMethod(builderMethod, null));
+		Builders.BuilderCombinator builderCombinator =
+			Builders.withBuilder(() -> ReflectionUtils.invokeMethod(builderMethod, null));
 
 		for (Map.Entry<String, Arbitrary> entry : fieldArbitraries.entrySet()) {
 			String methodName = entry.getKey();
@@ -110,7 +111,7 @@ public final class BuilderArbitraryGenerator extends AbstractArbitraryGenerator 
 		List<Map.Entry<Arbitrary, Combinators.F2<?, ?, ?>>> chains = fieldArbitraries.getCombinationChains();
 
 		for (Map.Entry<Arbitrary, Combinators.F2<?, ?, ?>> entry : chains) {
-			builderCombinator = builderCombinator.use(entry.getKey()).in(entry.getValue());
+			builderCombinator = builderCombinator.use(entry.getKey()).in((builder, value) -> entry.getValue());
 		}
 
 		Method buildMethod = BUILD_METHOD_CACHE.computeIfAbsent(builderType, t -> {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ConstructorPropertiesArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ConstructorPropertiesArbitraryGenerator.java
@@ -33,7 +33,7 @@ import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
@@ -91,8 +91,8 @@ public final class ConstructorPropertiesArbitraryGenerator extends AbstractArbit
 		String[] providedParameterNames = constructorProperties.value();
 		Parameter[] actualParameters = constructor.getParameters();
 
-		Combinators.BuilderCombinator<List<Object>> builderCombinator = Combinators.withBuilder(
-			() -> new ArrayList(providedParameterNames.length));
+		Builders.BuilderCombinator<List<Object>> builderCombinator =
+			Builders.withBuilder(() -> new ArrayList(providedParameterNames.length));
 		for (int i = 0; i < providedParameterNames.length; ++i) {
 			String fieldName = providedParameterNames[i];
 			Arbitrary<?> arbitrary = fieldArbitraries.getArbitrary(fieldName);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/FieldReflectionArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/FieldReflectionArbitraryGenerator.java
@@ -31,7 +31,7 @@ import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
@@ -72,8 +72,8 @@ public final class FieldReflectionArbitraryGenerator extends AbstractArbitraryGe
 
 		this.arbitraryCustomizers.customizeFields(clazz, fieldArbitraries);
 
-		Combinators.BuilderCombinator builderCombinator = Combinators.withBuilder(
-			() -> ReflectionUtils.newInstance(clazz));
+		Builders.BuilderCombinator builderCombinator =
+			Builders.withBuilder(() -> ReflectionUtils.newInstance(clazz));
 		for (Map.Entry<String, Arbitrary> entry : fieldArbitraries.entrySet()) {
 			String fieldName = entry.getKey();
 			String fieldKey = clazz.getName() + "#" + fieldName;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ListBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ListBuilder.java
@@ -23,8 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 
@@ -33,16 +32,15 @@ final class ListBuilder {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	<T> Arbitrary<T> build(List<ArbitraryNode> nodes) {
-		BuilderCombinator<CollectionBuilderFrame> listBuilderCombinator =
-			Combinators.withBuilder(ListBuilderFrame::new);
+		Builders.BuilderCombinator<CollectionBuilderFrame> listBuilderCombinator =
+			Builders.withBuilder(ListBuilderFrame::new);
 
 		if (nodes.isEmpty()) {
 			return (Arbitrary<T>)listBuilderCombinator.build(CollectionBuilderFrame::build);
 		}
 
 		for (ArbitraryNode<?> node : nodes) {
-			listBuilderCombinator = listBuilderCombinator.use(node.getArbitrary()).in(
-				CollectionBuilderFrame::add);
+			listBuilderCombinator = listBuilderCombinator.use(node.getArbitrary()).in(CollectionBuilderFrame::add);
 		}
 
 		return (Arbitrary<T>)listBuilderCombinator.build(CollectionBuilderFrame::build);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/MapBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/MapBuilder.java
@@ -23,8 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 
@@ -33,8 +32,8 @@ final class MapBuilder {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	<T> Arbitrary<T> build(List<ArbitraryNode> nodes) {
-		BuilderCombinator<MapBuilderFrame> mapBuilder =
-			Combinators.withBuilder(MapBuilderFrame::new);
+		Builders.BuilderCombinator<MapBuilderFrame> mapBuilder =
+			Builders.withBuilder(MapBuilderFrame::new);
 
 		if (nodes.isEmpty()) {
 			return (Arbitrary<T>)mapBuilder.build(MapBuilderFrame::build);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/SetBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/SetBuilder.java
@@ -23,8 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 
@@ -33,7 +32,8 @@ final class SetBuilder {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	<T> Arbitrary<T> build(List<ArbitraryNode> nodes) {
-		BuilderCombinator<CollectionBuilderFrame> setBuilderCombinator = Combinators.withBuilder(SetBuilderFrame::new);
+		Builders.BuilderCombinator<CollectionBuilderFrame> setBuilderCombinator =
+			Builders.withBuilder(SetBuilderFrame::new);
 		if (nodes.isEmpty()) {
 			return (Arbitrary<T>)setBuilderCombinator.build(CollectionBuilderFrame::build);
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/StreamBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/StreamBuilder.java
@@ -22,8 +22,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.Combinators.BuilderCombinator;
+import net.jqwik.api.Builders;
 
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 
@@ -32,7 +31,7 @@ final class StreamBuilder {
 	public static final StreamBuilder INSTANCE = new StreamBuilder();
 
 	<T> Arbitrary<T> build(List<ArbitraryNode> nodes) {
-		BuilderCombinator<Stream.Builder> streamBuilderCombinator = Combinators.withBuilder(Stream::builder);
+		Builders.BuilderCombinator<Stream.Builder> streamBuilderCombinator = Builders.withBuilder(Stream::builder);
 		if (nodes.isEmpty()) {
 			return (Arbitrary<T>)streamBuilderCombinator.build(Stream.Builder::build);
 		}


### PR DESCRIPTION
Deprecate된 `net.jqwik.api.Combinators` 대신 `net.jqwik.api.Builders`을 사용합니다.