### PR TITLE
Add ApplyNodeCountManipulator

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ApplyNodeCountManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ApplyNodeCountManipulator.java
@@ -1,0 +1,37 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+final class ApplyNodeCountManipulator implements NodeManipulator {
+	private final NodeManipulator nodeManipulator;
+	private int count;
+
+	public ApplyNodeCountManipulator(NodeManipulator nodeManipulator, int count) {
+		this.nodeManipulator = nodeManipulator;
+		this.count = count;
+	}
+
+	@Override
+	public void manipulate(ArbitraryNode arbitraryNode) {
+		if (count > 0) {
+			count--;
+			nodeManipulator.manipulate(arbitraryNode);
+		}
+	}
+}


### PR DESCRIPTION
연산을 적용할 노드 개수를 제한하는 NodeManipulator를 추가합니다.
기존 limit과 같은 동작을 합니다.

노드 최대 개수는 int로도 충분할 것 같아 long에서 int로 변경합니다.