### PR TITLE
Add DslBuilder

### DIFF
--- a/fixture-monkey-kotlin/build.gradle
+++ b/fixture-monkey-kotlin/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
 
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
+    testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.18.1")
 }
 

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
@@ -49,11 +49,11 @@ operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R>.get(index: Int): E
     ExpList(ArrayExpressionGenerator(KotlinProperty(this), index))
 
 @JvmName("getNestedList")
-operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R>.get(index: Int): ExpNestedList<E> =
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R>.get(index: Int): ExpNestedList<E> =
     ExpNestedList(ArrayExpressionGenerator(KotlinProperty(this), index))
 
 @JvmName("getNestedList")
-operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R>.get(key: String): ExpNestedList<E> =
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R>.get(key: String): ExpNestedList<E> =
     ExpNestedList(ArrayWithKeyExpressionGenerator(KotlinProperty(this), key))
 
 class ExpList<T> internal constructor(val delegate: ExpressionGenerator) : ExpressionGenerator by delegate {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.kotlin
 
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
@@ -13,7 +13,7 @@ class Exp<T> internal constructor(val delegate: ExpressionGenerator) : Expressio
     infix fun <R> dot(property: KProperty1<T, R>): Exp<R> =
         Exp(ParsedExpressionGenerator(listOf(delegate, PropertyExpressionGenerator(KotlinProperty(property)))))
 
-    @JvmName("onList")
+    @JvmName("dotList")
     infix fun <R : Collection<E>, E : Any> dot(property: KProperty1<T, R>): ExpList<E> = ExpList(
         ParsedExpressionGenerator(
             listOf(
@@ -23,7 +23,7 @@ class Exp<T> internal constructor(val delegate: ExpressionGenerator) : Expressio
         )
     )
 
-    @JvmName("onNestedList")
+    @JvmName("dotNestedList")
     infix fun <R : Collection<N>, N : Collection<E>, E : Any> dot(property: KProperty1<T, R>): ExpNestedList<E> =
         ExpNestedList(
             ParsedExpressionGenerator(

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerator.kt
@@ -1,0 +1,96 @@
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
+import com.navercorp.fixturemonkey.api.property.Property
+import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
+import java.lang.reflect.AnnotatedType
+import kotlin.reflect.KFunction2
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.javaField
+
+class ParsedExpressionGenerator(private val expressionGenerators: List<ExpressionGenerator>) : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String =
+        expressionGenerators.joinToString(separator = "") { expressionGenerator ->
+            expressionGenerator.generate(
+                propertyNameResolver
+            )
+        }.removePrefix(".")
+}
+
+class PropertyExpressionGenerator(private val property: Property) : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String =
+        ".${propertyNameResolver.resolve(property)}"
+}
+
+class IndexExpressionGenerator(val index: Long) : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String = "[$index]"
+}
+
+class AllIndexExpressionGenerator : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String = "[*]"
+}
+
+class EmptyExpressionGenerator : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String = ""
+}
+
+class DslBuilder<T>(private val expressionGenerator: ExpressionGenerator) {
+    operator fun <R> rangeTo(property: KProperty1<T, R>): DslBuilder<R> = property(property)
+
+    operator fun <R> rangeTo(indexWrapper: Index<T, R>): DslBuilder<R> = method(indexWrapper)
+
+    operator fun <R> rangeTo(allIndexWrapper: AllIndex<T, R>): DslBuilder<R> = method(allIndexWrapper)
+
+    infix fun <R> property(property: KProperty1<T, R>): DslBuilder<R> = DslBuilder(
+        ParsedExpressionGenerator(
+            listOf(
+                this.expressionGenerator,
+                PropertyExpressionGenerator(toProperty(property))
+            )
+        )
+    )
+
+    infix fun <R> method(indexWrapper: Index<T, R>): DslBuilder<R> = DslBuilder(
+        ParsedExpressionGenerator(
+            listOf(
+                this.expressionGenerator,
+                IndexExpressionGenerator(indexWrapper.index)
+            )
+        )
+    )
+
+    @Suppress("UNUSED_PARAMETER")
+    infix fun <R> method(allIndexWrapper: AllIndex<T, R>): DslBuilder<R> = DslBuilder(
+        ParsedExpressionGenerator(
+            listOf(
+                this.expressionGenerator,
+                AllIndexExpressionGenerator()
+            )
+        )
+    )
+
+    private fun <T, R> toProperty(property: KProperty1<T, R>): Property = KotlinProperty(property)
+
+    fun build() = expressionGenerator
+}
+
+@Suppress("UNUSED_PARAMETER")
+fun <T, R> from(clazz: Class<T>, setup: DslBuilder<T>.() -> DslBuilder<R>): ExpressionGenerator =
+    DslBuilder<T>(expressionGenerator = EmptyExpressionGenerator()).setup().build()
+
+data class Index<L, R>(private val getter: KFunction2<L, Int, R>, val index: Long)
+
+data class AllIndex<L, R>(private val getter: KFunction2<L, Int, R>)
+
+class KotlinProperty<V, R>(val property: KProperty1<V, R>) : Property {
+    override fun getType(): Class<*> = property.javaField!!.type
+
+    override fun getAnnotatedType(): AnnotatedType = property.javaField!!.annotatedType
+
+    override fun getName(): String = property.name
+
+    override fun getAnnotations(): List<Annotation> = property.annotations
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(obj: Any): Any? = property.get(obj as V)
+}

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.kotlin
 
 import org.assertj.core.api.BDDAssertions.then
