### PR TITLE
Refactor apply method as unified one public method

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNullity.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNullity.java
@@ -38,7 +38,7 @@ public final class ArbitraryNullity extends AbstractArbitraryExpressionManipulat
 	@SuppressWarnings("rawtypes")
 	@Override
 	public void accept(ArbitraryBuilder fixtureBuilder) {
-		fixtureBuilder.setNullity(this);
+		fixtureBuilder.apply(this);
 	}
 
 	@Override

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -23,6 +23,7 @@ import static com.navercorp.fixturemonkey.test.SimpleManipulatorTestSpecs.SUT;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,8 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.domains.Domain;
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import com.navercorp.fixturemonkey.test.SimpleManipulatorTestSpecs.IntValue;
 import com.navercorp.fixturemonkey.test.SimpleManipulatorTestSpecs.IntegerList;
@@ -1017,5 +1020,23 @@ class SimpleManipulatorTest {
 			.sample();
 
 		then(actual.getValues()).isEqualTo(integerList);
+	}
+
+	@Property
+	void unimplementedManipulatorThrows() {
+		thenThrownBy(() -> SUT.giveMeBuilder(Integer.class)
+			.apply(new BuilderManipulator() {
+				@Override
+				public void accept(@SuppressWarnings("rawtypes") ArbitraryBuilder arbitraryBuilder) {
+					arbitraryBuilder.apply(this);
+				}
+
+				@Override
+				public BuilderManipulator copy() {
+					return this;
+				}
+			})
+		).isExactlyInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Unimplemented manipulator type");
 	}
 }


### PR DESCRIPTION
연산 실행을 지연하지 않고 즉시 실행하는 `apply` 메소드를 구현 상세사항을 감추기 위해서 하나의 public 메소드로 노출합니다.
인터페이스가 달라졌지만 클라이언트는 동일하게 사용할 수 있으므로 별도 `@Deprecated` 마킹은 하지 않았습니다.

[찾아본 레퍼런스](https://github.com/spring-projects/spring-framework/blob/e85001f332bc4627a094cd2b57973e8eea370c81/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java#L85)
