### PR TITLE
Refactor improving usability type-safe expression generate DSL

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -18,11 +18,13 @@
 
 package com.navercorp.fixturemonkey.kotlin
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
 import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Field
+import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
@@ -66,10 +68,93 @@ class Exp<T> internal constructor(private val delegate: ExpressionGenerator) : E
     )
 }
 
-infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): ExpList<T, E> =
+fun <T> Exp(exp: Exp<T>) = Exp<T>(ParsedExpressionGenerator(listOf(exp)))
+
+fun <T, R> Exp(expList: ExpList<T, R>) = Exp<T>(ParsedExpressionGenerator(listOf(expList)))
+
+fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<T>(
+    ParsedExpressionGenerator(
+        listOf(
+            PropertyExpressionGenerator(
+                KotlinProperty(property)
+            )
+        )
+    )
+)
+
+fun <T, R> Exp(property: KFunction1<T, R?>) = Exp<T>(
+    ParsedExpressionGenerator(
+        listOf(
+            PropertyExpressionGenerator(
+                KotlinGetterProperty(property)
+            )
+        )
+    )
+)
+
+@JvmName("getterBoolean")
+fun Exp(property: KFunction1<*, Boolean>) = Exp<Boolean>(
+    ParsedExpressionGenerator(
+        listOf(
+            PropertyExpressionGenerator(
+                KotlinGetterProperty(property)
+            )
+        )
+    )
+)
+
+fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, *>, value: Any): ArbitraryBuilder<T> =
+    this.set(ParsedExpressionGenerator(listOf(PropertyExpressionGenerator(KotlinProperty(property)))), value)
+
+fun <T> ArbitraryBuilder<T>.set(property: KFunction1<T, *>, value: Any): ArbitraryBuilder<T> =
+    this.set(ParsedExpressionGenerator(listOf(PropertyExpressionGenerator(KotlinGetterProperty(property)))), value)
+
+infix fun <T, R, E> KProperty1<T, R?>.into(property: KProperty1<R, E?>): Exp<E> =
+    Exp(
+        ParsedExpressionGenerator(
+            listOf(
+                PropertyExpressionGenerator(KotlinProperty(this)),
+                PropertyExpressionGenerator(KotlinProperty(property))
+            )
+        )
+    )
+
+infix fun <T, R, E> KProperty1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
+    Exp(
+        ParsedExpressionGenerator(
+            listOf(
+                PropertyExpressionGenerator(KotlinProperty(this)),
+                expList
+            )
+        )
+    )
+
+infix fun <T, R, E> KFunction1<T, R?>.into(property: KFunction1<R, E?>): Exp<E> =
+    Exp(
+        ParsedExpressionGenerator(
+            listOf(
+                PropertyExpressionGenerator(KotlinGetterProperty(this)),
+                PropertyExpressionGenerator(KotlinGetterProperty(property))
+            )
+        )
+    )
+
+infix fun <T, R, E> KFunction1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
+    Exp(
+        ParsedExpressionGenerator(
+            listOf(
+                PropertyExpressionGenerator(KotlinGetterProperty(this)),
+                expList
+            )
+        )
+    )
+
+infix operator
+fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): ExpList<T, E> =
     ExpList(ArrayExpressionGenerator(KotlinProperty(this), index))
 
-infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, E> =
+infix operator
+fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, E> =
     ExpList(MapExpressionGenerator(KotlinProperty(this), key))
 
 @JvmName("getNestedList")
@@ -80,10 +165,12 @@ infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1
 infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, N?> =
     ExpList(MapExpressionGenerator(KotlinProperty(this), key))
 
-infix operator fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(index: Int): ExpList<T, E> =
+infix operator
+fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(index: Int): ExpList<T, E> =
     ExpList(ArrayExpressionGenerator(KotlinGetterProperty(this), index))
 
-infix operator fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(key: String): ExpList<T, E> =
+infix operator
+fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(key: String): ExpList<T, E> =
     ExpList(MapExpressionGenerator(KotlinGetterProperty(this), key))
 
 @JvmName("getNestedList")
@@ -95,7 +182,27 @@ infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KFunction1
     ExpList(MapExpressionGenerator(KotlinGetterProperty(this), key))
 
 @Suppress("unused")
