### PR TITLE
Fix OOM when annotated size without max

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.arbitrary;
 
+import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
 import static com.navercorp.fixturemonkey.Constants.HEAD_NAME;
 import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALUE;
 
@@ -112,7 +113,11 @@ public final class ArbitraryNode<T> {
 		Size size = type.getAnnotation(Size.class);
 		if (size != null) {
 			min = size.min();
-			max = size.max();
+			if (size.max() != Integer.MAX_VALUE) { // not initialized for preventing OOM
+				max = size.max();
+			} else {
+				max = min + DEFAULT_ELEMENT_MAX_SIZE;
+			}
 		}
 
 		NotEmpty notEmpty = type.getAnnotation(NotEmpty.class);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
 import static com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.SUT;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -54,6 +55,7 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntWithAnnotation
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerArray;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerIterable;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerIterator;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerListAnnotatedBySizeWithoutMax;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerListWithNotEmpty;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerOptional;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerSet;
@@ -1365,5 +1367,11 @@ class FixtureMonkeyTest {
 			.sample();
 
 		then(actual.get(0).getValue()).isEqualTo("test");
+	}
+
+	@Property
+	@Domain(FixtureMonkeyTestSpecs.class)
+	void giveMeListAnnotatedBySizeWithoutMax(@ForAll IntegerListAnnotatedBySizeWithoutMax actual) {
+		then(actual.getValues()).hasSizeBetween(1, 1 + DEFAULT_ELEMENT_MAX_SIZE);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTestSpecs.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Provide;
@@ -257,6 +258,17 @@ class FixtureMonkeyTestSpecs extends DomainContextBase {
 	@Provide
 	Arbitrary<NestedStringQueue> nestedStringQueue() {
 		return SUT.giveMeArbitrary(NestedStringQueue.class);
+	}
+
+	@Data
+	public static class IntegerListAnnotatedBySizeWithoutMax {
+		@Size(min = 1)
+		private List<Integer> values;
+	}
+
+	@Provide
+	Arbitrary<IntegerListAnnotatedBySizeWithoutMax> integerListAnnotatedBySizeWithoutMax() {
+		return SUT.giveMeArbitrary(IntegerListAnnotatedBySizeWithoutMax.class);
 	}
 
 	public static class DefaultArbitraryGroup {


### PR DESCRIPTION
`@Size` 에서 max를 설정하지 않는 경우 `Integer.MAX_VALUE`를 설정하여 OOM이 발생하는 문제를 해결합니다