### PR TITLE
Fix isExceptGeneratablePackage primitive check error

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryOption.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryOption.java
@@ -157,10 +157,11 @@ public final class ArbitraryOption {
 	}
 
 	public <T> boolean isExceptGeneratablePackage(Class<T> clazz) {
-		if (clazz.getPackage() == null) {
-			return false; // primitive
-		}
+		if (clazz.isPrimitive()) return false;
+		if (clazz.getPackage() == null) return true;
+
 		String packageName = clazz.getPackage().getName();
+
 		return exceptGeneratePackages.stream()
 			.noneMatch(packageName::startsWith);
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryOption.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryOption.java
@@ -157,11 +157,14 @@ public final class ArbitraryOption {
 	}
 
 	public <T> boolean isExceptGeneratablePackage(Class<T> clazz) {
-		if (clazz.isPrimitive()) return false;
-		if (clazz.getPackage() == null) return true;
-
+		if (clazz.isPrimitive()) {
+			return false;
+		}
+		// classes with no specified package
+		if (clazz.getPackage() == null) {
+			return true;
+		}
 		String packageName = clazz.getPackage().getName();
-
 		return exceptGeneratePackages.stream()
 			.noneMatch(packageName::startsWith);
 	}


### PR DESCRIPTION
isExceptGeneratablePackage()의 primitive 확인 코드를 수정하고, 패키지 없이 생성된 클래스의 경우 true를 리턴하도록 코드를 추가했습니다. 