### PR TITLE
Remove ContainerInfo in ArbitraryProperty

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -96,7 +96,7 @@ public final class ArbitraryGeneratorContext {
 	// return children arbitraries for object childrens
 	// container children is elementProperty and it does not support propertyName value.
 	public Map<String, Arbitrary<?>> getObjectChildrenArbitrariesByResolvedPropertyName() {
-		if (this.getArbitraryProperty().getContainerInfo() != null) {
+		if (this.getArbitraryProperty().isContainer()) {
 			return Collections.emptyMap();
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
@@ -42,8 +42,7 @@ public final class ArbitraryProperty {
 
 	private final List<Property> childProperties;
 
-	@Nullable
-	private final ArbitraryContainerInfo containerInfo;
+	private final boolean container;
 
 	public ArbitraryProperty(
 		Property property,
@@ -51,14 +50,14 @@ public final class ArbitraryProperty {
 		double nullInject,
 		@Nullable Integer elementIndex,
 		List<Property> childProperties,
-		@Nullable ArbitraryContainerInfo containerInfo
+		boolean container
 	) {
 		this.property = property;
 		this.propertyNameResolver = propertyNameResolver;
 		this.nullInject = nullInject;
 		this.elementIndex = elementIndex;
 		this.childProperties = childProperties;
-		this.containerInfo = containerInfo;
+		this.container = container;
 	}
 
 	public Property getProperty() {
@@ -86,16 +85,11 @@ public final class ArbitraryProperty {
 		return this.childProperties;
 	}
 
-	@Nullable
-	public ArbitraryContainerInfo getContainerInfo() {
-		return this.containerInfo;
+	public boolean isContainer() {
+		return this.container;
 	}
 
 	public boolean isRoot() {
 		return this.property instanceof RootProperty;
-	}
-
-	public boolean isContainer() {
-		return this.containerInfo != null;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerArbitraryPropertyGenerator.java
@@ -73,7 +73,7 @@ public final class ContainerArbitraryPropertyGenerator implements ArbitraryPrope
 			nullInject,
 			context.getElementIndex(),
 			childProperties,
-			containerInfo
+			true
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/EntryArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/EntryArbitraryPropertyGenerator.java
@@ -83,7 +83,7 @@ public final class EntryArbitraryPropertyGenerator implements ArbitraryPropertyG
 			nullInject,
 			context.getElementIndex(),
 			childProperties,
-			CONTAINER_INFO
+			true
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapArbitraryPropertyGenerator.java
@@ -86,7 +86,7 @@ public final class MapArbitraryPropertyGenerator implements ArbitraryPropertyGen
 			nullInject,
 			context.getElementIndex(),
 			childProperties,
-			containerInfo
+			true
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapEntryElementArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapEntryElementArbitraryPropertyGenerator.java
@@ -31,7 +31,6 @@ public final class MapEntryElementArbitraryPropertyGenerator implements Arbitrar
 	public static final MapEntryElementArbitraryPropertyGenerator INSTANCE =
 		new MapEntryElementArbitraryPropertyGenerator();
 
-	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(1, 1);
 	private static final double NULL_INJECT = 0.0d;
 
 	@Override
@@ -51,7 +50,7 @@ public final class MapEntryElementArbitraryPropertyGenerator implements Arbitrar
 			NULL_INJECT,
 			context.getElementIndex(),
 			Arrays.asList(mapEntryElementProperty.getKeyProperty(), mapEntryElementProperty.getValueProperty()),
-			CONTAINER_INFO
+			true
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectArbitraryPropertyGenerator.java
@@ -42,7 +42,7 @@ public final class ObjectArbitraryPropertyGenerator implements ArbitraryProperty
 			nullInject,
 			context.getElementIndex(),
 			childProperties,
-			null
+			false
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/OptionalArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/OptionalArbitraryPropertyGenerator.java
@@ -125,7 +125,7 @@ public final class OptionalArbitraryPropertyGenerator implements ArbitraryProper
 			nullInject,
 			context.getElementIndex(),
 			Collections.singletonList(valueProperty),
-			CONTAINER_INFO
+			true
 		);
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueArbitraryPropertyGenerator.java
@@ -40,7 +40,7 @@ public final class SingleValueArbitraryPropertyGenerator implements ArbitraryPro
 			nullInject,
 			context.getElementIndex(),
 			Collections.emptyList(),
-			null
+			false
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/StreamArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/StreamArbitraryPropertyGenerator.java
@@ -135,7 +135,7 @@ public final class StreamArbitraryPropertyGenerator implements ArbitraryProperty
 			nullInject,
 			context.getElementIndex(),
 			childProperties,
-			containerInfo
+			true
 		);
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/TupleLikeElementsArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/TupleLikeElementsArbitraryPropertyGenerator.java
@@ -29,7 +29,6 @@ public final class TupleLikeElementsArbitraryPropertyGenerator implements Arbitr
 	public static final TupleLikeElementsArbitraryPropertyGenerator INSTANCE =
 		new TupleLikeElementsArbitraryPropertyGenerator();
 
-	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(1, 1);
 	private static final double NULL_INJECT = 0.0d;
 
 	@Override
@@ -49,7 +48,7 @@ public final class TupleLikeElementsArbitraryPropertyGenerator implements Arbitr
 			NULL_INJECT,
 			context.getElementIndex(),
 			tupleLikeElementsProperty.getElementsProperties(),
-			CONTAINER_INFO
+			true
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
@@ -47,8 +47,7 @@ public final class ListIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
@@ -44,8 +44,7 @@ public final class MapEntryElementIntrospector implements ArbitraryIntrospector,
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
@@ -49,8 +49,7 @@ public final class MapIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
@@ -29,7 +29,6 @@ import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitrary;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -50,19 +49,13 @@ public final class OptionalIntrospector implements ArbitraryIntrospector, Matche
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
 		List<ArbitraryProperty> children = context.getChildren();
-		if (containerInfo == null || children.size() != 1) {
+		if (!property.isContainer() || children.size() != 1) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
 		ArbitraryProperty valueProperty = children.get(0);
 		double presenceProbability = valueProperty.getNullInject();
-		if (containerInfo.getElementMinSize() > 0) {
-			presenceProbability = 1.0d;
-		} else if (containerInfo.getElementMaxSize() == 0) {
-			presenceProbability = 0.0d;
-		}
 
 		Class<?> type = Types.getActualType(property.getProperty().getType());
 		Arbitrary<?> elementArbitrary = context.getChildrenArbitraries().get(0)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
@@ -48,8 +48,7 @@ public final class QueueIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
@@ -48,8 +48,7 @@ public final class SetIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
@@ -57,8 +57,7 @@ public final class StreamIntrospector implements ArbitraryIntrospector, Matcher 
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
@@ -27,8 +27,7 @@ public final class TupleLikeElementsIntrospector implements ArbitraryIntrospecto
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
-		if (containerInfo == null) {
+		if (!property.isContainer()) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContextTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContextTest.java
@@ -44,7 +44,7 @@ class ArbitraryGeneratorContextTest {
 			0.0D,
 			null,
 			Collections.emptyList(),
-			null
+			false
 		);
 		ArbitraryGeneratorContext sut = new ArbitraryGeneratorContext(
 			arbitraryProperty,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
@@ -46,13 +46,13 @@ class ArbitraryPropertyTest {
 			0.0D,
 			null,
 			Collections.emptyList(),
-			null
+			false
 		);
 
 		then(actual.isRoot()).isTrue();
 		then(actual.getProperty()).isEqualTo(rootProperty);
 		then(actual.getNullInject()).isEqualTo(0.0D);
-		then(actual.getContainerInfo()).isNull();
+		then(actual.isContainer()).isFalse();
 	}
 
 	@Test
@@ -69,7 +69,7 @@ class ArbitraryPropertyTest {
 			0.0D,
 			null,
 			Collections.emptyList(),
-			null
+			false
 		);
 
 		then(actual.getResolvePropertyName()).isEqualTo("x_name");

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGeneratorTest.java
@@ -55,7 +55,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -87,7 +87,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -119,7 +119,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -151,7 +151,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -183,7 +183,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -215,7 +215,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -247,7 +247,7 @@ class DefaultArbitraryGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectDelegatorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectDelegatorTest.java
@@ -52,7 +52,7 @@ class ArbitraryIntrospectDelegatorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorTest.java
@@ -59,7 +59,7 @@ class ArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -85,7 +85,7 @@ class ArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -111,7 +111,7 @@ class ArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -137,7 +137,7 @@ class ArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospectorTest.java
@@ -51,7 +51,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -79,7 +79,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -107,7 +107,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -135,7 +135,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -163,7 +163,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -191,7 +191,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -219,7 +219,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -247,7 +247,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -275,7 +275,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -303,7 +303,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -331,7 +331,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -359,7 +359,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -387,7 +387,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -415,7 +415,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -443,7 +443,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -471,7 +471,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -499,7 +499,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -527,7 +527,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -555,7 +555,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -583,7 +583,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -611,7 +611,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -639,7 +639,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -667,7 +667,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -695,7 +695,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -723,7 +723,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -751,7 +751,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -779,7 +779,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -807,7 +807,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -835,7 +835,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -863,7 +863,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -891,7 +891,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -919,7 +919,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -947,7 +947,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -975,7 +975,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1003,7 +1003,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1031,7 +1031,7 @@ class JavaArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospectorTest.java
@@ -64,7 +64,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -92,7 +92,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -120,7 +120,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -148,7 +148,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -176,7 +176,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -204,7 +204,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -232,7 +232,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -260,7 +260,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -288,7 +288,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -316,7 +316,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -344,7 +344,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -372,7 +372,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -400,7 +400,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -428,7 +428,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -456,7 +456,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -484,7 +484,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -512,7 +512,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -540,7 +540,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -568,7 +568,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -596,7 +596,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -624,7 +624,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -652,7 +652,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -680,7 +680,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -708,7 +708,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -736,7 +736,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -764,7 +764,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -792,7 +792,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -820,7 +820,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -848,7 +848,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -876,7 +876,7 @@ class JavaTimeArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/AssignableMatcherTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/AssignableMatcherTest.java
@@ -50,7 +50,7 @@ class AssignableMatcherTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -79,7 +79,7 @@ class AssignableMatcherTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
@@ -50,7 +50,7 @@ class ExactMatcherTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -79,7 +79,7 @@ class ExactMatcherTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
@@ -58,7 +58,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -89,7 +89,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -120,7 +120,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -151,7 +151,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -183,7 +183,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -215,7 +215,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -251,7 +251,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -282,7 +282,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -312,7 +312,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -343,7 +343,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -374,7 +374,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -405,7 +405,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -436,7 +436,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -467,7 +467,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -498,7 +498,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -529,7 +529,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -560,7 +560,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -591,7 +591,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -622,7 +622,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -653,7 +653,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -684,7 +684,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -715,7 +715,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -746,7 +746,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -777,7 +777,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -808,7 +808,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -839,7 +839,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -870,7 +870,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -901,7 +901,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -932,7 +932,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -963,7 +963,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -994,7 +994,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1025,7 +1025,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1056,7 +1056,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1087,7 +1087,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1118,7 +1118,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1149,7 +1149,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1180,7 +1180,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1211,7 +1211,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1242,7 +1242,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1273,7 +1273,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1304,7 +1304,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1335,7 +1335,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1366,7 +1366,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1397,7 +1397,7 @@ class JavaxValidationArbitraryIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationBooleanIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationBooleanIntrospectorTest.java
@@ -50,7 +50,7 @@ class JavaxValidationBooleanIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -80,7 +80,7 @@ class JavaxValidationBooleanIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -109,7 +109,7 @@ class JavaxValidationBooleanIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGeneratorTest.java
@@ -51,7 +51,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -83,7 +83,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -115,7 +115,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -147,7 +147,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -179,7 +179,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -211,7 +211,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -241,7 +241,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -271,7 +271,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -301,7 +301,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -331,7 +331,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -361,7 +361,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -391,7 +391,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -421,7 +421,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -451,7 +451,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -481,7 +481,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -511,7 +511,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -541,7 +541,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -571,7 +571,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -603,7 +603,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -635,7 +635,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -667,7 +667,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -699,7 +699,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -731,7 +731,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -763,7 +763,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -795,7 +795,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -827,7 +827,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -859,7 +859,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -891,7 +891,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -923,7 +923,7 @@ class JavaxValidationConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeArbitraryTypeIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeArbitraryTypeIntrospectorTest.java
@@ -72,7 +72,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -103,7 +103,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -136,7 +136,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -169,7 +169,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -202,7 +202,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -235,7 +235,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -266,7 +266,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -299,7 +299,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -332,7 +332,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -365,7 +365,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -398,7 +398,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -429,7 +429,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -463,7 +463,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -498,7 +498,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -530,7 +530,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -561,7 +561,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -592,7 +592,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -624,7 +624,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -657,7 +657,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -689,7 +689,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -720,7 +720,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -751,7 +751,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -783,7 +783,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -816,7 +816,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -848,7 +848,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -879,7 +879,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -910,7 +910,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -942,7 +942,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -975,7 +975,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1007,7 +1007,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1038,7 +1038,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1068,7 +1068,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -1098,7 +1098,7 @@ class JavaxValidationTimeArbitraryTypeIntrospectorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeConstraintGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeConstraintGeneratorTest.java
@@ -52,7 +52,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -82,7 +82,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -113,7 +113,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -145,7 +145,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -176,7 +176,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -207,7 +207,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -237,7 +237,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -268,7 +268,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -300,7 +300,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -331,7 +331,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -362,7 +362,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -392,7 +392,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -423,7 +423,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -455,7 +455,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,
@@ -486,7 +486,7 @@ class JavaxValidationTimeConstraintGeneratorTest {
 				0.0D,
 				null,
 				Collections.emptyList(),
-				null
+				false
 			),
 			Collections.emptyList(),
 			null,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
@@ -59,12 +59,20 @@ final class ArbitraryNode {
 		return this.arbitraryProperty;
 	}
 
+	public void setArbitraryProperty(ArbitraryProperty arbitraryProperty) {
+		this.arbitraryProperty = arbitraryProperty;
+	}
+
 	public Property getProperty() {
 		return this.getArbitraryProperty().getProperty();
 	}
 
 	public List<ArbitraryNode> getChildren() {
 		return this.children;
+	}
+
+	public void setChildren(List<ArbitraryNode> children) {
+		this.children = children;
 	}
 
 	@Nullable

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -67,7 +67,7 @@ public final class ArbitraryTraverser {
 			ArbitraryProperty childArbitraryProperty = arbitraryPropertyGenerator.generate(
 				new ArbitraryPropertyGeneratorContext(
 					childProperty,
-					arbitraryProperty.getContainerInfo() != null ? index : null,
+					arbitraryProperty.isContainer() ? index : null,
 					arbitraryProperty,
 					this.generateOptions
 				)


### PR DESCRIPTION
ContainerInfo는 ArbitraryPropertyGenerator 에서만 사용하도록 수정합니다.