### PR TITLE
Add ManipulatorOptimizer

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.resolver;
 
 import java.util.ArrayList;
@@ -14,20 +32,28 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 
 public final class ArbitraryResolver {
 	private final ArbitraryTraverser traverser;
 	private final GenerateOptions generateOptions;
+	private final ManipulatorOptimizer manipulatorOptimizer;
 
-	public ArbitraryResolver(ArbitraryTraverser traverser, GenerateOptions generateOptions) {
+	public ArbitraryResolver(
+		ArbitraryTraverser traverser,
+		GenerateOptions generateOptions,
+		ManipulatorOptimizer manipulatorOptimizer
+	) {
 		this.traverser = traverser;
 		this.generateOptions = generateOptions;
+		this.manipulatorOptimizer = manipulatorOptimizer;
 	}
 
-	public Arbitrary<?> resolve(RootProperty rootProperty) {
+	public Arbitrary<?> resolve(RootProperty rootProperty, List<BuilderManipulator> manipulators) {
 		ArbitraryNode arbitraryNode = this.traverser.traverse(rootProperty);
 
 		// manipulating 표현식 개수만큼 순회
+		List<BuilderManipulator> optimizedManipulator = manipulatorOptimizer.optimize(manipulators).getManipulators();
 
 		ArbitraryGeneratorContext context = this.generateContext(arbitraryNode, null);
 		return this.generateOptions.getArbitraryGenerator(rootProperty).generate(context);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -36,17 +36,17 @@ import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 
 public final class ArbitraryResolver {
 	private final ArbitraryTraverser traverser;
-	private final GenerateOptions generateOptions;
 	private final ManipulatorOptimizer manipulatorOptimizer;
+	private final GenerateOptions generateOptions;
 
 	public ArbitraryResolver(
 		ArbitraryTraverser traverser,
-		GenerateOptions generateOptions,
-		ManipulatorOptimizer manipulatorOptimizer
+		ManipulatorOptimizer manipulatorOptimizer,
+		GenerateOptions generateOptions
 	) {
 		this.traverser = traverser;
-		this.generateOptions = generateOptions;
 		this.manipulatorOptimizer = manipulatorOptimizer;
+		this.generateOptions = generateOptions;
 	}
 
 	public Arbitrary<?> resolve(RootProperty rootProperty, List<BuilderManipulator> manipulators) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulatorOptimizer.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulatorOptimizer.java
@@ -1,0 +1,69 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
+import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
+
+public class ManipulatorOptimizer {
+
+	@SuppressWarnings("rawtypes")
+	public OptimizedManipulatorResult optimize(List<BuilderManipulator> manipulators) {
+		List<BuilderManipulator> optimizedManipulators = new ArrayList<>();
+
+		List<MetadataManipulator> metadataManipulators = extractMetadataManipulators(manipulators);
+		List<BuilderManipulator> orderedManipulators = extractOrderedManipulators(manipulators);
+		List<PostArbitraryManipulator> postArbitraryManipulators = extractPostArbitraryManipulators(manipulators);
+
+		optimizedManipulators.addAll(metadataManipulators);
+		optimizedManipulators.addAll(orderedManipulators);
+		optimizedManipulators.addAll(postArbitraryManipulators);
+
+		return new OptimizedManipulatorResult(optimizedManipulators);
+	}
+
+	private List<BuilderManipulator> extractOrderedManipulators(List<BuilderManipulator> manipulators) {
+		return manipulators.stream()
+			.filter(it -> !(it instanceof MetadataManipulator))
+			.filter(it -> !(it instanceof PostArbitraryManipulator))
+			.collect(toList());
+	}
+
+	private List<MetadataManipulator> extractMetadataManipulators(List<BuilderManipulator> manipulators) {
+		return manipulators.stream()
+			.filter(MetadataManipulator.class::isInstance)
+			.map(MetadataManipulator.class::cast)
+			.sorted()
+			.collect(toList());
+	}
+
+	@SuppressWarnings("rawtypes")
+	private List<PostArbitraryManipulator> extractPostArbitraryManipulators(List<BuilderManipulator> manipulators) {
+		return manipulators.stream()
+			.filter(PostArbitraryManipulator.class::isInstance)
+			.map(PostArbitraryManipulator.class::cast)
+			.collect(toList());
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulatorOptimizer.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulatorOptimizer.java
@@ -23,11 +23,15 @@ import static java.util.stream.Collectors.toList;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
 
-public class ManipulatorOptimizer {
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ManipulatorOptimizer {
 
 	@SuppressWarnings("rawtypes")
 	public OptimizedManipulatorResult optimize(List<BuilderManipulator> manipulators) {
@@ -44,18 +48,18 @@ public class ManipulatorOptimizer {
 		return new OptimizedManipulatorResult(optimizedManipulators);
 	}
 
-	private List<BuilderManipulator> extractOrderedManipulators(List<BuilderManipulator> manipulators) {
-		return manipulators.stream()
-			.filter(it -> !(it instanceof MetadataManipulator))
-			.filter(it -> !(it instanceof PostArbitraryManipulator))
-			.collect(toList());
-	}
-
 	private List<MetadataManipulator> extractMetadataManipulators(List<BuilderManipulator> manipulators) {
 		return manipulators.stream()
 			.filter(MetadataManipulator.class::isInstance)
 			.map(MetadataManipulator.class::cast)
 			.sorted()
+			.collect(toList());
+	}
+
+	private List<BuilderManipulator> extractOrderedManipulators(List<BuilderManipulator> manipulators) {
+		return manipulators.stream()
+			.filter(it -> !(it instanceof MetadataManipulator))
+			.filter(it -> !(it instanceof PostArbitraryManipulator))
 			.collect(toList());
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/OptimizedManipulatorResult.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/OptimizedManipulatorResult.java
@@ -20,9 +20,13 @@ package com.navercorp.fixturemonkey.resolver;
 
 import java.util.List;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 
-public class OptimizedManipulatorResult {
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class OptimizedManipulatorResult {
 	private final List<BuilderManipulator> manipulators;
 
 	public OptimizedManipulatorResult(List<BuilderManipulator> manipulators) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/OptimizedManipulatorResult.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/OptimizedManipulatorResult.java
@@ -1,0 +1,35 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import java.util.List;
+
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+
+public class OptimizedManipulatorResult {
+	private final List<BuilderManipulator> manipulators;
+
+	public OptimizedManipulatorResult(List<BuilderManipulator> manipulators) {
+		this.manipulators = manipulators;
+	}
+
+	public List<BuilderManipulator> getManipulators() {
+		return manipulators;
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
@@ -22,8 +22,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
 import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.jqwik.api.Property;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.type.TypeReference;
+import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+import com.navercorp.fixturemonkey.resolver.ManipulatorOptimizer;
+import com.navercorp.fixturemonkey.resolver.OptimizedManipulatorResult;
+
+public class ManipulatorOptimizerTest {
+	private final FixtureMonkey fixture = FixtureMonkey.create();
+	private final ManipulatorOptimizer sut = new ManipulatorOptimizer();
+
+	@Property
+	public void optimize() {
+		List<BuilderManipulator> manipulators = fixture.giveMeOne(new TypeReference<List<BuilderManipulator>>() {
+		});
+
+		OptimizedManipulatorResult actual = sut.optimize(manipulators);
+
+		then(actual.getManipulators()).isEqualTo(manipulators);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ManipulatorOptimizerTest.java
@@ -30,12 +30,12 @@ import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.resolver.ManipulatorOptimizer;
 import com.navercorp.fixturemonkey.resolver.OptimizedManipulatorResult;
 
-public class ManipulatorOptimizerTest {
+class ManipulatorOptimizerTest {
 	private final FixtureMonkey fixture = FixtureMonkey.create();
 	private final ManipulatorOptimizer sut = new ManipulatorOptimizer();
 
 	@Property
-	public void optimize() {
+	void optimize() {
 		List<BuilderManipulator> manipulators = fixture.giveMeOne(new TypeReference<List<BuilderManipulator>>() {
 		});
 


### PR DESCRIPTION
`BuilderManipulator` 을 입력했을 때 DBMS의 쿼리 옵티마이저처럼 최적의 쿼리를 만들어주는 역할을 가진 `ManipulatorOptimizer`를 추가합니다.

현재 BuilderManipulator를 상속하는 인터페이스와 구현체들이 명확하게 나누어지지 않고 불필요하게 복잡한 구조를 가지고 있어 다음 PR에서 `@Deprecate` 마킹과 함께 정리를 할 예정입니다.