### PR TITLE
Refactor apply for preventing circular reference

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -578,7 +578,7 @@ public final class ArbitraryBuilder<T> {
 
 		for (ArbitraryNode<T> foundNode : foundNodes) {
 			if (fixtureSet.isApplicable()) {
-				foundNode.apply(fixtureSet);
+				foundNode.apply(foundNode, fixtureSet);
 				if (fixtureSet instanceof ArbitrarySet) {
 					traverser.traverse(foundNode, foundNode.isKeyOfMapStructure(), generator);
 				}
@@ -590,8 +590,8 @@ public final class ArbitraryBuilder<T> {
 	public ArbitraryBuilder<T> setNullity(ArbitraryNullity arbitraryNullity) {
 		ArbitraryExpression arbitraryExpression = arbitraryNullity.getArbitraryExpression();
 		Collection<ArbitraryNode> foundNodes = this.findNodesByExpression(arbitraryExpression);
-		for (ArbitraryNode foundNode : foundNodes) {
-			foundNode.apply(arbitraryNullity);
+		for (ArbitraryNode<?> foundNode : foundNodes) {
+			foundNode.apply(foundNode, arbitraryNullity);
 		}
 		return this;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -134,8 +134,19 @@ public final class ArbitraryNode<T> {
 		return getContainerSizeConstraint() == null;
 	}
 
+	public void apply(ArbitraryNode<?> sourceApplyNode, BuilderManipulator builderManipulator) {
+		if (builderManipulator instanceof PreArbitraryManipulator) {
+			apply((PreArbitraryManipulator)builderManipulator);
+		} else if (builderManipulator instanceof ArbitraryNullity) {
+			apply((ArbitraryNullity)builderManipulator);
+		} else {
+			throw new IllegalArgumentException("Given Manipulator is not supported : " + builderManipulator.getClass());
+		}
+		// TODO: apply callback
+	}
+
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	public void apply(PreArbitraryManipulator preArbitraryManipulator) {
+	private void apply(PreArbitraryManipulator preArbitraryManipulator) {
 		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary) {
 			this.setFixed(true);
 			this.setArbitrary((Arbitrary<T>)preArbitraryManipulator.getApplicableValue());
@@ -163,7 +174,7 @@ public final class ArbitraryNode<T> {
 		}
 	}
 
-	public void apply(ArbitraryNullity manipulator) {
+	private void apply(ArbitraryNullity manipulator) {
 		this.setActive(!manipulator.toNull());
 	}
 


### PR DESCRIPTION
ArbitraryNode를 변경하는 연산들을 입력받아 타입에 따라 분기하는 public 메소드를 추가합니다.
기존 연산들은 모두 private으로 전환합니다.