### PR TITLE
Apply ExpressionGenerator with legacy FieldNameResolver

### DIFF
--- a/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyJacksonArbitraryGeneratorTest.java
+++ b/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyJacksonArbitraryGeneratorTest.java
@@ -29,6 +29,8 @@ import lombok.Data;
 import lombok.Value;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.generator.BeanArbitraryGenerator;
 import com.navercorp.fixturemonkey.jackson.generator.JacksonArbitraryGenerator;
 
@@ -42,6 +44,23 @@ class FixtureMonkeyJacksonArbitraryGeneratorTest {
 		// when
 		JsonPropertyClass actual = sut.giveMeBuilder(JsonPropertyClass.class)
 			.set("jsonValue", "set")
+			.sample();
+
+		then(actual.value).isEqualTo("set");
+	}
+
+	@Property
+	void giveMeJsonPropertySetWithExpressionGenerator() {
+		// given
+		ExpressionGenerator expressionGenerator = resolver -> {
+			com.navercorp.fixturemonkey.api.property.Property property =
+				PropertyCache.getReadProperty(JsonPropertyClass.class, "value").get();
+			return resolver.resolve(property);
+		};
+
+		// when
+		JsonPropertyClass actual = sut.giveMeBuilder(JsonPropertyClass.class)
+			.set(expressionGenerator, "set")
 			.sample();
 
 		then(actual.value).isEqualTo("set");
@@ -80,6 +99,25 @@ class FixtureMonkeyJacksonArbitraryGeneratorTest {
 			.generator(BeanArbitraryGenerator.INSTANCE)
 			.generator(JacksonArbitraryGenerator.INSTANCE)
 			.set("jsonValue", "set")
+			.sample();
+
+		then(actual.value).isEqualTo("set");
+	}
+
+	@Property
+	void giveMeJsonPropertySetGeneratorToJacksonWithExpressionGenerator() {
+		// given
+		ExpressionGenerator expressionGenerator = resolver -> {
+			com.navercorp.fixturemonkey.api.property.Property property =
+				PropertyCache.getReadProperty(JsonPropertyClass.class, "value").get();
+			return resolver.resolve(property);
+		};
+
+		// when
+		JsonPropertyClass actual = sut.giveMeBuilder(JsonPropertyClass.class)
+			.generator(BeanArbitraryGenerator.INSTANCE)
+			.generator(JacksonArbitraryGenerator.INSTANCE)
+			.set(expressionGenerator, "set")
 			.sample();
 
 		then(actual.value).isEqualTo("set");

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -22,6 +22,7 @@ import static com.navercorp.fixturemonkey.Constants.HEAD_NAME;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.lang.reflect.Field;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +50,7 @@ import net.jqwik.api.Combinators.F4;
 
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
@@ -240,7 +242,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> set(ExpressionGenerator expressionGenerator, @Nullable Object value) {
-		return this.set(expressionGenerator.generate(), value);
+		return this.set(resolveExpression(expressionGenerator), value);
 	}
 
 	public ArbitraryBuilder<T> set(String expression, Object value, long limit) {
@@ -251,7 +253,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> set(ExpressionGenerator expressionGenerator, Object value, long limit) {
-		return this.set(expressionGenerator.generate(), value, limit);
+		return this.set(resolveExpression(expressionGenerator), value, limit);
 	}
 
 	public ArbitraryBuilder<T> set(String expression, @Nullable Arbitrary<?> value) {
@@ -265,7 +267,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> set(ExpressionGenerator expressionGenerator, @Nullable Arbitrary<?> value) {
-		return this.set(expressionGenerator.generate(), value);
+		return this.set(resolveExpression(expressionGenerator), value);
 	}
 
 	public ArbitraryBuilder<T> set(@Nullable Object value) {
@@ -280,7 +282,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> setBuilder(ExpressionGenerator expressionGenerator, ArbitraryBuilder<?> builder) {
-		return this.setBuilder(expressionGenerator.generate(), builder);
+		return this.setBuilder(resolveExpression(expressionGenerator), builder);
 	}
 
 	public ArbitraryBuilder<T> setBuilder(String expression, ArbitraryBuilder<?> builder, long limit) {
@@ -295,7 +297,7 @@ public final class ArbitraryBuilder<T> {
 		ArbitraryBuilder<?> builder,
 		long limit
 	) {
-		return this.setBuilder(expressionGenerator.generate(), builder, limit);
+		return this.setBuilder(resolveExpression(expressionGenerator), builder, limit);
 	}
 
 	public ArbitraryBuilder<T> setNull(String expression) {
@@ -306,7 +308,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> setNull(ExpressionGenerator expressionGenerator) {
-		return this.setNull(expressionGenerator.generate());
+		return this.setNull(resolveExpression(expressionGenerator));
 	}
 
 	public ArbitraryBuilder<T> setNotNull(String expression) {
@@ -317,7 +319,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public ArbitraryBuilder<T> setNotNull(ExpressionGenerator expressionGenerator) {
-		return this.setNotNull(expressionGenerator.generate());
+		return this.setNotNull(resolveExpression(expressionGenerator));
 	}
 
 	public ArbitraryBuilder<T> setPostCondition(Predicate<T> filter) {
@@ -338,7 +340,7 @@ public final class ArbitraryBuilder<T> {
 		Class<U> clazz,
 		Predicate<U> filter
 	) {
-		return this.setPostCondition(expressionGenerator.generate(), clazz, filter);
+		return this.setPostCondition(resolveExpression(expressionGenerator), clazz, filter);
 	}
 
 	public <U> ArbitraryBuilder<T> setPostCondition(
@@ -359,7 +361,7 @@ public final class ArbitraryBuilder<T> {
 		Predicate<U> filter,
 		long limit
 	) {
-		return this.setPostCondition(expressionGenerator.generate(), clazz, filter, limit);
+		return this.setPostCondition(resolveExpression(expressionGenerator), clazz, filter, limit);
 	}
 
 	public ArbitraryBuilder<T> size(String expression, int size) {
@@ -370,7 +372,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public <U> ArbitraryBuilder<T> size(ExpressionGenerator expressionGenerator, int size) {
-		return this.size(expressionGenerator.generate(), size);
+		return this.size(resolveExpression(expressionGenerator), size);
 	}
 
 	public ArbitraryBuilder<T> size(String expression, int min, int max) {
@@ -381,7 +383,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public <U> ArbitraryBuilder<T> size(ExpressionGenerator expressionGenerator, int min, int max) {
-		return this.size(expressionGenerator.generate(), min, max);
+		return this.size(resolveExpression(expressionGenerator), min, max);
 	}
 
 	public ArbitraryBuilder<T> minSize(String expression, int min) {
@@ -394,7 +396,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public <U> ArbitraryBuilder<T> minSize(ExpressionGenerator expressionGenerator, int min) {
-		return this.minSize(expressionGenerator.generate(), min);
+		return this.minSize(resolveExpression(expressionGenerator), min);
 	}
 
 	public ArbitraryBuilder<T> maxSize(String expression, int max) {
@@ -405,7 +407,7 @@ public final class ArbitraryBuilder<T> {
 
 	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 	public <U> ArbitraryBuilder<T> maxSize(ExpressionGenerator expressionGenerator, int max) {
-		return this.maxSize(expressionGenerator.generate(), max);
+		return this.maxSize(resolveExpression(expressionGenerator), max);
 	}
 
 	public ArbitraryBuilder<T> customize(Class<T> type, ArbitraryCustomizer<T> customizer) {
@@ -730,6 +732,22 @@ public final class ArbitraryBuilder<T> {
 			generator = ((WithFixtureCustomizer)generator).withFixtureCustomizers(customizers);
 		}
 		return generator;
+	}
+
+	// Temporary adapter for legacy FieldNameResolver
+	@Deprecated
+	private String resolveExpression(ExpressionGenerator expressionGenerator) {
+		return expressionGenerator.generate(property -> {
+			Class<?> type = property.getType();
+			ArbitraryGenerator generator = this.generatorMap.getOrDefault(type, this.generator);
+			Map<String, Field> fields = PropertyCache.getFields(this.tree.getClazz());
+			Field field = fields.get(property.getName());
+			if (field == null) {
+				return property.getName();
+			}
+
+			return generator.resolveFieldName(field);
+		});
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -740,8 +740,8 @@ public final class ArbitraryBuilder<T> {
 		return expressionGenerator.generate(property -> {
 			Class<?> type = property.getType();
 			ArbitraryGenerator generator = this.generatorMap.getOrDefault(type, this.generator);
-			Map<String, Field> fields = PropertyCache.getFields(this.tree.getClazz());
-			Field field = fields.get(property.getName());
+			Map<String, Field> fieldsByPropertyName = PropertyCache.getFields(this.tree.getClazz());
+			Field field = fieldsByPropertyName.get(property.getName());
 			if (field == null) {
 				return property.getName();
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -76,11 +76,6 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec set(ExpressionGenerator expressionGenerator, @Nullable Object value) {
-		return this.set(expressionGenerator.generate(), value);
-	}
-
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public ExpressionSpec set(String expression, Object value, long limit) {
 		if (value == null) {
@@ -94,11 +89,6 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec set(ExpressionGenerator expressionGenerator, Object value, long limit) {
-		return this.set(expressionGenerator.generate(), value, limit);
-	}
-
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public <T> ExpressionSpec set(String expression, Arbitrary<T> arbitrary) {
 		if (arbitrary == null) {
@@ -107,11 +97,6 @@ public final class ExpressionSpec {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ArbitrarySetArbitrary(fixtureExpression, arbitrary));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec set(ExpressionGenerator expressionGenerator, Arbitrary<T> arbitrary) {
-		return this.set(expressionGenerator.generate(), arbitrary);
 	}
 
 	public <T> ExpressionSpec setBuilder(String expression, @Nullable ArbitraryBuilder<T> builder, long limit) {
@@ -123,15 +108,6 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec setBuilder(
-		ExpressionGenerator expressionGenerator,
-		@Nullable ArbitraryBuilder<T> builder,
-		long limit
-	) {
-		return this.setBuilder(expressionGenerator.generate(), builder, limit);
-	}
-
 	public <T> ExpressionSpec setBuilder(String expression, @Nullable ArbitraryBuilder<T> builder) {
 		if (builder == null) {
 			return this.setNull((String)null);
@@ -139,14 +115,6 @@ public final class ExpressionSpec {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ArbitrarySetArbitrary<>(fixtureExpression, builder.build()));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec setBuilder(
-		ExpressionGenerator expressionGenerator,
-		@Nullable ArbitraryBuilder<T> builder
-	) {
-		return this.setBuilder(expressionGenerator.generate(), builder);
 	}
 
 	public ExpressionSpec set(String expression, ExpressionSpec spec) {
@@ -203,20 +171,10 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec setNull(ExpressionGenerator expressionGenerator) {
-		return this.setNull(expressionGenerator.generate());
-	}
-
 	public ExpressionSpec setNotNull(String expression) {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ArbitraryNullity(fixtureExpression, false));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec setNotNull(ExpressionGenerator expressionGenerator) {
-		return this.setNotNull(expressionGenerator.generate());
 	}
 
 	public ExpressionSpec size(String expression, int size) {
@@ -225,20 +183,10 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec size(ExpressionGenerator expressionGenerator, int size) {
-		return this.size(expressionGenerator.generate(), size);
-	}
-
 	public ExpressionSpec size(String expression, int min, int max) {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ContainerSizeManipulator(fixtureExpression, min, max));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec size(ExpressionGenerator expressionGenerator, int min, int max) {
-		return this.size(expressionGenerator.generate(), min, max);
 	}
 
 	public ExpressionSpec minSize(String expression, int min) {
@@ -247,20 +195,10 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec minSize(ExpressionGenerator expressionGenerator, int min) {
-		return this.minSize(expressionGenerator.generate(), min);
-	}
-
 	public ExpressionSpec maxSize(String expression, int max) {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ContainerSizeManipulator(fixtureExpression, null, max));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec maxSize(ExpressionGenerator expressionGenerator, int max) {
-		return this.maxSize(expressionGenerator.generate(), max);
 	}
 
 	public <T> ExpressionSpec setPostCondition(String expression, Class<T> clazz, Predicate<T> predicate, long count) {
@@ -269,29 +207,10 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec setPostCondition(
-		ExpressionGenerator expressionGenerator,
-		Class<T> clazz,
-		Predicate<T> predicate,
-		long count
-	) {
-		return this.setPostCondition(expressionGenerator.generate(), clazz, predicate, count);
-	}
-
 	public <T> ExpressionSpec setPostCondition(String expression, Class<T> clazz, Predicate<T> predicate) {
 		ArbitraryExpression fixtureExpression = ArbitraryExpression.from(expression);
 		builderManipulators.add(new ArbitrarySetPostCondition<>(clazz, fixtureExpression, predicate));
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec setPostCondition(
-		ExpressionGenerator expressionGenerator,
-		Class<T> clazz,
-		Predicate<T> predicate
-	) {
-		return this.setPostCondition(expressionGenerator.generate(), clazz, predicate);
 	}
 
 	public ExpressionSpec list(String iterableName, Consumer<IterableSpec> iterableSpecSupplier) {
@@ -299,14 +218,6 @@ public final class ExpressionSpec {
 		iterableSpecSupplier.accept(iterableSpec);
 		iterableSpec.visit(this);
 		return this;
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public <T> ExpressionSpec list(
-		ExpressionGenerator expressionGenerator,
-		Consumer<IterableSpec> iterableSpecSupplier
-	) {
-		return this.list(expressionGenerator.generate(), iterableSpecSupplier);
 	}
 
 	public ExpressionSpec copy() {
@@ -364,12 +275,7 @@ public final class ExpressionSpec {
 	}
 
 	public ExpressionSpec exclude(String... excludeExpressions) {
-		return this.exclude(Arrays.stream(excludeExpressions).collect(toList()));
-	}
-
-	@API(since = "0.4.0", status = Status.MAINTAINED)
-	public ExpressionSpec exclude(List<String> excludeExpressions) {
-		List<ArbitraryExpression> excludeArbitraryExpression = excludeExpressions.stream()
+		List<ArbitraryExpression> excludeArbitraryExpression = Arrays.stream(excludeExpressions)
 			.map(ArbitraryExpression::from)
 			.collect(toList());
 
@@ -382,25 +288,11 @@ public final class ExpressionSpec {
 		return this;
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public ExpressionSpec exclude(ExpressionGenerator... excludeExpressionGenerators) {
-		return this.exclude(
-			Arrays.stream(excludeExpressionGenerators)
-				.map(ExpressionGenerator::generate)
-				.collect(toList())
-		);
-	}
-
 	public boolean hasOrderedManipulators(String expression) {
 		return this.builderManipulators.stream()
 			.filter(it -> !(it instanceof PostArbitraryManipulator) && !(it instanceof MetadataManipulator))
 			.map(ArbitraryExpressionManipulator.class::cast)
 			.anyMatch(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)));
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public boolean hasOrderedManipulators(ExpressionGenerator expressionGenerator) {
-		return this.hasOrderedManipulators(expressionGenerator.generate());
 	}
 
 	public boolean hasPostArbitraryManipulators(String expression) {
@@ -410,21 +302,11 @@ public final class ExpressionSpec {
 			.anyMatch(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)));
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public boolean hasPostArbitraryManipulators(ExpressionGenerator expressionGenerator) {
-		return this.hasPostArbitraryManipulators(expressionGenerator.generate());
-	}
-
 	public boolean hasSet(String expression) {
 		return this.builderManipulators.stream()
 			.filter(AbstractArbitrarySet.class::isInstance)
 			.map(AbstractArbitrarySet.class::cast)
 			.anyMatch(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)));
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public boolean hasSet(ExpressionGenerator expressionGenerator) {
-		return this.hasSet(expressionGenerator.generate());
 	}
 
 	public boolean hasPostCondition(String expression) {
@@ -434,21 +316,11 @@ public final class ExpressionSpec {
 			.anyMatch(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)));
 	}
 
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public boolean hasPostCondition(ExpressionGenerator expressionGenerator) {
-		return this.hasPostCondition(expressionGenerator.generate());
-	}
-
 	public boolean hasMetadata(String expression) {
 		return this.builderManipulators.stream()
 			.filter(MetadataManipulator.class::isInstance)
 			.map(MetadataManipulator.class::cast)
 			.anyMatch(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)));
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public boolean hasMetadata(ExpressionGenerator expressionGenerator) {
-		return this.hasMetadata(expressionGenerator.generate());
 	}
 
 	public Optional<Object> findSetValue(String expression) {
@@ -458,11 +330,6 @@ public final class ExpressionSpec {
 			.filter(it -> it.getArbitraryExpression().equals(ArbitraryExpression.from(expression)))
 			.map(AbstractArbitrarySet::getInputValue)
 			.findAny();
-	}
-
-	@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-	public Optional<Object> findSetValue(ExpressionGenerator expressionGenerator) {
-		return this.findSetValue(expressionGenerator.generate());
 	}
 
 	public List<BuilderManipulator> getBuilderManipulators() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ExpressionSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ExpressionSpecTest.java
@@ -68,20 +68,6 @@ class ExpressionSpecTest {
 	}
 
 	@Property
-	void mergeWithExpressionGenerator() {
-		// given
-		ExpressionSpec merger = new ExpressionSpec()
-			.set((resolver) -> "test", "test");
-		ExpressionSpec merged = new ExpressionSpec()
-			.set((resolver) -> "test", "test2");
-
-		// when
-		ExpressionSpec actual = merger.merge(merged);
-
-		then(actual.getBuilderManipulators()).hasSize(2);
-	}
-
-	@Property
 	void mergeNotOverwrite() {
 		// given
 		ExpressionSpec merger = new ExpressionSpec()
@@ -167,19 +153,6 @@ class ExpressionSpecTest {
 	}
 
 	@Property
-	void excludeWithExpressionGenerator() {
-		// given
-		ExpressionSpec actual = new ExpressionSpec()
-			.set("test", "test")
-			.set("test2", "test");
-
-		// when
-		actual.exclude((resolver) -> "test");
-
-		then(actual.getBuilderManipulators()).hasSize(1);
-	}
-
-	@Property
 	void hasPostCondition() {
 		// when
 		ExpressionSpec actual = new ExpressionSpec()
@@ -187,16 +160,6 @@ class ExpressionSpecTest {
 
 		then(actual.hasSet("test")).isFalse();
 		then(actual.hasPostCondition("test")).isTrue();
-	}
-
-	@Property
-	void hasPostConditionWithExpressionGenerator() {
-		// when
-		ExpressionSpec actual = new ExpressionSpec()
-			.setPostCondition((resolver) -> "test", String.class, Objects::nonNull);
-
-		then(actual.hasSet((resolver) -> "test")).isFalse();
-		then(actual.hasPostCondition((resolver) -> "test")).isTrue();
 	}
 
 	@Property
@@ -217,16 +180,6 @@ class ExpressionSpecTest {
 
 		//noinspection OptionalGetWithoutIsPresent
 		then(actual.findSetValue("test").get()).isEqualTo("test");
-	}
-
-	@Property
-	void findSetValueWithExpressionGenerator() {
-		// when
-		ExpressionSpec actual = new ExpressionSpec()
-			.set("test", "test");
-
-		//noinspection OptionalGetWithoutIsPresent
-		then(actual.findSetValue((resolver) -> "test").get()).isEqualTo("test");
 	}
 
 	@Property


### PR DESCRIPTION
현재 구조 기준으로 ExpressionGenerator 를 generate 할 때 타입에 따른 기존의 FieldNameResolver 를 사용해서 속성 적용을 할 수 있도록 어댑팅 합니다.
FiledNameResolver 를 어댑팅해서 ExressionGenerator generate 를 지원하는 기능은 구조 개선 후 제거될 예정입니다.

타입에 따른 적절한 PropertyNameResolver 를 선택할 수 있어야 하기 때문에 ExpressionGenerator 의 generate 실행은 더 안쪽 실행으로 들어가야할 필요가 있습니다. 이에 따른 구조의 변경이 필요합니다.
점진적으로 구조를 개선하도록 하겠습니다.