-class ExpList<E, L> internal constructor(val delegate: ExpressionGenerator) : ExpressionGenerator by delegate
+class ExpList<E, L> internal constructor(val delegate: ExpressionGenerator) : ExpressionGenerator by delegate {
+    infix fun <R> into(property: KProperty1<L, R?>): Exp<R> =
+        Exp(
+            ParsedExpressionGenerator(
+                listOf(
+                    this,
+                    PropertyExpressionGenerator(KotlinProperty(property))
+                )
+            )
+        )
+
+    infix fun <R> into(property: KFunction1<L, R?>): Exp<R> =
+        Exp(
+            ParsedExpressionGenerator(
+                listOf(
+                    this,
+                    PropertyExpressionGenerator(KotlinGetterProperty(property))
+                )
+            )
+        )
+}
 
 infix operator fun <T, R : Collection<E>, E : Any> ExpList<T, R?>.get(index: Int): ExpList<T, E> =
     ExpList(ParsedExpressionGenerator(listOf(delegate, IndexExpressionGenerator(index))))
@@ -128,12 +235,14 @@ private class IndexExpressionGenerator(val index: Int) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String = "[$index]"
 }
 
-private class ArrayExpressionGenerator(private val property: Property, val index: Int) : ExpressionGenerator {
+private class ArrayExpressionGenerator(private val property: Property, val index: Int) :
+    ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         ".${propertyNameResolver.resolve(property)}[$index]"
 }
 
-private class MapExpressionGenerator(private val property: Property, val key: String) : ExpressionGenerator {
+private class MapExpressionGenerator(private val property: Property, val key: String) :
+    ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         ".${propertyNameResolver.resolve(property)}[$key]"
 }
@@ -161,9 +270,15 @@ private class KotlinProperty<V, R>(private val property: KProperty1<V, R>) : Pro
 
 private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) : Property {
     private val callerType = getter.parameters[0].type.javaType as Class<*>
-    private val type: Class<*> = getter.returnType.javaType as Class<*>
+    private val returnJavaType = getter.returnType.javaType
+    private val type: Class<*> = if (returnJavaType is ParameterizedType) {
+        returnJavaType.rawType as Class<*>
+    } else {
+        returnJavaType as Class<*>
+    }
     private val propertyName: String =
-        getter.name.substringAfter("get", getter.name.substringAfter("is")).replaceFirstChar { it.lowercaseChar() }
+        getter.name.substringAfter("get", getter.name.substringAfter("is"))
+            .replaceFirstChar { it.lowercaseChar() }
 
     private val property: KProperty<*>? = try {
         callerType.getDeclaredField(name).kotlinProperty
@@ -181,7 +296,8 @@ private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) :
 
     override fun getType(): Class<*> = type
 
-    override fun getAnnotatedType(): AnnotatedType? = property?.javaField?.annotatedType ?: javaField?.annotatedType
+    override fun getAnnotatedType(): AnnotatedType? =
+        property?.javaField?.annotatedType ?: javaField?.annotatedType
 
     override fun getName(): String = propertyName
 

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -70,9 +70,9 @@ class Exp<T> internal constructor(private val delegate: ExpressionGenerator) : E
 
 fun <T> Exp(exp: Exp<T>) = Exp<T>(ParsedExpressionGenerator(listOf(exp)))
 
-fun <T, R> Exp(expList: ExpList<T, R>) = Exp<T>(ParsedExpressionGenerator(listOf(expList)))
+fun <T, R> Exp(expList: ExpList<T, R>) = Exp<R>(ParsedExpressionGenerator(listOf(expList)))
 
-fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<T>(
+fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<R>(
     ParsedExpressionGenerator(
         listOf(
             PropertyExpressionGenerator(
@@ -82,7 +82,7 @@ fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<T>(
     )
 )
 
-fun <T, R> Exp(property: KFunction1<T, R?>) = Exp<T>(
+fun <T, R> Exp(property: KFunction1<T, R?>) = Exp<R>(
     ParsedExpressionGenerator(
         listOf(
             PropertyExpressionGenerator(

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
@@ -36,9 +36,42 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::dog)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog")
+    }
+
+    @Test
     fun getPropertyExpressionNestedField() {
         // given
         val generator = Exp<Person>() into Person::dog into Dog::name
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::dog into Dog::name)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedFieldWithoutExp() {
+        // given
+        val generator = Person::dog into Dog::name
 
         // when
         val actual = generator.generate()
@@ -58,9 +91,53 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionNestedFieldWithIndexWithConstructor() {
+        // given
+        val generator = Exp<Person>(Person::dog into Dog::loves[0])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[0]")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedFieldWithIndexWithoutExp() {
+        // given
+        val generator = Person::dog into Dog::loves[0]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[0]")
+    }
+
+    @Test
     fun getPropertyExpressionNestedFieldWithAllIndex() {
         // given
         val generator = Exp<Person>() into Person::dog into Dog::loves["*"]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[*]")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedFieldWithAllIndexWithConstructor() {
+        // given
+        val generator = Exp(Person::dog into Dog::loves["*"])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[*]")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedFieldWithAllIndexWithoutExp() {
+        // given
+        val generator = Person::dog into Dog::loves["*"]
 
         // when
         val actual = generator.generate()
@@ -80,9 +157,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionListWithIndexOnceWithConstructor() {
+        // given
+        val generator = Exp(Person::dogs[1])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[1]")
+    }
+
+    @Test
     fun getPropertyExpressionListWithAllIndexOnce() {
         // given
         val generator = Exp<Person>() into Person::dogs["*"]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs[*]")
+    }
+
+    @Test
+    fun getPropertyExpressionListWithAllIndexOnceWithConstructor() {
+        // given
+        val generator = Exp(Person::dogs["*"])
 
         // when
         val actual = generator.generate()
@@ -102,9 +201,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionNestedListWithIndexWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedDogs[1])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1]")
+    }
+
+    @Test
     fun getPropertyExpressionNestedListWithAllIndex() {
         // given
         val generator = Exp<Person>() into Person::nestedDogs["*"]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*]")
+    }
+
+    @Test
+    fun getPropertyExpressionNestedListWithAllIndexWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedDogs["*"])
 
         // when
         val actual = generator.generate()
@@ -124,6 +245,17 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionListWithIndexAndAllIndexWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedDogs[1]["*"])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[1][*]")
+    }
+
+    @Test
     fun getPropertyExpressionListWithAllIndexAndIndex() {
         // given
         val generator = Exp<Person>() into Person::nestedDogs["*"][2]
@@ -135,9 +267,42 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionListWithAllIndexAndIndexWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedDogs["*"][2])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][2]")
+    }
+
+    @Test
     fun getPropertyExpressionListWithAllIndexTwiceWithField() {
         // given
         val generator = Exp<Person>() into Person::nestedDogs["*"]["*"] into Dog::name
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][*].name")
+    }
+
+    @Test
+    fun getPropertyExpressionListWithAllIndexTwiceWithFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedDogs["*"]["*"] into Dog::name)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedDogs[*][*].name")
+    }
+
+    @Test
+    fun getPropertyExpressionListWithAllIndexTwiceWithFieldWithoutExp() {
+        // given
+        val generator = Person::nestedDogs["*"]["*"] into Dog::name
 
         // when
         val actual = generator.generate()
@@ -206,11 +371,33 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getPropertyExpressionFieldWithIndexThriceWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedThriceDogs[1][2][2])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedThriceDogs[1][2][2]")
+    }
+
+    @Test
     fun getPropertyExpressionFieldWithIndexThriceWithField() {
         // given
         val generator = Exp<Person>()
             .into(Person::nestedThriceDogs[1][2][2])
             .into(Dog::name)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nestedThriceDogs[1][2][2].name")
+    }
+
+    @Test
+    fun getPropertyExpressionFieldWithIndexThriceWithFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::nestedThriceDogs[1][2][2] into Dog::name)
 
         // when
         val actual = generator.generate()
