### PR TITLE
Introduce PropertyDescriptorProperty

### DIFF
--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -24,6 +24,10 @@ editorconfig {
     excludes = ["build"]
 }
 
+test {
+    useJUnitPlatform()
+}
+
 check.dependsOn editorconfigCheck
 
 checkstyle {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorProperty.java
@@ -1,0 +1,116 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.property;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class PropertyDescriptorProperty implements Property {
+	private final PropertyDescriptor propertyDescriptor;
+	private final List<Annotation> annotations;
+	private final Map<Class<? extends Annotation>, Annotation> annotationsMap;
+
+	public PropertyDescriptorProperty(PropertyDescriptor propertyDescriptor) {
+		this.propertyDescriptor = propertyDescriptor;
+		this.annotations = Arrays.asList(propertyDescriptor.getReadMethod().getAnnotations());
+		this.annotationsMap = this.annotations.stream()
+			.collect(toMap(Annotation::annotationType, Function.identity(), (a1, a2) -> a1));
+	}
+
+	public PropertyDescriptor getPropertyDescriptor() {
+		return this.propertyDescriptor;
+	}
+
+	@Override
+	public Class<?> getType() {
+		return this.propertyDescriptor.getPropertyType();
+	}
+
+	@Override
+	public AnnotatedType getAnnotatedType() {
+		return this.propertyDescriptor.getReadMethod().getAnnotatedReturnType();
+	}
+
+	@Override
+	public String getName() {
+		return this.propertyDescriptor.getName();
+	}
+
+	@Override
+	public List<Annotation> getAnnotations() {
+		return this.annotations;
+	}
+
+	@Override
+	public <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationClass) {
+		return Optional.ofNullable(this.annotationsMap.get(annotationClass))
+			.map(annotationClass::cast);
+	}
+
+	@Nullable
+	@Override
+	public Object getValue(Object obj) {
+		try {
+			return this.propertyDescriptor.getReadMethod().invoke(obj);
+		} catch (InvocationTargetException | IllegalAccessException ex) {
+			throw new IllegalArgumentException(
+				"Can not invoke value. obj: " + obj.toString() + ", propertyName: " + this.propertyDescriptor.getName(),
+				ex
+			);
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		PropertyDescriptorProperty that = (PropertyDescriptorProperty)obj;
+		return Objects.equals(this.propertyDescriptor, that.propertyDescriptor);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.propertyDescriptor);
+	}
+
+	@Override
+	public String toString() {
+		return "PropertyDescriptorProperty{propertyDescriptor='" + this.propertyDescriptor + '}';
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorPropertyTest.java
@@ -1,0 +1,87 @@
+package com.navercorp.fixturemonkey.api.property;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Test;
+
+class PropertyDescriptorPropertyTest {
+	@Test
+	void getPropertyDescriptor() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getPropertyDescriptor()).isSameAs(propertyDescriptor);
+	}
+
+	@Test
+	void getAnnotations() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getAnnotations()).hasSize(1);
+		then(sut.getAnnotations().get(0).annotationType()).isEqualTo(Nonnull.class);
+	}
+
+	@Test
+	void getAnnotation() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getAnnotation(Nonnull.class)).isPresent();
+	}
+
+	@Test
+	void getAnnotationNotFound() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getAnnotation(Nullable.class)).isEmpty();
+	}
+
+	@Test
+	void getName() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getName()).isEqualTo("name");
+	}
+
+	@Test
+	void getAnnotatedType() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		then(sut.getAnnotatedType().getType()).isEqualTo(String.class);
+	}
+
+	@Test
+	void getValue() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty sut = new PropertyDescriptorProperty(propertyDescriptor);
+		PropertyValue propertyValue = new PropertyValue("hello world");
+		then(sut.getValue(propertyValue)).isEqualTo("hello world");
+	}
+
+	@Test
+	void equalsAndHashCode() {
+		PropertyDescriptor propertyDescriptor = getNamePropertyDescriptor();
+		PropertyDescriptorProperty property1 = new PropertyDescriptorProperty(propertyDescriptor);
+		PropertyDescriptorProperty property2 = new PropertyDescriptorProperty(propertyDescriptor);
+		then(property1.equals(property2)).isTrue();
+		then(property1.hashCode() == property2.hashCode()).isTrue();
+	}
+
+	private PropertyDescriptor getNamePropertyDescriptor() {
+		try {
+			PropertyDescriptor[] descriptors = Introspector.getBeanInfo(PropertyValue.class).getPropertyDescriptors();
+			for (PropertyDescriptor descriptor : descriptors) {
+				if (descriptor.getName().equals("name")) {
+					return descriptor;
+				}
+			}
+			return null;
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorPropertyTest.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.api.property;
 
 import static org.assertj.core.api.BDDAssertions.then;

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyValue.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyValue.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.property;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class PropertyValue {
@@ -26,5 +27,10 @@ public class PropertyValue {
 
 	public PropertyValue(String name) {
 		this.name = name;
+	}
+
+	@Nonnull
+	public String getName() {
+		return this.name;
 	}
 }


### PR DESCRIPTION
지금까지 Field 를 기준으로 애노테이션을 식별하고 메소드를 기준으로 식별할 수 없었다
메소드를 기준으로 annotation 등을 관리하는 PropertyDescriptorProperty 를 추가한다.