### PR TITLE
Add ArbitraryTree for encapsulating

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
@@ -28,6 +28,7 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 final class ArbitraryNode {
@@ -56,6 +57,10 @@ final class ArbitraryNode {
 
 	public ArbitraryProperty getArbitraryProperty() {
 		return this.arbitraryProperty;
+	}
+
+	public Property getProperty(){
+		return this.getArbitraryProperty().getProperty();
 	}
 
 	public List<ArbitraryNode> getChildren() {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
@@ -59,7 +59,7 @@ final class ArbitraryNode {
 		return this.arbitraryProperty;
 	}
 
-	public Property getProperty(){
+	public Property getProperty() {
 		return this.getArbitraryProperty().getProperty();
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -52,7 +52,7 @@ public final class ArbitraryTraverser {
 			)
 		);
 
-		return new ArbitraryTree(rootProperty, this.traverse(rootArbitraryProperty), generateOptions);
+		return new ArbitraryTree(this.traverse(rootArbitraryProperty), generateOptions);
 	}
 
 	private ArbitraryNode traverse(ArbitraryProperty arbitraryProperty) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -39,7 +39,7 @@ public final class ArbitraryTraverser {
 		this.generateOptions = generateOptions;
 	}
 
-	public ArbitraryNode traverse(RootProperty rootProperty) {
+	public ArbitraryTree traverse(RootProperty rootProperty) {
 		ArbitraryPropertyGenerator arbitraryPropertyGenerator =
 			this.generateOptions.getArbitraryPropertyGenerator(rootProperty);
 
@@ -52,7 +52,7 @@ public final class ArbitraryTraverser {
 			)
 		);
 
-		return this.traverse(rootArbitraryProperty);
+		return new ArbitraryTree(rootProperty, this.traverse(rootArbitraryProperty), generateOptions);
 	}
 
 	private ArbitraryNode traverse(ArbitraryProperty arbitraryProperty) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -34,33 +34,26 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 final class ArbitraryTree {
-	private final RootProperty rootProperty;
 	private final ArbitraryNode rootNode;
 	private final GenerateOptions generateOptions;
 
 	ArbitraryTree(
-		RootProperty rootProperty,
 		ArbitraryNode rootNode,
 		GenerateOptions generateOptions
 	) {
-		this.rootProperty = rootProperty;
 		this.rootNode = rootNode;
 		this.generateOptions = generateOptions;
 	}
 
 	Arbitrary<?> generate() {
-		return this.generateOptions.getArbitraryGenerator(rootProperty).generate(generateContext());
+		return this.generateOptions.getArbitraryGenerator(rootNode.getProperty())
+			.generate(generateContext(rootNode, null));
 	}
 
-	private ArbitraryGeneratorContext generateContext() {
-		return doGenerateContext(rootNode, null);
-	}
-
-	private ArbitraryGeneratorContext doGenerateContext(
+	private ArbitraryGeneratorContext generateContext(
 		ArbitraryNode arbitraryNode,
 		@Nullable ArbitraryGeneratorContext parentContext
 	) {
@@ -87,7 +80,7 @@ final class ArbitraryTree {
 				}
 
 				return this.generateOptions.getArbitraryGenerator(prop.getProperty())
-					.generate(this.doGenerateContext(node, ctx));
+					.generate(this.generateContext(node, ctx));
 			}
 		);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -25,6 +25,9 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 
@@ -33,6 +36,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 final class ArbitraryTree {
 	private final RootProperty rootProperty;
 	private final ArbitraryNode rootNode;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -79,8 +79,9 @@ final class ArbitraryTree {
 					return arbitrary;
 				}
 
+				ArbitraryGeneratorContext childArbitraryGeneratorContext = this.generateContext(node, ctx);
 				return this.generateOptions.getArbitraryGenerator(prop.getProperty())
-					.generate(this.generateContext(node, ctx));
+					.generate(childArbitraryGeneratorContext);
 			}
 		);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -49,8 +49,9 @@ final class ArbitraryTree {
 	}
 
 	Arbitrary<?> generate() {
+		ArbitraryGeneratorContext context = generateContext(rootNode, null);
 		return this.generateOptions.getArbitraryGenerator(rootNode.getProperty())
-			.generate(generateContext(rootNode, null));
+			.generate(context);
 	}
 
 	private ArbitraryGeneratorContext generateContext(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -1,0 +1,90 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.RootProperty;
+
+final class ArbitraryTree {
+	private final RootProperty rootProperty;
+	private final ArbitraryNode rootNode;
+	private final GenerateOptions generateOptions;
+
+	ArbitraryTree(
+		RootProperty rootProperty,
+		ArbitraryNode rootNode,
+		GenerateOptions generateOptions
+	) {
+		this.rootProperty = rootProperty;
+		this.rootNode = rootNode;
+		this.generateOptions = generateOptions;
+	}
+
+	Arbitrary<?> generate() {
+		return this.generateOptions.getArbitraryGenerator(rootProperty).generate(generateContext());
+	}
+
+	private ArbitraryGeneratorContext generateContext() {
+		return doGenerateContext(rootNode, null);
+	}
+
+	private ArbitraryGeneratorContext doGenerateContext(
+		ArbitraryNode arbitraryNode,
+		@Nullable ArbitraryGeneratorContext parentContext
+	) {
+		Map<ArbitraryProperty, ArbitraryNode> childNodesByArbitraryProperty = new HashMap<>();
+		List<ArbitraryProperty> childrenProperties = new ArrayList<>();
+		for (ArbitraryNode childNode : arbitraryNode.getChildren()) {
+			childNodesByArbitraryProperty.put(childNode.getArbitraryProperty(), childNode);
+			childrenProperties.add(childNode.getArbitraryProperty());
+		}
+
+		return new ArbitraryGeneratorContext(
+			arbitraryNode.getArbitraryProperty(),
+			childrenProperties,
+			parentContext,
+			(ctx, prop) -> {
+				ArbitraryNode node = childNodesByArbitraryProperty.get(prop);
+				if (node == null) {
+					return Arbitraries.just(null);
+				}
+
+				Arbitrary<?> arbitrary = node.getArbitrary();
+				if (arbitrary != null) {
+					return arbitrary;
+				}
+
+				return this.generateOptions.getArbitraryGenerator(prop.getProperty())
+					.generate(this.doGenerateContext(node, ctx));
+			}
+		);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -42,8 +42,7 @@ class FixtureMonkeyV04Test {
 		GenerateOptions generateOptions = GenerateOptions.DEFAULT_GENERATE_OPTIONS;
 		ArbitraryResolver resolver = new ArbitraryResolver(
 			new ArbitraryTraverser(generateOptions),
-			new ManipulatorOptimizer(),
-			generateOptions
+			new ManipulatorOptimizer()
 		);
 		TypeReference<ComplexObject> typeReference = new TypeReference<ComplexObject>() {
 		};


### PR DESCRIPTION
traverse의 결과로 만들어진 트리를 root인 ArbitraryNode에 직접 접근하여 조회하는 대신 ArbitraryTree 객체를 통해 조회하도록 수정합니다.

ArbitraryTree에서는 다음과 같은 역할을 합니다.
1. 표현식에 해당하는 ArbitraryNode 조회
2. Arbitrary 생성