@@ -231,9 +418,42 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getGetterExpressionFieldWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getDogs)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dogs")
+    }
+
+    @Test
     fun getGetterExpressionNestedField() {
         // given
         val generator = Exp<PersonJava>() into PersonJava::getDog into DogJava::getName
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getGetterExpressionNestedFieldWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getDog into DogJava::getName)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.name")
+    }
+
+    @Test
+    fun getGetterExpressionNestedFieldWithoutExp() {
+        // given
+        val generator = PersonJava::getDog into DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -253,9 +473,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getGetterExpressionNestedFieldWithIndexWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getDog into DogJava::getLoves[0])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[0]")
+    }
+
+    @Test
     fun getGetterExpressionNestedFieldWithAllIndex() {
         // given
         val generator = Exp<PersonJava>() into PersonJava::getDog into DogJava::getLoves["*"]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("dog.loves[*]")
+    }
+
+    @Test
+    fun getGetterExpressionNestedFieldWithAllIndexWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getDog into DogJava::getLoves["*"])
 
         // when
         val actual = generator.generate()
@@ -436,9 +678,42 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getterNullableFieldWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getNullableDog into DogJava::getName)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDog.name")
+    }
+
+    @Test
+    fun getterNullableFieldWithoutExp() {
+        // given
+        val generator = PersonJava::getNullableDog into DogJava::getName
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDog.name")
+    }
+
+    @Test
     fun getterNullableNestedField() {
         // given
         val generator = Exp<PersonJava>() into PersonJava::getNullableDog into DogJava::getNullableName
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDog.nullableName")
+    }
+
+    @Test
+    fun getterNullableNestedFieldWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getNullableDog into DogJava::getNullableName)
 
         // when
         val actual = generator.generate()
