### PR TITLE
Set ElementProperty index null when container is set or map

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.generator;
 import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -36,6 +37,8 @@ public final class ContainerArbitraryPropertyGenerator implements ArbitraryPrope
 	@Override
 	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
 		Property property = context.getProperty();
+
+		Class<?> containerType = Types.getActualType(property.getType());
 
 		List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
 		if (elementTypes.size() != 1) {
@@ -54,11 +57,17 @@ public final class ContainerArbitraryPropertyGenerator implements ArbitraryPrope
 		AnnotatedType elementType = elementTypes.get(0);
 		List<Property> childProperties = new ArrayList<>();
 		for (int index = 0; index < size; index++) {
+			Integer elementIndex = index;
+
+			if (containerType.isAssignableFrom(Set.class)) {
+				elementIndex = null;
+			}
+
 			childProperties.add(
 				new ElementProperty(
 					property,
 					elementType,
-					index,
+					elementIndex,
 					0.0d
 				)
 			);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
@@ -59,7 +59,7 @@ public final class ContainerArbitraryPropertyGenerator implements ArbitraryPrope
 		for (int index = 0; index < size; index++) {
 			Integer elementIndex = index;
 
-			if (containerType.isAssignableFrom(Set.class)) {
+			if (Set.class.isAssignableFrom(containerType)) {
 				elementIndex = null;
 			}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/EntryArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/EntryArbitraryPropertyGenerator.java
@@ -61,13 +61,13 @@ public final class EntryArbitraryPropertyGenerator implements ArbitraryPropertyG
 					new ElementProperty(
 						property,
 						keyType,
-						index,
+						null,
 						0.0d
 					),
 					new ElementProperty(
 						property,
 						valueType,
-						index,
+						null,
 						null
 					)
 				)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapArbitraryPropertyGenerator.java
@@ -64,13 +64,13 @@ public final class MapArbitraryPropertyGenerator implements ArbitraryPropertyGen
 					new ElementProperty(
 						property,
 						keyType,
-						index,
+						null,
 						0.0d
 					),
 					new ElementProperty(
 						property,
 						valueType,
-						index,
+						null,
 						null
 					)
 				)


### PR DESCRIPTION
ElementProperty는 항상 index가 존재해야할 것 같은데요, @Nullable로 처리되있어서 제거합니다.
혹시 nullable로 설정하신 이유가 있을까요??