### PR TITLE
Extends old ArbitraryBuilder

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -196,7 +196,11 @@ public class ArbitraryBuilder<T> {
 
 	// Only for V04 ArbitraryBuilder inherit type
 	// Do not use this constructor.
-	@API(since = "0.4.0", status = Status.DEPRECATED, consumers = "com.navercorp.fixturemonkey.builder.ArbitraryBuilder")
+	@API(
+		since = "0.4.0",
+		status = Status.DEPRECATED,
+		consumers = "com.navercorp.fixturemonkey.builder.ArbitraryBuilder"
+	)
 	@Deprecated
 	protected ArbitraryBuilder() {
 		this(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -77,7 +77,7 @@ import com.navercorp.fixturemonkey.customizer.WithFixtureCustomizer;
 import com.navercorp.fixturemonkey.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 
-public final class ArbitraryBuilder<T> {
+public class ArbitraryBuilder<T> {
 	private final ArbitraryTree<T> tree;
 	private final ArbitraryTraverser traverser;
 	private final List<BuilderManipulator> builderManipulators;
@@ -192,6 +192,23 @@ public final class ArbitraryBuilder<T> {
 				getGenerator(it.getValue(), arbitraryCustomizers))
 			)
 			.collect(toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+	}
+
+	// Only for V04 ArbitraryBuilder inherit type
+	// Do not use this constructor.
+	@API(since = "0.4.0", status = Status.DEPRECATED, consumers = "com.navercorp.fixturemonkey.builder.ArbitraryBuilder")
+	@Deprecated
+	protected ArbitraryBuilder() {
+		this(
+			null,
+			null,
+			null,
+			null,
+			null,
+			Collections.emptyList(),
+			Collections.emptyList(),
+			Collections.emptyMap()
+		);
 	}
 
 	public ArbitraryBuilder<T> validOnly(boolean validOnly) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilder.java
@@ -18,7 +18,10 @@
 
 package com.navercorp.fixturemonkey.builder;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -30,8 +33,9 @@ import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryResolver;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 
+// TODO: remove extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> inheritance in 1.0.0
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class ArbitraryBuilder<T> {
+public final class ArbitraryBuilder<T> extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> {
 	private final RootProperty rootProperty;
 	private final List<BuilderManipulator> manipulators;
 	private final ArbitraryResolver resolver;
@@ -44,23 +48,40 @@ public final class ArbitraryBuilder<T> {
 		ArbitraryResolver resolver,
 		ArbitraryValidator validator
 	) {
+		super();
 		this.rootProperty = rootProperty;
 		this.manipulators = manipulators;
 		this.resolver = resolver;
 		this.validator = validator;
 	}
 
+	@Override
 	public ArbitraryBuilder<T> validOnly(boolean validOnly) {
 		this.validOnly = validOnly;
 		return this;
 	}
 
 	@SuppressWarnings("unchecked")
+	@Override
 	public Arbitrary<T> build() {
 		return new ArbitraryValue<>(
 			() -> (Arbitrary<T>)this.resolver.resolve(this.rootProperty, this.manipulators),
 			this.validator,
 			this.validOnly
 		);
+	}
+
+	@Override
+	public T sample() {
+		return this.build().sample();
+	}
+
+	@Override
+	public Stream<T> sampleStream() {
+		return this.build().sampleStream();
+	}
+
+	public List<T> sampleList(int size) {
+		return this.sampleStream().limit(size).collect(toList());
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilder.java
@@ -28,12 +28,15 @@ import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitrary;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryResolver;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 
 // TODO: remove extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> inheritance in 1.0.0
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class ArbitraryBuilder<T> extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> {
 	private final RootProperty rootProperty;


### PR DESCRIPTION
신규 ArbitraryBuilder 에서 이전 ArbitraryBuilder 를 상속합니다.
타입을 맞춰 FixtureMonkey 객체에서 사용하는 버전에 따라 선택적으로 ArbitraryBuilder 를 생성하고 반환해서 사용하기 위함입니다.

신규 ArbitararyBuilder 에서는 재구현한 public 메소드들을 Override 해서 구현해야 하며, 신규에서 제공하지 않을 메소드는 `@Deprecated` 
 후 UnsupportedException 을 던지도록 Override 하면 됩니다.

