### PR TITLE
Introduce Types utils for generics

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
@@ -1,0 +1,36 @@
+package com.navercorp.fixturemonkey.api.type;
+
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+public class Types {
+	public static Class<?> getActualType(Type type) {
+		if (type.getClass() == Class.class) {
+			return (Class<?>)type;
+		}
+
+		if (TypeVariable.class.isAssignableFrom(type.getClass())) {
+			GenericDeclaration genericDeclaration = ((TypeVariable<?>)type).getGenericDeclaration();
+			if (genericDeclaration.getClass() == Class.class) {
+				return (Class<?>)genericDeclaration;
+			} else {
+				// Method? Constructor?
+				throw new UnsupportedOperationException(
+					"Unsupported TypeVariable's generationDeclaration type. type: " + genericDeclaration.getClass()
+				);
+			}
+		}
+
+		if (ParameterizedType.class.isAssignableFrom(type.getClass())) {
+			ParameterizedType parameterizedType = (ParameterizedType)type;
+			Type rawType = parameterizedType.getRawType();
+			return getActualType(rawType);
+		}
+
+		throw new UnsupportedOperationException(
+			"Unsupported Type to get actualType. type: " + type.getClass()
+		);
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypesTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypesTest.java
@@ -1,0 +1,76 @@
+package com.navercorp.fixturemonkey.api.type;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.lang.reflect.Type;
+
+import org.junit.jupiter.api.Test;
+
+class TypesTest {
+
+	@Test
+	void getActualType() {
+		// given
+		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
+		};
+		Type type = typeReference.getType();
+
+		// when
+		Class<?> actual = Types.getActualType(type);
+
+		then(actual).isEqualTo(Sample.class);
+	}
+
+	@Test
+	void getActualTypeForGenerics() {
+		// given
+		TypeReference<GenericSample<String>> typeReference = new TypeReference<GenericSample<String>>() {
+		};
+		Type type = typeReference.getType();
+
+		// when
+		Class<?> actual = Types.getActualType(type);
+
+		then(actual).isEqualTo(GenericSample.class);
+	}
+
+	@Test
+	void getActualTypeForWildCardGenerics() {
+		// given
+		TypeReference<GenericSample<?>> typeReference = new TypeReference<GenericSample<?>>() {
+		};
+		Type type = typeReference.getType();
+
+		// when
+		Class<?> actual = Types.getActualType(type);
+
+		then(actual).isEqualTo(GenericSample.class);
+	}
+
+	@Test
+	void getActualTypeForExceptGenerics() {
+		// given
+		TypeReference<GenericSample> typeReference = new TypeReference<GenericSample>() {
+		};
+		Type type = typeReference.getType();
+
+		// when
+		Class<?> actual = Types.getActualType(type);
+
+		then(actual).isEqualTo(GenericSample.class);
+	}
+
+	static class Sample {
+		private String name;
+	}
+
+	static class GenericSample<T> {
+		private GenericSample2<T> sample2;
+		private T name;
+		private Sample test;
+	}
+
+	static class GenericSample2<T> {
+		private T name;
+	}
+}


### PR DESCRIPTION
TypeReference 를 통한 Type 으로 Generics 를 식별하기 위한 유틸을 추가합니다.
우선 Type 에서 Class 를 도출하는 Util 메소드만 추가했으며 이 PR 이후 Generics 등을 판단하는 유틸 메소드들을 추가할 예정입니다.