@@ -458,9 +733,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getterNullableListWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getNullableDogs[0])
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDogs[0]")
+    }
+
+    @Test
     fun propertyNullableField() {
         // given
         val generator = Exp<Person>() into Person::nullableDog into Dog::name
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDog.name")
+    }
+
+    @Test
+    fun propertyNullableFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::nullableDog into Dog::name)
 
         // when
         val actual = generator.generate()
@@ -480,9 +777,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun propertyNullableNestedFieldWithConstructor() {
+        // given
+        val generator = Exp(Person::nullableDog into Dog::nullableName)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDog.nullableName")
+    }
+
+    @Test
     fun propertyNullableList() {
         // given
         val generator = Exp<Person>() into Person::nullableDogs[0]
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("nullableDogs[0]")
+    }
+
+    @Test
+    fun propertyNullableListWithConstructor() {
+        // given
+        val generator = Exp(Person::nullableDogs[0])
 
         // when
         val actual = generator.generate()
@@ -502,9 +821,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun propertyBooleanWithConstructor() {
+        // given
+        val generator = Exp(Person::married)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("married")
+    }
+
+    @Test
     fun propertyNullableBoolean() {
         // given
         val generator = Exp<Person>() into Person::happy
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("happy")
+    }
+
+    @Test
+    fun propertyNullableBooleanWithConstructor() {
+        // given
+        val generator = Exp(Person::happy)
 
         // when
         val actual = generator.generate()
@@ -524,9 +865,31 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
+    fun getterBooleanWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::isMarried)
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("married")
+    }
+
+    @Test
     fun getterNullableBoolean() {
         // given
         val generator = Exp<PersonJava>() into PersonJava::getHappy
+
+        // when
+        val actual = generator.generate()
+
+        then(actual).isEqualTo("happy")
+    }
+
+    @Test
+    fun getterNullableBooleanWithConstructor() {
+        // given
+        val generator = Exp(PersonJava::getHappy)
 
         // when
         val actual = generator.generate()

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensionsTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensionsTest.kt
@@ -48,7 +48,10 @@ class FixtureMonkeyExtensionsTest {
         // when
         val actual = sut.giveMe(
             object : KArbitraryCustomizer<IntegerStringWrapperClass> {
-                override fun customizeFields(type: KClass<IntegerStringWrapperClass>, fieldArbitraries: FieldArbitraries) {
+                override fun customizeFields(
+                    type: KClass<IntegerStringWrapperClass>,
+                    fieldArbitraries: FieldArbitraries,
+                ) {
                     fieldArbitraries.apply {
                         replaceArbitrary("intValue", Arbitraries.just(-1))
                     }
@@ -101,7 +104,10 @@ class FixtureMonkeyExtensionsTest {
         val actual = sut.giveMe(
             10,
             object : KArbitraryCustomizer<IntegerStringWrapperClass> {
-                override fun customizeFields(type: KClass<IntegerStringWrapperClass>, fieldArbitraries: FieldArbitraries) {
+                override fun customizeFields(
+                    type: KClass<IntegerStringWrapperClass>,
+                    fieldArbitraries: FieldArbitraries,
+                ) {
                     fieldArbitraries.apply {
                         replaceArbitrary("intValue", Arbitraries.just(-1))
                     }
@@ -151,7 +157,10 @@ class FixtureMonkeyExtensionsTest {
         // when
         val actual = sut.giveMeOne(
             object : KArbitraryCustomizer<IntegerStringWrapperClass> {
-                override fun customizeFields(type: KClass<IntegerStringWrapperClass>, fieldArbitraries: FieldArbitraries) {
+                override fun customizeFields(
+                    type: KClass<IntegerStringWrapperClass>,
+                    fieldArbitraries: FieldArbitraries,
+                ) {
                     fieldArbitraries.apply {
                         replaceArbitrary("intValue", Arbitraries.just(-1))
                     }
@@ -212,6 +221,15 @@ class FixtureMonkeyExtensionsTest {
         val actual = sut.giveMeBuilder(value)
 
         then(actual).isNotNull
+    }
+
+    @Property
+    fun giveMeBuilderSetWithProperty() {
+        val actual = sut.giveMeBuilder<IntegerStringWrapperClass>()
+            .set(IntegerStringWrapperClass::intValue, 1)
+            .sample()
+
+        then(actual.intValue).isEqualTo(1)
     }
 
     data class IntegerStringWrapperClass(


### PR DESCRIPTION
다음과 같은 표현식을 지원합니다.
1. `set(Exp(Dog::getName), "name")`
2. `set(Dog::getName, "name")`
3. `set(Exp<Dog>() into Dog::getName, "name")`