### PR TITLE
Fix PriorityManipulator implementations sorting

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
@@ -82,9 +82,11 @@ public final class ArbitraryExpression implements Comparable<ArbitraryExpression
 	public int compareTo(ArbitraryExpression arbitraryExpression) {
 		List<Exp> oExpList = arbitraryExpression.expList;
 
-		int expLength = Math.min(oExpList.size(), expList.size());
+		if (expList.size() != oExpList.size()) {
+			return Integer.compare(expList.size(), oExpList.size());
+		}
 
-		for (int i = 0; i < expLength; i++) {
+		for (int i = 0; i < expList.size(); i++) {
 			Exp exp = expList.get(i);
 			Exp oExp = oExpList.get(i);
 			int expCompare = exp.compareTo(oExp);
@@ -93,7 +95,7 @@ public final class ArbitraryExpression implements Comparable<ArbitraryExpression
 			}
 		}
 
-		return Integer.compare(oExpList.size(), expList.size());
+		return 0;
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ContainerSizeManipulator.java
@@ -57,7 +57,15 @@ public final class ContainerSizeManipulator extends AbstractArbitraryExpressionM
 
 	@Override
 	public Priority getPriority() {
-		return Priority.HIGH;
+		return Priority.LOW;
+	}
+
+	@Override
+	public int compareTo(PriorityManipulator priorityManipulator) {
+		if (priorityManipulator instanceof ContainerSizeManipulator) {
+			return getArbitraryExpression().compareTo(priorityManipulator.getArbitraryExpression());
+		}
+		return MetadataManipulator.super.compareTo(priorityManipulator);
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/PriorityManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/PriorityManipulator.java
@@ -23,13 +23,7 @@ interface PriorityManipulator extends ArbitraryExpressionManipulator, Comparable
 
 	@Override
 	default int compareTo(PriorityManipulator priorityManipulator) {
-		int priorityCompare =
-			Integer.compare(this.getPriority().ordinal(), priorityManipulator.getPriority().ordinal());
-		if (priorityCompare != 0) {
-			return priorityCompare;
-		}
-
-		return getArbitraryExpression().compareTo(priorityManipulator.getArbitraryExpression());
+		return Integer.compare(this.getPriority().ordinal(), priorityManipulator.getPriority().ordinal());
 	}
 
 	enum Priority {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -57,6 +57,7 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.NestedString
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.SetArbitraryAcceptGroup;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.SetArbitraryArbitraryAcceptGroup;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringAndIntGroup;
+import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringIntegerWrapper;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.IntegerArray;
 
 class ComplexManipulatorTest {
@@ -907,5 +908,17 @@ class ComplexManipulatorTest {
 		});
 
 		then(actual.getValue()).isEqualTo("test");
+	}
+
+	@Property
+	void giveMeNestedFieldSizeAndApplySize() {
+		StringIntegerWrapper actual = SUT.giveMeBuilder(StringIntegerWrapper.class)
+			.size("value.values", 1)
+			.apply((it, builder) -> {
+			})
+			.size("value.values", 2)
+			.sample();
+
+		then(actual.getValue().getValues()).hasSize(2);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTestSpecs.java
@@ -54,6 +54,11 @@ class ComplexManipulatorTestSpecs extends DomainContextBase {
 	}
 
 	@Data
+	public static class StringIntegerWrapper {
+		private StringIntegerList value;
+	}
+
+	@Data
 	public static class StringIntegerList {
 		private String value;
 		private List<Integer> values;


### PR DESCRIPTION
`Apply` 연산을 `MetaManipulator` 구현체로 변경하면서 생긴 우선순위 정렬 문제를 해결합니다.
`PriorityManipulator`는 Priority 값을 기준으로 정렬을 진행하고, 구현체간 정렬 기준은 별도로 정의가 필요한 경우 override하여 구현합니다.
