### PR TITLE
Refactor set using traverse

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -581,6 +581,9 @@ public final class ArbitraryBuilder<T> {
 		for (ArbitraryNode<T> foundNode : foundNodes) {
 			if (fixtureSet.isApplicable()) {
 				foundNode.apply(fixtureSet);
+				if (fixtureSet instanceof ArbitrarySet) {
+					traverser.traverse(foundNode, foundNode.isKeyOfMapStructure(), generator);
+				}
 			}
 		}
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -105,7 +105,7 @@ public final class ArbitraryNode<T> {
 			return new ContainerSizeConstraint(0, 1).getArbitraryElementSize();
 		}
 
-		if(getContainerSizeConstraint() != null){
+		if (getContainerSizeConstraint() != null) {
 			return getContainerSizeConstraint().getArbitraryElementSize();
 		}
 
@@ -130,7 +130,7 @@ public final class ArbitraryNode<T> {
 		return new ContainerSizeConstraint(min, max).getArbitraryElementSize();
 	}
 
-	public boolean isNotSetContainerSize(){
+	public boolean isNotSetContainerSize() {
 		return getContainerSizeConstraint() == null;
 	}
 
@@ -281,6 +281,7 @@ public final class ArbitraryNode<T> {
 	public boolean isKeyOfMapStructure() {
 		return keyOfMapStructure;
 	}
+
 	@API(since = "0.4.0", status = Status.INTERNAL)
 	private ContainerSizeConstraint getContainerSizeConstraint() {
 		return this.status.containerSizeConstraint;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -282,8 +282,12 @@ public final class ArbitraryNode<T> {
 		return keyOfMapStructure;
 	}
 
+	/**
+	 * Deprecated Use getElementSize instead
+	 */
 	@API(since = "0.4.0", status = Status.INTERNAL)
-	private ContainerSizeConstraint getContainerSizeConstraint() {
+	@Deprecated
+	public ContainerSizeConstraint getContainerSizeConstraint() {
 		return this.status.containerSizeConstraint;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -20,13 +20,9 @@ package com.navercorp.fixturemonkey.arbitrary;
 
 import static com.navercorp.fixturemonkey.Constants.HEAD_NAME;
 import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALUE;
-import static com.navercorp.fixturemonkey.TypeSupports.extractFields;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -43,8 +39,6 @@ import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.TypeSupports;
-import com.navercorp.fixturemonkey.api.property.FieldProperty;
-import com.navercorp.fixturemonkey.api.property.Property;
 
 public final class ArbitraryNode<T> {
 	@SuppressWarnings("rawtypes")
@@ -104,16 +98,15 @@ public final class ArbitraryNode<T> {
 		return foundChildren;
 	}
 
-	public void initializeElementSize() {
+	public int getElementSize() {
 		if (!type.isContainer()) {
 			throw new IllegalStateException("Can not initialize element size because node is not container.");
 		} else if (type.isOptional()) {
-			setContainerSizeConstraint(new ContainerSizeConstraint(0, 1));
-			return;
+			return new ContainerSizeConstraint(0, 1).getArbitraryElementSize();
 		}
 
-		if (getContainerSizeConstraint() != null) {
-			return;
+		if(getContainerSizeConstraint() != null){
+			return getContainerSizeConstraint().getArbitraryElementSize();
 		}
 
 		Integer min = null;
@@ -134,10 +127,14 @@ public final class ArbitraryNode<T> {
 			}
 		}
 
-		setContainerSizeConstraint(new ContainerSizeConstraint(min, max));
+		return new ContainerSizeConstraint(min, max).getArbitraryElementSize();
 	}
 
-	@SuppressWarnings("unchecked")
+	public boolean isNotSetContainerSize(){
+		return getContainerSizeConstraint() == null;
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void apply(PreArbitraryManipulator preArbitraryManipulator) {
 		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary) {
 			this.setFixed(true);
@@ -160,54 +157,9 @@ public final class ArbitraryNode<T> {
 					);
 				}
 			}
-			setValueRecursively(toValue);
+			this.status.setValue(new LazyValue(toValue));
 		} else {
 			throw new IllegalArgumentException("Not Implemented PreArbitraryManipulator");
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private void setValueRecursively(Object value) {
-		this.setManipulated(true);
-		this.setActive(true);
-		Class<?> type = this.getType().getType();
-		List<Field> fields = extractFields(type);
-
-		if (!getType().isContainer() && (this.children.isEmpty() || value == null)) {
-			if (value == null) {
-				this.setFixedAsNull(true);
-			}
-			this.setArbitrary((Arbitrary<T>)Arbitraries.just(value));
-			return;
-		}
-
-		if (value instanceof Map) {
-			this.setArbitrary((Arbitrary<T>)Arbitraries.just(value));
-			return;
-		} else if (value instanceof Collection) {
-			children.clear();
-			ArbitraryType<Object> childType = this.type.getGenericArbitraryType(0);
-			int index = 0;
-			for (Object element : (Collection<Object>)value) {
-				ArbitraryNode<?> nextNode = ArbitraryNode.builder()
-					.type(childType)
-					.value(element)
-					.propertyName(propertyName)
-					.indexOfIterable(index)
-					.build();
-				index++;
-				this.children.add(nextNode);
-				nextNode.setValueRecursively(element);
-			}
-			return;
-		}
-
-		for (int i = 0; i < fields.size(); i++) {
-			Field field = fields.get(i);
-			ArbitraryNode<?> childNode = this.children.get(i);
-			Property property = new FieldProperty(field);
-			Object childValue = property.getValue(value);
-			childNode.setValueRecursively(childValue);
 		}
 	}
 
@@ -329,8 +281,8 @@ public final class ArbitraryNode<T> {
 	public boolean isKeyOfMapStructure() {
 		return keyOfMapStructure;
 	}
-
-	public ContainerSizeConstraint getContainerSizeConstraint() {
+	@API(since = "0.4.0", status = Status.INTERNAL)
+	private ContainerSizeConstraint getContainerSizeConstraint() {
 		return this.status.containerSizeConstraint;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -285,7 +285,6 @@ public final class ArbitraryNode<T> {
 	/**
 	 * Deprecated Use getElementSize instead
 	 */
-	@API(since = "0.4.0", status = Status.INTERNAL)
 	@Deprecated
 	public ContainerSizeConstraint getContainerSizeConstraint() {
 		return this.status.containerSizeConstraint;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
@@ -31,7 +31,6 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 
 	@Override
 	public <T> List<ArbitraryNode<?>> generate(ArbitraryNode<T> containerNode) {
-		int elementSize = Integer.MAX_VALUE;
 		int currentIndex = 0;
 
 		ArbitraryType<T> clazz = containerNode.getType();
@@ -41,9 +40,10 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 
 		List<ArbitraryNode<?>> generatedNodeList = new ArrayList<>();
 
+		int elementSize = containerNode.getElementSize();
+
 		if (lazyValue != null) {
 			T value = lazyValue.get();
-			ContainerSizeConstraint containerSizeConstraint = containerNode.getContainerSizeConstraint();
 
 			if (value == null) {
 				containerNode.setArbitrary(Arbitraries.just(null));
@@ -51,12 +51,9 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 			}
 			int length = Array.getLength(value);
 
-			if (containerSizeConstraint != null) {
-				// container size is set.
-				elementSize = containerSizeConstraint.getArbitraryElementSize();
-			}
-
-			for (currentIndex = 0; currentIndex < length && currentIndex < elementSize; currentIndex++) {
+			for (currentIndex = 0;
+				 currentIndex < length && (containerNode.isNotSetContainerSize() || currentIndex < elementSize);
+				 currentIndex++) {
 				Object nextValue = Array.get(value, currentIndex);
 				@SuppressWarnings("unchecked")
 				ArbitraryNode<?> nextNode = ArbitraryNode.builder()
@@ -67,32 +64,24 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 					.build();
 				generatedNodeList.add(nextNode);
 			}
+		}
 
-			if (containerSizeConstraint == null) {
-				// value exists, container size size is same as value size.
-				containerNode.setContainerSizeConstraint(new ContainerSizeConstraint(length, length));
-				return generatedNodeList;
+		if (lazyValue == null || !containerNode.isNotSetContainerSize()) {
+			for (int i = currentIndex; i < elementSize; i++) {
+				@SuppressWarnings("unchecked")
+				ArbitraryNode<?> genericFrame = ArbitraryNode.builder()
+					.type(childType)
+					.propertyName(propertyName)
+					.indexOfIterable(i)
+					.nullable(false)
+					.nullInject(0.f)
+					.build();
+
+				generatedNodeList.add(genericFrame);
 			}
 		}
 
-		containerNode.initializeElementSize();
-		if (isNotInitialized(elementSize)) {
-			// value does not exist.
-			elementSize = containerNode.getContainerSizeConstraint().getArbitraryElementSize();
-		}
-
-		for (int i = currentIndex; i < elementSize; i++) {
-			@SuppressWarnings("unchecked")
-			ArbitraryNode<?> genericFrame = ArbitraryNode.builder()
-				.type(childType)
-				.propertyName(propertyName)
-				.indexOfIterable(i)
-				.nullable(false)
-				.nullInject(0.f)
-				.build();
-
-			generatedNodeList.add(genericFrame);
-		}
+		containerNode.setContainerSizeConstraint(null); // clear
 		return generatedNodeList;
 	}
 
@@ -106,9 +95,5 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 		FieldNameResolver fieldNameResolver
 	) {
 		return this.generate(nowNode);
-	}
-
-	private boolean isNotInitialized(int elementSize) {
-		return elementSize == Integer.MAX_VALUE;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
@@ -51,9 +51,11 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 			}
 			int length = Array.getLength(value);
 
-			for (currentIndex = 0;
-				 currentIndex < length && (containerNode.isNotSetContainerSize() || currentIndex < elementSize);
-				 currentIndex++) {
+			for (
+				currentIndex = 0;
+				currentIndex < length && (containerNode.isNotSetContainerSize() || currentIndex < elementSize);
+				currentIndex++
+			) {
 				Object nextValue = Array.get(value, currentIndex);
 				@SuppressWarnings("unchecked")
 				ArbitraryNode<?> nextNode = ArbitraryNode.builder()

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/MapArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/MapArbitraryNodeGenerator.java
@@ -45,9 +45,7 @@ public class MapArbitraryNodeGenerator implements ContainerArbitraryNodeGenerato
 		ArbitraryType<?> keyType = clazz.getGenericArbitraryType(0);
 		ArbitraryType<?> valueType = clazz.getGenericArbitraryType(1);
 
-		containerNode.initializeElementSize();
-
-		int elementSize = containerNode.getContainerSizeConstraint().getArbitraryElementSize();
+		int elementSize = containerNode.getElementSize();
 
 		if (clazz.isMapEntry()) {
 			elementSize = 1;
@@ -73,6 +71,8 @@ public class MapArbitraryNodeGenerator implements ContainerArbitraryNodeGenerato
 
 			generatedNodeList.add(valueNode);
 		}
+
+		containerNode.setContainerSizeConstraint(null); // clear
 		return generatedNodeList;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -54,6 +54,7 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.NestedString
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.SetArbitraryAcceptGroup;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.SetArbitraryArbitraryAcceptGroup;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringAndIntGroup;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerArray;
 
 class ComplexManipulatorTest {
 	@Property
@@ -785,5 +786,29 @@ class ComplexManipulatorTest {
 		// then
 		Complex notExpected = generator.next(Randoms.current()).value();
 		then(actual).isNotEqualTo(notExpected);
+	}
+
+	@Property
+	void setSizeAndSetEmptyListFixed() {
+		// when
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
+			.size("values", 2)
+			.set("values", new ArrayList<>())
+			.fixed()
+			.sample();
+
+		then(actual.getValues()).isEmpty();
+	}
+
+	@Property
+	void setSizeAndSetEmptyArrayFixed() {
+		// when
+		IntegerArray actual = SUT.giveMeBuilder(IntegerArray.class)
+			.size("values", 2)
+			.set("values", new Integer[] {})
+			.fixed()
+			.sample();
+
+		then(actual.getValues()).isEmpty();
 	}
 }


### PR DESCRIPTION
https://github.com/naver/fixture-monkey/pull/85 에서 처럼 set 연산을 실행할 때 입력한 객체를 분해해서 Virtual Class Tree에 반영할 때 로직을 수정합니다.
Set을 실행할 때 객체를 분해하지 않고 일관성 있는 로직을 위해 기존의 traverse시에 decompose 로직을 활용하도록 수정합니다.
수정하면서 컨테이너 생성 로직에 있었던 버그를 발견해 수정합니다.


---

Modify the logic when decomposing the input object when executing the set operation as shown in #85 and reflecting it in the Virtual Class Tree.
When executing Set, modify the object to utilize the compose logic in the existing traverse for consistent logic without decomposing it.
While modifying, find and correct the bug that was in the container creation logic.

다음 PR에서는 `apply`/`acceptIf`를 연산 (Manipulator)로 전환할 예정입니다.