### PR TITLE
Rename TypeMatcher to Matcher

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospectDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospectDelegator.java
@@ -16,15 +16,31 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.api.matcher;
+package com.navercorp.fixturemonkey.api.introspector;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-@FunctionalInterface
-public interface TypeMatcher {
-	boolean match(ArbitraryGeneratorContext context);
+public class ArbitraryTypeIntrospectDelegator implements ArbitraryTypeIntrospector, Matcher {
+	private final Matcher matcher;
+	private final ArbitraryTypeIntrospector delegate;
+
+	public ArbitraryTypeIntrospectDelegator(Matcher matcher, ArbitraryTypeIntrospector delegate) {
+		this.matcher = matcher;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public boolean match(ArbitraryGeneratorContext context) {
+		return this.matcher.match(context);
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		return this.delegate.introspect(context);
+	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/CompositeArbitraryTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/CompositeArbitraryTypeIntrospector.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.matcher.TypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public class CompositeArbitraryTypeIntrospector implements ArbitraryTypeIntrospector {
@@ -37,8 +37,8 @@ public class CompositeArbitraryTypeIntrospector implements ArbitraryTypeIntrospe
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		for (ArbitraryTypeIntrospector introspector : this.introspectors) {
-			if (introspector instanceof TypeMatcher) {
-				if (((TypeMatcher)introspector).match(context)) {
+			if (introspector instanceof Matcher) {
+				if (((Matcher)introspector).match(context)) {
 					ArbitraryIntrospectorResult result = introspector.introspect(context);
 					if (!ArbitraryIntrospectorResult.EMPTY.equals(result)) {
 						return result;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumTypeIntrospector.java
@@ -24,10 +24,10 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.matcher.TypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class EnumTypeIntrospector implements ArbitraryTypeIntrospector, TypeMatcher {
+public final class EnumTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
 	@Override
 	public boolean match(ArbitraryGeneratorContext context) {
 		return context.getType().isEnum();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/UuidTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/UuidTypeIntrospector.java
@@ -27,15 +27,15 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
-import com.navercorp.fixturemonkey.api.matcher.TypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class UuidTypeIntrospector implements ArbitraryTypeIntrospector, TypeMatcher {
-	private static final TypeMatcher TYPE_MATCHER = new ExactTypeMatcher(UUID.class);
+public final class UuidTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
+	private static final Matcher MATCHER = new ExactTypeMatcher(UUID.class);
 
 	@Override
 	public boolean match(ArbitraryGeneratorContext context) {
-		return TYPE_MATCHER.match(context);
+		return MATCHER.match(context);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/ExactTypeMatcher.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/ExactTypeMatcher.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class ExactTypeMatcher implements TypeMatcher {
+public final class ExactTypeMatcher implements Matcher {
 	private final Class<?> type;
 
 	public ExactTypeMatcher(Class<?> type) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matcher.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matcher.java
@@ -16,27 +16,15 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.api.introspector;
+package com.navercorp.fixturemonkey.api.matcher;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitraries;
-
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.matcher.Matcher;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class BooleanTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
-
-	@Override
-	public boolean match(ArbitraryGeneratorContext context) {
-		Class<?> type = context.getType();
-		return type == boolean.class || type == Boolean.class;
-	}
-
-	@Override
-	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		return new ArbitraryIntrospectorResult(Arbitraries.of(true, false));
-	}
+@FunctionalInterface
+public interface Matcher {
+	boolean match(ArbitraryGeneratorContext context);
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResultTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResultTest.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.api.introspector;
 
 import static org.assertj.core.api.BDDAssertions.then;

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospectDelegatorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryTypeIntrospectDelegatorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryTypeIntrospectorTest.Sample;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
+
+class ArbitraryTypeIntrospectDelegatorTest {
+	@Test
+	void matchAndIntrospectEmpty() {
+		ArbitraryTypeIntrospectDelegator sut = new ArbitraryTypeIntrospectDelegator(
+			ctx -> true,
+			ctx -> ArbitraryIntrospectorResult.EMPTY
+		);
+
+		Property property = PropertyCache.getReadProperty(Sample.class, "season").get();
+		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
+			new ArbitraryProperty(property, "", null, false, 0.0D),
+			Collections.emptyList()
+		);
+
+		then(sut.match(context)).isTrue();
+		then(sut.introspect(context)).isEqualTo(ArbitraryIntrospectorResult.EMPTY);
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
@@ -29,11 +29,11 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 
-class ExactTypeMatcherTest {
+class ExactMatcherTest {
 	@Test
 	void match() {
 		// given
-		TypeMatcher sut = new ExactTypeMatcher(String.class);
+		Matcher sut = new ExactTypeMatcher(String.class);
 
 		String propertyName = "str";
 		Property property = PropertyCache.getReadProperty(TypeMatcherSpec.class, propertyName).get();
@@ -51,7 +51,7 @@ class ExactTypeMatcherTest {
 	@Test
 	void matchInheritedFalse() {
 		// given
-		TypeMatcher sut = new ExactTypeMatcher(TypeMatcherSpec.class);
+		Matcher sut = new ExactTypeMatcher(TypeMatcherSpec.class);
 
 		String propertyName = "inherited";
 		Property property = PropertyCache.getReadProperty(TypeMatcherSpec.class, propertyName).get();


### PR DESCRIPTION
Type 외에 다른 요소로도 Matching 을 판단할 수 있기 때문에
TypeMatcher 를 Matcher 로 이름 변경합니다.