### PR TITLE
Apply gradle Java toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,6 @@ subprojects {
     apply plugin: "maven-publish"
     apply plugin: "signing"
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-
     ext {
         JUNIT_ENGINE_VERSION = "1.8.1"
         JUNIT_JUPITER_VERSION = "5.8.1"
@@ -44,8 +41,7 @@ subprojects {
     java {
         withJavadocJar()
         withSourcesJar()
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        toolchain {languageVersion = JavaLanguageVersion.of(8)}
     }
 
     publishing {

--- a/fixture-monkey-kotlin/build.gradle
+++ b/fixture-monkey-kotlin/build.gradle
@@ -19,8 +19,6 @@ repositories {
     mavenCentral()
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     api(project(":fixture-monkey"))
     api("net.jqwik:jqwik-kotlin:${JQWIK_VERSION}")


### PR DESCRIPTION
Java toolchain을 적용합니다.

이후 JDK16 record 생성을 지원하는 모듈을 추가할 때 사용할 예정입니다.