### PR TITLE
Extract type for Matchers implements

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BooleanTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BooleanTypeIntrospector.java
@@ -18,8 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.introspector;
 
-import java.lang.reflect.Type;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -27,14 +25,14 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.matcher.Matchers;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class BooleanTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
 
 	@Override
 	public boolean match(ArbitraryGeneratorContext context) {
-		Type type = context.getType();
-		return type == boolean.class || type == Boolean.class;
+		return Matchers.BOOLEAN_TYPE_MATCHER.match(context);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumTypeIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumTypeIntrospector.java
@@ -27,13 +27,13 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
-import com.navercorp.fixturemonkey.api.type.Types;
+import com.navercorp.fixturemonkey.api.matcher.Matchers;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class EnumTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
 	@Override
 	public boolean match(ArbitraryGeneratorContext context) {
-		return Types.getActualType(context.getType()).isEnum();
+		return Matchers.ENUM_TYPE_MATCHER.match(context);
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matchers.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matchers.java
@@ -16,28 +16,23 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.api.introspector;
+package com.navercorp.fixturemonkey.api.matcher;
 
+import java.lang.reflect.Type;
 import java.util.UUID;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitraries;
-
-import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.matcher.Matcher;
-import com.navercorp.fixturemonkey.api.matcher.Matchers;
+import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class UuidTypeIntrospector implements ArbitraryTypeIntrospector, Matcher {
-	@Override
-	public boolean match(ArbitraryGeneratorContext context) {
-		return Matchers.UUID_TYPE_MATCHER.match(context);
-	}
+public class Matchers {
 
-	@Override
-	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		return new ArbitraryIntrospectorResult(Arbitraries.create(UUID::randomUUID));
-	}
+	public static final Matcher ENUM_TYPE_MATCHER = ctx -> Types.getActualType(ctx.getType()).isEnum();
+	public static final Matcher BOOLEAN_TYPE_MATCHER = ctx -> {
+		Type type = ctx.getType();
+		return type == boolean.class || type == Boolean.class;
+	};
+	public static final Matcher UUID_TYPE_MATCHER = new ExactTypeMatcher(UUID.class);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matchers.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/Matchers.java
@@ -27,7 +27,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public class Matchers {
+public final class Matchers {
 
 	public static final Matcher ENUM_TYPE_MATCHER = ctx -> Types.getActualType(ctx.getType()).isEnum();
 	public static final Matcher BOOLEAN_TYPE_MATCHER = ctx -> {


### PR DESCRIPTION
조립할 수 있는 형태로 지원하기 위해 Matcher 구현을 분리합니다.