### PR TITLE
Refactor apply for better readability

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -670,12 +670,10 @@ public class ArbitraryBuilder<T> {
 	private ArbitraryBuilder<T> apply(ArbitraryApply<T> arbitraryApply) {
 		ArbitraryBuilder<T> toSampleArbitraryBuilder = arbitraryApply.getToSampleArbitraryBuilder();
 		BiConsumer<T, ArbitraryBuilder<T>> builderBiConsumer = arbitraryApply.getBuilderBiConsumer();
-		T sample = toSampleArbitraryBuilder.sample();
-		ArbitrarySet<T> toFixSampled = new ArbitrarySet<>(ArbitraryExpression.from(HEAD_NAME), sample);
-		toSampleArbitraryBuilder.builderManipulators.clear();
-		toSampleArbitraryBuilder.builderManipulators.add(toFixSampled);
-		builderBiConsumer.accept(sample, toSampleArbitraryBuilder);
-		this.apply(toSampleArbitraryBuilder.builderManipulators);
+		T fixedPreApplySampled = toSampleArbitraryBuilder.fixed().sample();
+		builderBiConsumer.accept(fixedPreApplySampled, toSampleArbitraryBuilder);
+		T postApplySampled = toSampleArbitraryBuilder.sample();
+		this.apply(new ArbitrarySet<>(ArbitraryExpression.from(HEAD_NAME), postApplySampled));
 		return this;
 	}
 


### PR DESCRIPTION
builderManipulators와 같은 내부 구현이 드러나지 않기 위해 `fixed`를 사용해서 동일한 동작 (apply)를 구현합니다.