### PR TITLE
Introduce TypeReference

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
@@ -25,7 +25,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public abstract class TypeReference<T> implements Comparable<TypeReference<T>> {
+public abstract class TypeReference<T> {
 	private final Type type;
 
 	protected TypeReference() {
@@ -45,10 +45,5 @@ public abstract class TypeReference<T> implements Comparable<TypeReference<T>> {
 
 	public Type getType() {
 		return this.type;
-	}
-
-	@Override
-	public int compareTo(TypeReference<T> obj) {
-		return 0;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
@@ -48,7 +48,7 @@ public abstract class TypeReference<T> implements Comparable<TypeReference<T>> {
 	}
 
 	@Override
-	public int compareTo(TypeReference<T> o) {
+	public int compareTo(TypeReference<T> obj) {
 		return 0;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeReference.java
@@ -1,0 +1,54 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.type;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public abstract class TypeReference<T> implements Comparable<TypeReference<T>> {
+	private final Type type;
+
+	protected TypeReference() {
+		Type superClass = getClass().getGenericSuperclass();
+		if (superClass instanceof Class<?>) {
+			throw new IllegalArgumentException(
+				"Internal error: TypeReference constructed without actual type information"
+			);
+		}
+
+		this.type = ((ParameterizedType)superClass).getActualTypeArguments()[0];
+	}
+
+	protected TypeReference(Class<T> type) {
+		this.type = type;
+	}
+
+	public Type getType() {
+		return this.type;
+	}
+
+	@Override
+	public int compareTo(TypeReference<T> o) {
+		return 0;
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypeReferenceTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypeReferenceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.type;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import java.util.Map;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.junit.jupiter.api.Test;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+class TypeReferenceTest {
+
+	@Test
+	void construct() {
+		TypeReference<String> actual = new TypeReference<String>() {
+		};
+		then(actual.getType()).isEqualTo(String.class);
+	}
+
+	@Test
+	void constructClassType() {
+		TypeReference<String> actual = new TypeReference<String>(String.class) {
+		};
+		then(actual.getType()).isEqualTo(String.class);
+	}
+
+	@Test
+	void constructListGenerics() {
+		TypeReference<List<String>> actual = new TypeReference<List<String>>() {
+		};
+
+		then(actual.getType()).isInstanceOf(ParameterizedType.class);
+
+		ParameterizedType parameterizedType = (ParameterizedType)actual.getType();
+		then(parameterizedType.getRawType()).isEqualTo(List.class);
+		then(parameterizedType.getActualTypeArguments()[0]).isEqualTo(String.class);
+	}
+
+	@Test
+	void constructMap() {
+		TypeReference<Map<Integer, String>> actual = new TypeReference<Map<Integer, String>>() {
+		};
+
+		then(actual.getType()).isInstanceOf(ParameterizedType.class);
+
+		ParameterizedType parameterizedType = (ParameterizedType)actual.getType();
+		then(parameterizedType.getRawType()).isEqualTo(Map.class);
+		then(parameterizedType.getActualTypeArguments()[0]).isEqualTo(Integer.class);
+		then(parameterizedType.getActualTypeArguments()[1]).isEqualTo(String.class);
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypeReferenceTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypeReferenceTest.java
@@ -24,11 +24,8 @@ import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.junit.jupiter.api.Test;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 class TypeReferenceTest {
 
 	@Test


### PR DESCRIPTION
Generics 를 지원하기 위한 TypeReference 를 추가합니다.
Property 등을 재 구성 하는 과정에 TypeReference 지원이 같이 고려되어야 이후에 breaking 을 최소화할 수 있을거 같아 현시점에서 같이 반영합니다.