### PR TITLE
Fix resolveExpression working in nested fields

### DIFF
--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/generator/JacksonArbitraryGenerator.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/generator/JacksonArbitraryGenerator.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryType;
@@ -139,6 +140,11 @@ public final class JacksonArbitraryGenerator extends AbstractArbitraryGenerator 
 	@Override
 	public String resolveFieldName(Field field) {
 		return this.propertyNameResolver.resolve(new FieldProperty(field));
+	}
+
+	@Override
+	public String resolvePropertyName(Property property) {
+		return propertyNameResolver.resolve(property);
 	}
 }
 

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -181,7 +181,7 @@ private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) :
 
     override fun getType(): Class<*> = type
 
-    override fun getAnnotatedType(): AnnotatedType = property?.javaField?.annotatedType ?: javaField?.annotatedType!!
+    override fun getAnnotatedType(): AnnotatedType? = property?.javaField?.annotatedType ?: javaField?.annotatedType
 
     override fun getName(): String = propertyName
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -727,13 +727,7 @@ public final class ArbitraryBuilder<T> {
 		return expressionGenerator.generate(property -> {
 			Class<?> type = Types.getActualType(property.getType());
 			ArbitraryGenerator generator = this.generatorMap.getOrDefault(type, this.generator);
-			Map<String, Field> fieldsByPropertyName = PropertyCache.getFields(type);
-			Field field = fieldsByPropertyName.get(property.getName());
-			if (field == null) {
-				return property.getName();
-			}
-
-			return generator.resolveFieldName(field);
+			return generator.resolvePropertyName(property);
 		});
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -727,7 +727,7 @@ public final class ArbitraryBuilder<T> {
 		return expressionGenerator.generate(property -> {
 			Class<?> type = Types.getActualType(property.getType());
 			ArbitraryGenerator generator = this.generatorMap.getOrDefault(type, this.generator);
-			Map<String, Field> fieldsByPropertyName = PropertyCache.getFields(this.tree.getClazz());
+			Map<String, Field> fieldsByPropertyName = PropertyCache.getFields(type);
 			Field field = fieldsByPropertyName.get(property.getName());
 			if (field == null) {
 				return property.getName();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -22,7 +22,6 @@ import static com.navercorp.fixturemonkey.Constants.HEAD_NAME;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
-import java.lang.reflect.Field;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +49,6 @@ import net.jqwik.api.Combinators.F4;
 
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
-import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import com.navercorp.fixturemonkey.api.type.Types;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArbitraryGenerator.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 import net.jqwik.api.Arbitrary;
 
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryType;
 
@@ -37,5 +39,9 @@ public interface ArbitraryGenerator extends FieldNameResolver {
 	@Deprecated
 	default String resolveFieldName(Field field) {
 		return field.getName();
+	}
+
+	default String resolvePropertyName(Property property) {
+		return property.getName();
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/ArbitraryGenerator.java
@@ -24,7 +24,6 @@ import java.util.List;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryType;
 


### PR DESCRIPTION
`fieldsByPropertyName` 에서 생성하고자 하는 타입 (최상위 객체)의 필드만 조회하여 자식 객체의 필드명을 표현식으로 변경할 때 `@JsonProperty`가 적용되지 않는 문제를 해결합니다.