### PR TITLE
Refactor build as private

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -180,7 +180,11 @@ public final class ArbitraryBuilder<T> {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+	/**
+	 * Build is now package-private method since 0.4.0
+	 * To remove dependency between ArbitraryBuilder interface and Jqwik Arbitrary
+	 * @return Arbitrary of target class
+	 */
 	Arbitrary<T> build() {
 		ArbitraryBuilder<T> buildArbitraryBuilder = this.copy();
 		return buildArbitraryBuilder.tree.result(() -> {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -57,6 +57,7 @@ import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNullity;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySet;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetArbitrary;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetBuilder;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetPostCondition;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySpecAny;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryTraverser;
@@ -179,7 +180,8 @@ public final class ArbitraryBuilder<T> {
 		return this;
 	}
 
-	public Arbitrary<T> build() {
+	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+	Arbitrary<T> build() {
 		ArbitraryBuilder<T> buildArbitraryBuilder = this.copy();
 		return buildArbitraryBuilder.tree.result(() -> {
 			ArbitraryTree<T> buildTree = buildArbitraryBuilder.tree;
@@ -290,7 +292,7 @@ public final class ArbitraryBuilder<T> {
 
 	public ArbitraryBuilder<T> setBuilder(String expression, ArbitraryBuilder<?> builder) {
 		ArbitraryExpression arbitraryExpression = ArbitraryExpression.from(expression);
-		this.builderManipulators.add(new ArbitrarySetArbitrary<>(arbitraryExpression, builder.build()));
+		this.builderManipulators.add(new ArbitrarySetBuilder<>(arbitraryExpression, builder));
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -70,11 +70,11 @@ public class FixtureMonkey {
 	}
 
 	public <T> Stream<T> giveMe(Class<T> type) {
-		return this.giveMeBuilder(type, options).build().sampleStream();
+		return this.giveMeBuilder(type).sampleStream();
 	}
 
 	public <T> Stream<T> giveMe(Class<T> type, ArbitraryCustomizer<T> customizer) {
-		return this.giveMeBuilder(type, options, customizer).build().sampleStream();
+		return this.giveMeBuilder(type, options, customizer).sampleStream();
 	}
 
 	public <T> List<T> giveMe(Class<T> type, int size) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.arbitrary;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+
+public final class ArbitrarySetBuilder<T> extends AbstractArbitrarySet<T> {
+	private final ArbitraryBuilder<T> builder;
+	private long limit;
+
+	public ArbitrarySetBuilder(ArbitraryExpression arbitraryExpression, ArbitraryBuilder<T> builder, long limit) {
+		super(arbitraryExpression);
+		this.builder = builder.copy();
+		this.limit = limit;
+	}
+
+	public ArbitrarySetBuilder(ArbitraryExpression arbitraryExpression, ArbitraryBuilder<T> builder) {
+		this(arbitraryExpression, builder, Long.MAX_VALUE);
+	}
+
+	@Nullable
+	@Override
+	public T getApplicableValue() {
+		if (this.limit > 0) {
+			limit--;
+			return builder.sample();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public boolean isApplicable() {
+		return limit > 0;
+	}
+
+	@Override
+	public Object getInputValue() {
+		return builder;
+	}
+
+	@Override
+	public ArbitrarySetBuilder<T> copy() {
+		return new ArbitrarySetBuilder<>(this.getArbitraryExpression(), this.builder, this.limit);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		ArbitrarySetBuilder<?> that = (ArbitrarySetBuilder<?>)obj;
+		return builder.equals(that.builder);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), builder);
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -46,6 +46,7 @@ import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpressionManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNullity;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySet;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetArbitrary;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetBuilder;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetPostCondition;
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
@@ -119,7 +120,7 @@ public final class ExpressionSpec {
 			return this.setNull((String)null);
 		}
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
-		builderManipulators.add(new ArbitrarySetArbitrary<>(fixtureExpression, builder.build(), limit));
+		builderManipulators.add(new ArbitrarySetBuilder<>(fixtureExpression, builder, limit));
 		return this;
 	}
 
@@ -137,7 +138,7 @@ public final class ExpressionSpec {
 			return this.setNull((String)null);
 		}
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
-		builderManipulators.add(new ArbitrarySetArbitrary<>(fixtureExpression, builder.build()));
+		builderManipulators.add(new ArbitrarySetBuilder<>(fixtureExpression, builder));
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -749,14 +749,17 @@ class ComplexManipulatorTest {
 	@Property
 	void setBuilderReturnsDiff() {
 		// given
-		ArbitraryBuilder<StringValue> sut = SUT.giveMeBuilder(StringValue.class)
-			.set("value", SUT.giveMeBuilder(String.class));
+		ArbitraryBuilder<Complex> sut = SUT.giveMeBuilder(Complex.class)
+			.set("value1", SUT.giveMeBuilder(String.class))
+			.set("value2", SUT.giveMeBuilder(Integer.class))
+			.set("value3", SUT.giveMeBuilder(Float.class))
+			.set("value4", SUT.giveMeBuilder(String.class));
 
 		// when
-		StringValue actual = sut.sample();
+		Complex actual = sut.sample();
 
 		// then
-		StringValue other = sut.sample();
+		Complex other = sut.sample();
 		then(actual).isNotEqualTo(other);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -346,25 +346,6 @@ class ComplexManipulatorTest {
 	}
 
 	@Property
-	void giveMeZipReturnsNew() {
-		// given
-		ArbitraryBuilder<String> stringArbitraryBuilder = SUT.giveMeBuilder(String.class);
-		ArbitraryBuilder<Integer> integerArbitraryBuilder = SUT.giveMeBuilder(Integer.class);
-
-		// when
-		Arbitrary<String> zippedArbitraryBuilder = ArbitraryBuilders.zip(
-			stringArbitraryBuilder,
-			integerArbitraryBuilder,
-			(integer, string) -> integer + "" + string
-		).build();
-
-		// then
-		String result1 = zippedArbitraryBuilder.sample();
-		String result2 = zippedArbitraryBuilder.sample();
-		then(result1).isNotEqualTo(result2);
-	}
-
-	@Property
 	void giveMeMap() {
 		// when
 		StringValue actual = SUT.giveMeBuilder(StringValue.class)
@@ -763,5 +744,19 @@ class ComplexManipulatorTest {
 
 		then(actual.getValue().containsValue(-1)).isTrue();
 		then(actual.getValue().containsKey("test")).isTrue();
+	}
+
+	@Property
+	void setBuilderReturnsDiff() {
+		// given
+		ArbitraryBuilder<StringValue> sut = SUT.giveMeBuilder(StringValue.class)
+			.set("value", SUT.giveMeBuilder(String.class));
+
+		// when
+		StringValue actual = sut.sample();
+
+		// then
+		StringValue other = sut.sample();
+		then(actual).isNotEqualTo(other);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -36,7 +36,6 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Example;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.TooManyFilterMissesException;
 import net.jqwik.api.Tuple.Tuple1;
 import net.jqwik.api.Tuple.Tuple2;
 import net.jqwik.api.constraints.Size;
@@ -270,53 +269,6 @@ class FixtureMonkeyTest {
 		actual.forEach(it -> then(it.getValue()).isNotBlank());
 	}
 
-	@Example
-	void giveMeBuilderBuildInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build();
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
-	void giveMeBuilderBuildInvalidThenSampleStreamThrowsTooManyFilterMissesException() {
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build();
-
-		//noinspection ResultOfMethodCallIgnored
-		thenThrownBy(() -> sut.sampleStream().limit(5).collect(toList()))
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
-	void giveMeBuilderBuildFixGenSizeInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.fixGenSize(5);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
-	void giveMeBuilderBuildOptionalInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<Optional<StringWithNotBlank>> sut =
-			SUT.giveMeBuilder(StringWithNotBlank.class)
-				.set("value", "")
-				.build()
-				.optional(1.0);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
 	@Property
 	void giveMeArbitraryOptional() {
 		// given
@@ -328,18 +280,6 @@ class FixtureMonkeyTest {
 		Optional<StringWithNotBlank> actual = sut.sample();
 
 		then(actual).isNotNull();
-	}
-
-	@Example
-	void giveMeBuilderBuildCollectInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<List<StringWithNotBlank>> sut =
-			SUT.giveMeBuilder(StringWithNotBlank.class)
-				.set("value", "")
-				.build().collect(it -> !it.isEmpty());
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 
 	@Property
@@ -356,19 +296,6 @@ class FixtureMonkeyTest {
 	}
 
 	@Example
-	void giveMeBuilderBuildInjectDuplicatesInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut =
-			SUT.giveMeBuilder(StringWithNotBlank.class)
-				.set("value", "")
-				.build()
-				.injectDuplicates(1);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
 	void giveMeArbitraryInjectDuplicates() {
 		// given
 		Arbitrary<StringWithNotBlank> sut = SUT.giveMeArbitrary(StringWithNotBlank.class)
@@ -376,18 +303,6 @@ class FixtureMonkeyTest {
 
 		thenNoException()
 			.isThrownBy(sut::sample);
-	}
-
-	@Example
-	void giveMeBuilderBuildTuple1InvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<Tuple1<StringWithNotBlank>> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.tuple1();
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 
 	@Property
@@ -399,18 +314,6 @@ class FixtureMonkeyTest {
 		Tuple1<StringWithNotBlank> sample = sut.sample();
 
 		then(sample).isNotNull();
-	}
-
-	@Example
-	void giveMeBuilderBuildTuple2InvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<Tuple2<StringWithNotBlank, StringWithNotBlank>> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.tuple2();
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 
 	@Property
@@ -425,18 +328,6 @@ class FixtureMonkeyTest {
 		then(sample).isNotNull();
 	}
 
-	@Example
-	void giveMeBuilderBuildIgnoreExceptionInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.ignoreException(NullPointerException.class);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
 	@Property
 	void giveMeArbitraryIgnoreException() {
 		// given
@@ -447,18 +338,6 @@ class FixtureMonkeyTest {
 			.isThrownBy(sut::sample);
 	}
 
-	@Example
-	void giveMeBuilderBuildDontShrinkInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.dontShrink();
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
 	@Property
 	void giveMeArbitraryDontShrink() {
 		// given
@@ -467,19 +346,6 @@ class FixtureMonkeyTest {
 
 		thenNoException()
 			.isThrownBy(sut::sample);
-	}
-
-	@Example
-	void giveMeBuilderBuildEdgeCasesInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.edgeCases(it -> {
-			});
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 
 	@Property
@@ -494,18 +360,6 @@ class FixtureMonkeyTest {
 	}
 
 	@Example
-	void giveMeBuilderBuildInjectNullInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.injectNull(0);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
 	void giveMeArbitraryInjectNull() {
 		// given
 		Arbitrary<StringWithNotBlank> sut = SUT.giveMeArbitrary(StringWithNotBlank.class)
@@ -517,18 +371,6 @@ class FixtureMonkeyTest {
 	}
 
 	@Example
-	void giveMeBuilderBuildFlatMapInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<String> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.flatMap(it -> Arbitraries.just("String"));
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
-	@Example
 	void giveMeArbitraryFlatMap() {
 		// given
 		Arbitrary<String> sut = SUT.giveMeArbitrary(StringWithNotBlank.class)
@@ -537,18 +379,6 @@ class FixtureMonkeyTest {
 		String actual = sut.sample();
 
 		then(actual).isEqualTo("String");
-	}
-
-	@Example
-	void giveMeBuilderBuildMapInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.map(it -> it);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 
 	@Property
@@ -563,18 +393,6 @@ class FixtureMonkeyTest {
 		then(actual).isNotNull();
 	}
 
-	@Example
-	void giveMeBuilderBuildFilterInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<StringWithNotBlank> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.filter(it -> true);
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
 	@Property
 	void giveMeArbitraryFilter() {
 		// given
@@ -587,18 +405,6 @@ class FixtureMonkeyTest {
 		then(actual).isNotNull();
 	}
 
-	@Example
-	void giveMeBuilderBuildAsGenericInvalidThenSampleThrowsTooManyFilterMissesException() {
-		// when
-		Arbitrary<Object> sut = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "")
-			.build()
-			.asGeneric();
-
-		thenThrownBy(sut::sample)
-			.isExactlyInstanceOf(TooManyFilterMissesException.class);
-	}
-
 	@Property
 	void giveMeArbitraryAsGeneric() {
 		// given
@@ -609,21 +415,6 @@ class FixtureMonkeyTest {
 		Object actual = sut.sample();
 
 		then(actual).isNotNull();
-	}
-
-	@Property
-	void setAfterBuildNotAffected() {
-		// given
-		ArbitraryBuilder<StringWithNotBlank> builder = SUT.giveMeBuilder(StringWithNotBlank.class);
-		Arbitrary<StringWithNotBlank> build = builder.build();
-
-		// when
-		ArbitraryBuilder<StringWithNotBlank> actual = builder.set("value", "set");
-
-		StringWithNotBlank actualSample = actual.sample();
-		StringWithNotBlank buildSample = build.sample();
-		then(actualSample).isNotEqualTo(buildSample);
-		then(actualSample.getValue()).isEqualTo("set");
 	}
 
 	@Property


### PR DESCRIPTION
ArbitraryBuilder 인터페이스에서 jqwik의 `Arbitrary` 의존성을 제거하기 위해 `build`를 private으로 변경하여 클라이언트에게 노출하지 않습니다.

이런 결정을 한 이유는 다음과 같습니다.
1. jqwik이 버전업될 때마다 breaking change가 생길 위험이 있다. 
2. Fixture Monkey에서 만들어진 Arbitrary는 `apply`, `acceptIf` 등의 복잡한 연산을 사용하는 경우 jqwik에서 정의한 연산을 의도대로 지원하기 어렵다.
3. 사용자는 Arbitrary 인터페이스에서 극히 일부 메소드만 사용한다.
3. Arbitrary 인터페이스 지원은 Fixture Monkey 기능 확장을 방해한다.

