### PR TITLE
Refactor apply, acceptIf as manipulator

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -628,6 +628,7 @@ public final class ArbitraryBuilder<T> {
 		return this;
 	}
 
+	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> apply(ArbitraryApply<T> arbitraryApply) {
 		ArbitraryBuilder<T> toSampleArbitraryBuilder = arbitraryApply.getToSampleArbitraryBuilder();
 		BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer = arbitraryApply.getBuilderBiConsumer();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -52,6 +52,7 @@ import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
+import com.navercorp.fixturemonkey.arbitrary.ArbitraryApply;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpression;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpressionManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
@@ -520,18 +521,7 @@ public final class ArbitraryBuilder<T> {
 	}
 
 	public ArbitraryBuilder<T> apply(BiConsumer<T, ArbitraryBuilder<T>> biConsumer) {
-		ArbitraryBuilder<T> appliedBuilder = this.copy();
-
-		this.decomposedManipulators.add(biConsumer);
-		setCurrentBuilderManipulatorsAsUsed();
-		this.tree.setDecomposedValue(() -> {
-			ArbitraryBuilder<T> copied = appliedBuilder.copy();
-			T sample = copied.sampleInternal();
-			copied.tree.setDecomposedValue(() -> sample); // fix builder value
-			this.decomposedManipulators.forEach(it -> it.accept(sample, copied));
-			return copied.sampleInternal();
-		});
-
+		this.builderManipulators.add(new ArbitraryApply<>(this, biConsumer));
 		return this;
 	}
 
@@ -548,6 +538,27 @@ public final class ArbitraryBuilder<T> {
 		setCurrentBuilderManipulatorsAsUsed();
 		this.tree.setFixedDecomposedValue(copied::sampleInternal);
 		return this;
+	}
+
+	private void setCurrentBuilderManipulatorsAsUsed() {
+		this.usedManipulators.clear();
+		this.usedManipulators.addAll(this.builderManipulators);
+	}
+
+	private List<BuilderManipulator> getActiveManipulators() {
+		List<BuilderManipulator> activeManipulators = new ArrayList<>();
+		for (int i = 0; i < builderManipulators.size(); i++) {
+			BuilderManipulator builderManipulator = builderManipulators.get(i);
+			if (i < usedManipulators.size()) {
+				BuilderManipulator appliedManipulator = usedManipulators.get(i);
+				if (builderManipulator.equals(appliedManipulator)) {
+					continue;
+				}
+			}
+
+			activeManipulators.add(builderManipulator);
+		}
+		return activeManipulators;
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
@@ -617,6 +628,33 @@ public final class ArbitraryBuilder<T> {
 		return this;
 	}
 
+	public ArbitraryBuilder<T> apply(ArbitraryApply<T> arbitraryApply) {
+		ArbitraryBuilder<T> toSampleArbitraryBuilder = arbitraryApply.getToSampleArbitraryBuilder();
+		BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer = arbitraryApply.getBuilderBiConsumer();
+
+		T sample = toSampleArbitraryBuilder.sample();
+		int preApplyManipulatorSize = toSampleArbitraryBuilder.builderManipulators.size();
+		builderBiConsumer.accept(sample, toSampleArbitraryBuilder);
+
+		this.apply(new ArbitrarySet<>(ArbitraryExpression.from(HEAD_NAME), sample));
+		this.apply(getDeltaManipulators(toSampleArbitraryBuilder, preApplyManipulatorSize));
+		return this;
+	}
+
+	private List<BuilderManipulator> getDeltaManipulators(
+		ArbitraryBuilder<T> toSampleArbitraryBuilder,
+		int preApplyManipulatorSize
+	) {
+		List<BuilderManipulator> deltaManipulators = new ArrayList<>();
+		int postApplyManipulatorSize = toSampleArbitraryBuilder.builderManipulators.size();
+
+		for (int i = preApplyManipulatorSize; i < postApplyManipulatorSize; i++) {
+			deltaManipulators.add(toSampleArbitraryBuilder.builderManipulators.get(i));
+		}
+
+		return deltaManipulators;
+	}
+
 	@API(since = "0.4.0", status = Status.INTERNAL)
 	@SuppressWarnings("rawtypes")
 	private void apply(List<BuilderManipulator> arbitraryManipulators) {
@@ -631,6 +669,7 @@ public final class ArbitraryBuilder<T> {
 		postArbitraryManipulators.forEach(it -> it.accept(this));
 	}
 
+	@Deprecated
 	public boolean isDirty() {
 		return usedManipulators.size() != builderManipulators.size();
 	}
@@ -649,27 +688,6 @@ public final class ArbitraryBuilder<T> {
 		);
 		copied.validOnly(this.validOnly);
 		return copied;
-	}
-
-	private void setCurrentBuilderManipulatorsAsUsed() {
-		this.usedManipulators.clear();
-		this.usedManipulators.addAll(this.builderManipulators);
-	}
-
-	private List<BuilderManipulator> getActiveManipulators() {
-		List<BuilderManipulator> activeManipulators = new ArrayList<>();
-		for (int i = 0; i < builderManipulators.size(); i++) {
-			BuilderManipulator builderManipulator = builderManipulators.get(i);
-			if (i < usedManipulators.size()) {
-				BuilderManipulator appliedManipulator = usedManipulators.get(i);
-				if (builderManipulator.equals(appliedManipulator)) {
-					continue;
-				}
-			}
-
-			activeManipulators.add(builderManipulator);
-		}
-		return activeManipulators;
 	}
 
 	private ArbitraryBuilder<T> setSpec(String expression, ExpressionSpec expressionSpec) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryApply.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryApply.java
@@ -1,0 +1,74 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.arbitrary;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+
+public final class ArbitraryApply<T> implements BuilderManipulator {
+	private final ArbitraryBuilder<T> toSampleArbitraryBuilder;
+	private final BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer;
+
+	public ArbitraryApply(
+		ArbitraryBuilder<T> toSampleArbitraryBuilder,
+		BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer
+	) {
+		this.toSampleArbitraryBuilder = toSampleArbitraryBuilder.copy();
+		this.builderBiConsumer = builderBiConsumer;
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	@Override
+	public void accept(ArbitraryBuilder arbitraryBuilder) {
+		arbitraryBuilder.apply(this);
+	}
+
+	@Override
+	public BuilderManipulator copy() {
+		return new ArbitraryApply<>(toSampleArbitraryBuilder, builderBiConsumer);
+	}
+
+	public ArbitraryBuilder<T> getToSampleArbitraryBuilder() {
+		return toSampleArbitraryBuilder;
+	}
+
+	public BiConsumer<T, ArbitraryBuilder<T>> getBuilderBiConsumer() {
+		return builderBiConsumer;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		ArbitraryApply<?> that = (ArbitraryApply<?>)obj;
+		return toSampleArbitraryBuilder.equals(that.toSampleArbitraryBuilder)
+			&& builderBiConsumer.equals(that.builderBiConsumer);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(toSampleArbitraryBuilder, builderBiConsumer);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -811,4 +811,20 @@ class ComplexManipulatorTest {
 
 		then(actual.getValues()).isEmpty();
 	}
+
+	@Property
+	void applyNested() {
+		// when
+		StringValue actual = SUT.giveMeBuilder(StringValue.class)
+			.set("value", "test")
+			.apply((outerValue, outerBuilder) ->
+				outerBuilder.set("value", "0" + outerValue.getValue())
+					.apply((innerValue, innerBuilder) ->
+						innerBuilder.set("value", "1" + innerValue.getValue())
+					)
+			)
+			.sample();
+
+		then(actual.getValue()).isEqualTo("10test");
+	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -1069,34 +1069,6 @@ class FixtureMonkeyTest {
 	}
 
 	@Property
-	void isDirtyWhenManipulatedAndApplyReturnsFalse() {
-		// given
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "test")
-			.apply((builder, it) -> {
-			});
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
-	void isDirtyWhenManipulatedAndAcceptIfReturnsFalse() {
-		// given
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.set("value", "test")
-			.acceptIf(it -> true, it -> {
-			});
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
 	void isDirtyWhenManipulatedAndApplyAndManipulatedReturnsTrue() {
 		// given
 		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = SUT.giveMeBuilder(StringWithNotBlank.class)
@@ -1170,34 +1142,6 @@ class FixtureMonkeyTest {
 	}
 
 	@Property
-	void isDirtyWhenFixedAndApplyReturnsFalse() {
-		// given
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.fixed()
-			.apply((builder, it) -> {
-			});
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
-	void isDirtyWhenFixedAndAcceptIfReturnsFalse() {
-		// given
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = SUT.giveMeBuilder(StringWithNotBlank.class)
-			.fixed()
-			.acceptIf(it -> true, it -> {
-			});
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
 	@Domain(FixtureMonkeyTestSpecs.class)
 	void isDirtyWhenDecomposeReturnsFalse(@ForAll StringWithNotBlank stringWithNotBlank) {
 		// given
@@ -1260,44 +1204,6 @@ class FixtureMonkeyTest {
 				fixture.giveMeBuilder(StringWithNotBlank.class)
 					.set("value", "test")
 					.fixed()
-			)
-			.build();
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = sut.giveMeBuilder(StringWithNotBlank.class);
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
-	void isDirtyWhenRegisterWithManipulatedAndApplyReturnsFalse() {
-		// given
-		FixtureMonkey sut = FixtureMonkey.builder()
-			.register(StringWithNotBlank.class, fixture ->
-				fixture.giveMeBuilder(StringWithNotBlank.class)
-					.set("value", "test")
-					.apply((it, builder) -> {
-					})
-			)
-			.build();
-		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = sut.giveMeBuilder(StringWithNotBlank.class);
-
-		// when
-		boolean changed = arbitraryBuilder.isDirty();
-
-		then(changed).isFalse();
-	}
-
-	@Property
-	void isDirtyWhenRegisterWithManipulatedAndAcceptIfReturnsFalse() {
-		// given
-		FixtureMonkey sut = FixtureMonkey.builder()
-			.register(StringWithNotBlank.class, fixture ->
-				fixture.giveMeBuilder(StringWithNotBlank.class)
-					.set("value", "test")
-					.acceptIf(it -> true, it -> {
-					})
 			)
 			.build();
 		ArbitraryBuilder<StringWithNotBlank> arbitraryBuilder = sut.giveMeBuilder(StringWithNotBlank.class);


### PR DESCRIPTION
apply와 acceptIf 연산을 BuilderManipulator 구현체인 `ArbitraryApply` 객체를 통해 실행하도록 수정합니다.
다른 연산과 동일한 구조로 변경하여 일관성을 보장합니다.


다음 PR에서는 `fixed`를 BuilderManipulator 구현체를 통해 실행하도록 수정할 예정입니다.

---

Modify the `apply` and `acceptIf` operations to run through the 'ArbitraryApply' object, the BuilderManipulator implementation.
It ensures consistency by changing it to the same structure as other operations.


In the next PR, `fixed` will be modified to run through the BuilderManipulator implementation.