### PR TITLE
Refactor not copying BuilderManipulator

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -157,8 +157,8 @@ public final class ArbitraryBuilder<T> {
 		this.generator = getGenerator(generator, arbitraryCustomizers);
 		this.validator = validator;
 		this.arbitraryCustomizers = arbitraryCustomizers;
-		this.builderManipulators = new ArrayList<>(builderManipulators);
-		this.usedManipulators = new ArrayList<>(usedManipulators);
+		this.builderManipulators = builderManipulators;
+		this.usedManipulators = usedManipulators;
 		this.generatorMap = generatorMap.entrySet().stream()
 			.map(it -> new SimpleEntry<Class<?>, ArbitraryGenerator>(
 				it.getKey(),


### PR DESCRIPTION
실제 사용하는 곳이 `copy` 밖에 없고 `copy` 내에서는 값을 복사해서 넘겨주므로 의미가 없습니다.
생성자 내에서 복사한다는 것을 예측하기 어려우므로 제거합니다.