### PR TITLE
Refactor apply field toSampleArbitraryBuilder as immutable object

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryApply.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryApply.java
@@ -31,7 +31,7 @@ public final class ArbitraryApply<T> implements BuilderManipulator {
 		ArbitraryBuilder<T> toSampleArbitraryBuilder,
 		BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer
 	) {
-		this.toSampleArbitraryBuilder = toSampleArbitraryBuilder.copy();
+		this.toSampleArbitraryBuilder = toSampleArbitraryBuilder;
 		this.builderBiConsumer = builderBiConsumer;
 	}
 
@@ -47,7 +47,7 @@ public final class ArbitraryApply<T> implements BuilderManipulator {
 	}
 
 	public ArbitraryBuilder<T> getToSampleArbitraryBuilder() {
-		return toSampleArbitraryBuilder;
+		return toSampleArbitraryBuilder.copy();
 	}
 
 	public BiConsumer<T, ArbitraryBuilder<T>> getBuilderBiConsumer() {


### PR DESCRIPTION
Apply를 선언한 시점의 ArbitraryBuilder의 변경을 막고 불변하게 만들기 위해 getter에서 복제합니다.