@@ -175,14 +193,4 @@ class ExpressionGeneratorTest {
 
         then(actual).isEqualTo("nestedThriceDogs[1][2][2].name")
     }
-
-    data class Person(
-        val name: String?,
-        val dog: Dog,
-        val dogs: List<Dog>,
-        val nestedDogs: List<List<Dog>>,
-        val nestedThriceDogs: List<List<List<Dog>>>,
-    )
-
-    data class Dog(val name: String, val loves: List<Int>)
 }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
@@ -5,31 +5,9 @@ import org.junit.jupiter.api.Test
 
 class ExpressionGeneratorTest {
     @Test
-    fun getExpressionEmpty() {
+    fun getExpressionField() {
         // given
-        val generator = from(Person::class.java) { this }
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("")
-    }
-
-    @Test
-    fun getExpressionFieldWithImplicitRangeTo() {
-        // given
-        val generator = from(Person::class.java) { this..Person::dog }
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog")
-    }
-
-    @Test
-    fun getExpressionFieldWithExplicitProperty() {
-        // given
-        val generator = from(Person::class.java) { this.property(Person::dogs) }
+        val generator = Exp<Person>() on Person::dogs
 
         // when
         val actual = generator.generate()
@@ -40,7 +18,7 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNestedField() {
         // given
-        val generator = from(Person::class.java) { this..Person::dog..Dog::name }
+        val generator = Exp<Person>() on Person::dog on Dog::name
 
         // when
         val actual = generator.generate()
@@ -49,9 +27,20 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionListWithImplicitRangeTo() {
+    fun getExpressionNestedFieldWithIndex() {
         // given
-        val generator = from(Person::class.java) { this..Person::dogs..Index(List<Dog>::get, 1) }
+        val generator = Exp<Person>() on Person::dog on Dog::loves[0]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[0]")
+    }
+
+    @Test
+    fun getExpressionFieldWithIndex() {
+        // given
+        val generator = Exp<Person>() on Person::dogs[1]
 
         // when
         val actual = generator.generate()
@@ -60,78 +49,44 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionListWithImplicitIndex() {
+    fun getExpressionNFieldWithAllIndexWithField() {
         // given
-        val generator = from(Person::class.java) { this.property(Person::dogs).method(Index(List<Dog>::get, 1)) }
+        val generator = Exp<Person>() on Person::nestedDogs["*"]["*"] on Dog::name
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("dogs[1]")
+        then(actual).isEqualTo("nestedDogs[*][*].name")
     }
 
     @Test
-    fun getExpressionListWithImplicitAllIndex() {
+    fun getExpressionFieldWithIndexWithFieldExpression1() {
         // given
-        val generator = from(Person::class.java) { this.property(Person::dogs).method(AllIndex(List<Dog>::get)) }
+        val generator = Exp<Person>() on Person::nestedDogs[1][2] on Dog::name
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("dogs[*]")
+        then(actual).isEqualTo("nestedDogs[*][*].name")
     }
 
     @Test
-    fun getExpressionListAllIndex() {
+    fun getExpressionFieldWithIndexWithFieldExpression2() {
         // given
-        val generator = from(Person::class.java) { this..Person::dogs..AllIndex(List<Dog>::get) }
+        val generator = Exp<Person>() on Person::nestedDogs get 1 get 2 on Dog::name
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("dogs[*]")
+        then(actual).isEqualTo("nestedDogs[*][*].name")
     }
 
     @Test
-    fun getExpressionNestedListAllIndex() {
+    fun getExpressionFieldWithIndexWithFieldExpression3() {
         // given
-        val generator = from(Person::class.java) {
-            this..Person::nestedDogs..AllIndex(List<List<Dog>>::get)..AllIndex(List<Dog>::get)
-        }
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*][*]")
-    }
-
-    @Test
-    fun getExpressionNestedListIndex() {
-        // given
-        val generator =
-            from(Person::class.java) {
-                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
-                    List<Dog>::get,
-                    2
-                )
-            }
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2]")
-    }
-
-    @Test
-    fun getExpressionNestedListField() {
-        // given
-        val generator =
-            from(Person::class.java) {
-                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
-                    List<Dog>::get,
-                    2
-                )..Dog::name
-            }
+        val generator = Exp<Person>()
+            .on(Person::nestedDogs)[1][2]
+            .on(Dog::name)
 
         // when
         val actual = generator.generate()
@@ -140,20 +95,16 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionNestedListIndexFieldListIndex() {
+    fun getExpressionFieldWithIndexWithFieldExpression4() {
         // given
-        val generator =
-            from(Person::class.java) {
-                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
-                    List<Dog>::get,
-                    2
-                )..Dog::loves..Index(List<Int>::get, 1)
-            }
+        val generator = Exp<Person>()
+            .on(Person::nestedDogs[1][2])
+            .on(Dog::name)
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("nestedDogs[1][2].loves[1]")
+        then(actual).isEqualTo("nestedDogs[1][2].name")
     }
 
     data class Person(

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
@@ -7,7 +7,18 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionField() {
         // given
-        val generator = Exp<Person>() on Person::dogs
+        val generator = Exp<Person>() dot Person::dogs
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs")
+    }
+
+    @Test
+    fun getExpressionFieldDiv() {
+        // given
+        val generator = Exp<Person>() / Person::dogs
 
         // when
         val actual = generator.generate()
@@ -18,7 +29,18 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNestedField() {
         // given
-        val generator = Exp<Person>() on Person::dog on Dog::name
+        val generator = Exp<Person>() dot Person::dog dot Dog::name
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getExpressionNestedFieldDiv() {
+        // given
+        val generator = Exp<Person>() / Person::dog / Dog::name
 
         // when
         val actual = generator.generate()
@@ -29,7 +51,18 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNestedFieldWithIndex() {
         // given
-        val generator = Exp<Person>() on Person::dog on Dog::loves[0]
+        val generator = Exp<Person>() dot Person::dog dot Dog::loves[0]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[0]")
+    }
+
+    @Test
+    fun getExpressionNestedFieldWithIndexDiv() {
+        // given
+        val generator = Exp<Person>() / Person::dog / Dog::loves[0]
 
         // when
         val actual = generator.generate()
@@ -40,7 +73,18 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionFieldWithIndex() {
         // given
-        val generator = Exp<Person>() on Person::dogs[1]
+        val generator = Exp<Person>() dot Person::dogs[1]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[1]")
+    }
+
+    @Test
+    fun getExpressionFieldWithIndexDiv() {
+        // given
+        val generator = Exp<Person>() / Person::dogs[1]
 
         // when
         val actual = generator.generate()
@@ -51,7 +95,18 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNFieldWithAllIndexWithField() {
         // given
-        val generator = Exp<Person>() on Person::nestedDogs["*"]["*"] on Dog::name
+        val generator = Exp<Person>() dot Person::nestedDogs["*"]["*"] dot Dog::name
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][*].name")
+    }
+
+    @Test
+    fun getExpressionNFieldWithAllIndexWithFieldDiv() {
+        // given
+        val generator = Exp<Person>() / Person::nestedDogs["*"]["*"] / Dog::name
 
         // when
         val actual = generator.generate()
@@ -62,31 +117,31 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionFieldWithIndexWithFieldExpression1() {
         // given
-        val generator = Exp<Person>() on Person::nestedDogs[1][2] on Dog::name
+        val generator = Exp<Person>() dot Person::nestedDogs[1][2] dot Dog::name
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("nestedDogs[*][*].name")
+        then(actual).isEqualTo("nestedDogs[1][2].name")
     }
 
     @Test
     fun getExpressionFieldWithIndexWithFieldExpression2() {
         // given
-        val generator = Exp<Person>() on Person::nestedDogs get 1 get 2 on Dog::name
+        val generator = Exp<Person>() dot Person::nestedDogs get 1 get 2 dot Dog::name
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("nestedDogs[*][*].name")
+        then(actual).isEqualTo("nestedDogs[1][2].name")
     }
 
     @Test
     fun getExpressionFieldWithIndexWithFieldExpression3() {
         // given
         val generator = Exp<Person>()
-            .on(Person::nestedDogs)[1][2]
-            .on(Dog::name)
+            .dot(Person::nestedDogs)[1][2]
+            .dot(Dog::name)
 
         // when
         val actual = generator.generate()
@@ -98,8 +153,8 @@ class ExpressionGeneratorTest {
     fun getExpressionFieldWithIndexWithFieldExpression4() {
         // given
         val generator = Exp<Person>()
-            .on(Person::nestedDogs[1][2])
-            .on(Dog::name)
+            .dot(Person::nestedDogs[1][2])
+            .dot(Dog::name)
 
         // when
         val actual = generator.generate()

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
@@ -1,0 +1,167 @@
+package com.navercorp.fixturemonkey.kotlin
+
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+
+class ExpressionGeneratorTest {
+    @Test
+    fun getExpressionEmpty() {
+        // given
+        val generator = from(Person::class.java) { this }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("")
+    }
+
+    @Test
+    fun getExpressionFieldWithImplicitRangeTo() {
+        // given
+        val generator = from(Person::class.java) { this..Person::dog }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog")
+    }
+
+    @Test
+    fun getExpressionFieldWithExplicitProperty() {
+        // given
+        val generator = from(Person::class.java) { this.property(Person::dogs) }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs")
+    }
+
+    @Test
+    fun getExpressionNestedField() {
+        // given
+        val generator = from(Person::class.java) { this..Person::dog..Dog::name }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getExpressionListWithImplicitRangeTo() {
+        // given
+        val generator = from(Person::class.java) { this..Person::dogs..Index(List<Dog>::get, 1) }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[1]")
+    }
+
+    @Test
+    fun getExpressionListWithImplicitIndex() {
+        // given
+        val generator = from(Person::class.java) { this.property(Person::dogs).method(Index(List<Dog>::get, 1)) }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[1]")
+    }
+
+    @Test
+    fun getExpressionListWithImplicitAllIndex() {
+        // given
+        val generator = from(Person::class.java) { this.property(Person::dogs).method(AllIndex(List<Dog>::get)) }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[*]")
+    }
+
+    @Test
+    fun getExpressionListAllIndex() {
+        // given
+        val generator = from(Person::class.java) { this..Person::dogs..AllIndex(List<Dog>::get) }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[*]")
+    }
+
+    @Test
+    fun getExpressionNestedListAllIndex() {
+        // given
+        val generator = from(Person::class.java) {
+            this..Person::nestedDogs..AllIndex(List<List<Dog>>::get)..AllIndex(List<Dog>::get)
+        }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][*]")
+    }
+
+    @Test
+    fun getExpressionNestedListIndex() {
+        // given
+        val generator =
+            from(Person::class.java) {
+                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
+                    List<Dog>::get,
+                    2
+                )
+            }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1][2]")
+    }
+
+    @Test
+    fun getExpressionNestedListField() {
+        // given
+        val generator =
+            from(Person::class.java) {
+                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
+                    List<Dog>::get,
+                    2
+                )..Dog::name
+            }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1][2].name")
+    }
+
+    @Test
+    fun getExpressionNestedListIndexFieldListIndex() {
+        // given
+        val generator =
+            from(Person::class.java) {
+                this..Person::nestedDogs..Index(List<List<Dog>>::get, 1)..Index(
+                    List<Dog>::get,
+                    2
+                )..Dog::loves..Index(List<Int>::get, 1)
+            }
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1][2].loves[1]")
+    }
+
+    data class Person(
+        val name: String?,
+        val dog: Dog,
+        val dogs: List<Dog>,
+        val nestedDogs: List<List<Dog>>,
+    )
+
+    data class Dog(val name: String, val loves: List<Int>)
+}

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTest.kt
@@ -7,18 +7,7 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionField() {
         // given
-        val generator = Exp<Person>() dot Person::dogs
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs")
-    }
-
-    @Test
-    fun getExpressionFieldDiv() {
-        // given
-        val generator = Exp<Person>() / Person::dogs
+        val generator = Exp<Person>() into Person::dogs
 
         // when
         val actual = generator.generate()
@@ -29,18 +18,7 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNestedField() {
         // given
-        val generator = Exp<Person>() dot Person::dog dot Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.name")
-    }
-
-    @Test
-    fun getExpressionNestedFieldDiv() {
-        // given
-        val generator = Exp<Person>() / Person::dog / Dog::name
+        val generator = Exp<Person>() into Person::dog into Dog::name
 
         // when
         val actual = generator.generate()
@@ -51,7 +29,7 @@ class ExpressionGeneratorTest {
     @Test
     fun getExpressionNestedFieldWithIndex() {
         // given
-        val generator = Exp<Person>() dot Person::dog dot Dog::loves[0]
+        val generator = Exp<Person>() into Person::dog into Dog::loves[0]
 
         // when
         val actual = generator.generate()
@@ -60,20 +38,20 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionNestedFieldWithIndexDiv() {
+    fun getExpressionNestedFieldWithAllIndex() {
         // given
-        val generator = Exp<Person>() / Person::dog / Dog::loves[0]
+        val generator = Exp<Person>() into Person::dog into Dog::loves["*"]
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("dog.loves[0]")
+        then(actual).isEqualTo("dog.loves[*]")
     }
 
     @Test
-    fun getExpressionFieldWithIndex() {
+    fun getExpressionListWithIndexOnce() {
         // given
-        val generator = Exp<Person>() dot Person::dogs[1]
+        val generator = Exp<Person>() into Person::dogs[1]
 
         // when
         val actual = generator.generate()
@@ -82,20 +60,42 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionFieldWithIndexDiv() {
+    fun getExpressionListWithAllIndexOnce() {
         // given
-        val generator = Exp<Person>() / Person::dogs[1]
+        val generator = Exp<Person>() into Person::dogs["*"]
 
         // when
         val actual = generator.generate()
 
-        then(actual).isEqualTo("dogs[1]")
+        then(actual).isEqualTo("dogs[*]")
     }
 
     @Test
-    fun getExpressionNFieldWithAllIndexWithField() {
+    fun getExpressionListWithIndexAndAllIndex() {
         // given
-        val generator = Exp<Person>() dot Person::nestedDogs["*"]["*"] dot Dog::name
+        val generator = Exp<Person>() into Person::nestedDogs[1]["*"]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1][*]")
+    }
+
+    @Test
+    fun getExpressionListWithAllIndexAndIndex() {
+        // given
+        val generator = Exp<Person>() into Person::nestedDogs["*"][2]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][2]")
+    }
+
+    @Test
+    fun getExpressionListWithAllIndexTwiceWithField() {
+        // given
+        val generator = Exp<Person>() into Person::nestedDogs["*"]["*"] into Dog::name
 
         // when
         val actual = generator.generate()
@@ -104,20 +104,9 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionNFieldWithAllIndexWithFieldDiv() {
+    fun getExpressionListWithIndexTwiceWithFieldDiffExpression1() {
         // given
-        val generator = Exp<Person>() / Person::nestedDogs["*"]["*"] / Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*][*].name")
-    }
-
-    @Test
-    fun getExpressionFieldWithIndexWithFieldExpression1() {
-        // given
-        val generator = Exp<Person>() dot Person::nestedDogs[1][2] dot Dog::name
+        val generator = Exp<Person>() into Person::nestedDogs[1][2] into Dog::name
 
         // when
         val actual = generator.generate()
@@ -126,9 +115,9 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionFieldWithIndexWithFieldExpression2() {
+    fun getExpressionListWithIndexTwiceWithFieldDiffExpression2() {
         // given
-        val generator = Exp<Person>() dot Person::nestedDogs get 1 get 2 dot Dog::name
+        val generator = Exp<Person>() into Person::nestedDogs get 1 get 2 into Dog::name
 
         // when
         val actual = generator.generate()
@@ -137,11 +126,11 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionFieldWithIndexWithFieldExpression3() {
+    fun getExpressionListWithIndexTwiceWithFieldDiffExpression3() {
         // given
         val generator = Exp<Person>()
-            .dot(Person::nestedDogs)[1][2]
-            .dot(Dog::name)
+            .into(Person::nestedDogs)[1][2]
+            .into(Dog::name)
 
         // when
         val actual = generator.generate()
@@ -150,16 +139,41 @@ class ExpressionGeneratorTest {
     }
 
     @Test
-    fun getExpressionFieldWithIndexWithFieldExpression4() {
+    fun getExpressionListWithIndexTwiceWithFieldDiffExpression4() {
         // given
         val generator = Exp<Person>()
-            .dot(Person::nestedDogs[1][2])
-            .dot(Dog::name)
+            .into(Person::nestedDogs[1][2])
+            .into(Dog::name)
 
         // when
         val actual = generator.generate()
 
         then(actual).isEqualTo("nestedDogs[1][2].name")
+    }
+
+    @Test
+    fun getExpressionFieldWithIndexThrice() {
+        // given
+        val generator = Exp<Person>()
+            .into(Person::nestedThriceDogs[1][2][2])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedThriceDogs[1][2][2]")
+    }
+
+    @Test
+    fun getExpressionFieldWithIndexThriceWithField() {
+        // given
+        val generator = Exp<Person>()
+            .into(Person::nestedThriceDogs[1][2][2])
+            .into(Dog::name)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedThriceDogs[1][2][2].name")
     }
 
     data class Person(
@@ -167,6 +181,7 @@ class ExpressionGeneratorTest {
         val dog: Dog,
         val dogs: List<Dog>,
         val nestedDogs: List<List<Dog>>,
+        val nestedThriceDogs: List<List<List<Dog>>>,
     )
 
     data class Dog(val name: String, val loves: List<Int>)

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTestSpecs.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorTestSpecs.kt
@@ -1,0 +1,29 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotlin
+
+data class Person(
+    val name: String?,
+    val dog: Dog,
+    val dogs: List<Dog>,
+    val nestedDogs: List<List<Dog>>,
+    val nestedThriceDogs: List<List<List<Dog>>>,
+)
+
+data class Dog(val name: String, val loves: List<Int>)


### PR DESCRIPTION
표현식을 만들어주는 kotlin DSL을 추가합니다.

필드 이름을 변경할 때 IDE의 `Refactor` 기능으로 일괄 수정이 가능해집니다.
필드 명을 유지한채로 변경하면 필드 타입을 변경하면 타입이 맞지 않으므로 IDE에서 에러를 확인할 수 있습니다.
e.g. `List` → `Set`, `List<List>>` → `List`, `Person` →`Dog` 으로 변경하면 에러가 납니다.

필드 접근 방식과 유사한 연산자 `..`와 일반적인 메소드 (`property`, `method`) 를 지원합니다.