### PR TITLE
Add ArbitrarySetLazyValue

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -638,11 +638,18 @@ public class ArbitraryBuilder<T> {
 
 		for (ArbitraryNode<T> foundNode : foundNodes) {
 			if (fixtureSet.isApplicable()) {
+				if (fixtureSet instanceof ArbitrarySetLazyValue) {
+					ArbitraryExpression arbitraryExpression = fixtureSet.getArbitraryExpression();
+					Object value = fixtureSet.getInputValue();
+					long limit = ((ArbitrarySetLazyValue<T>)fixtureSet).getLimit();
+					if (((ArbitrarySetLazyValue<T>)fixtureSet).isArbitraryValue()) {
+						fixtureSet = new ArbitrarySetArbitrary<>(arbitraryExpression, (Arbitrary<T>)value, limit);
+					} else {
+						fixtureSet = new ArbitrarySet<>(arbitraryExpression, (T)value, limit);
+					}
+				}
 				foundNode.apply(fixtureSet);
-				boolean isArbitrarySetLazyValue =
-					fixtureSet instanceof ArbitrarySetLazyValue
-						&& !((ArbitrarySetLazyValue)fixtureSet).isArbitraryValue();
-				if (fixtureSet instanceof ArbitrarySet || isArbitrarySetLazyValue) {
+				if (fixtureSet instanceof ArbitrarySet) {
 					traverser.traverse(foundNode, foundNode.isKeyOfMapStructure(), generator);
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -61,6 +61,7 @@ import com.navercorp.fixturemonkey.arbitrary.ArbitraryNode;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryNullity;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySet;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetArbitrary;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetLazyValue;
 import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetPostCondition;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryTree;
@@ -314,6 +315,12 @@ public class ArbitraryBuilder<T> {
 
 	public ArbitraryBuilder<T> set(@Nullable Object value) {
 		return this.set(HEAD_NAME, value);
+	}
+
+	public ArbitraryBuilder<T> setLazy(String expression, Supplier<?> supplier) {
+		ArbitraryExpression arbitraryExpression = ArbitraryExpression.from(expression);
+		this.builderManipulators.add(new ArbitrarySetLazyValue<>(arbitraryExpression, supplier));
+		return this;
 	}
 
 	private ArbitraryBuilder<T> setBuilder(String expression, ArbitraryBuilder<?> builder) {
@@ -632,7 +639,10 @@ public class ArbitraryBuilder<T> {
 		for (ArbitraryNode<T> foundNode : foundNodes) {
 			if (fixtureSet.isApplicable()) {
 				foundNode.apply(fixtureSet);
-				if (fixtureSet instanceof ArbitrarySet) {
+				boolean isArbitrarySetLazyValue =
+					fixtureSet instanceof ArbitrarySetLazyValue
+						&& !((ArbitrarySetLazyValue)fixtureSet).isArbitraryValue();
+				if (fixtureSet instanceof ArbitrarySet || isArbitrarySetLazyValue) {
 					traverser.traverse(foundNode, foundNode.isKeyOfMapStructure(), generator);
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -635,19 +635,8 @@ public class ArbitraryBuilder<T> {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private void apply(AbstractArbitrarySet<T> fixtureSet) {
 		Collection<ArbitraryNode> foundNodes = this.findNodesByExpression(fixtureSet.getArbitraryExpression());
-
 		for (ArbitraryNode<T> foundNode : foundNodes) {
 			if (fixtureSet.isApplicable()) {
-				if (fixtureSet instanceof ArbitrarySetLazyValue) {
-					ArbitraryExpression arbitraryExpression = fixtureSet.getArbitraryExpression();
-					Object value = fixtureSet.getInputValue();
-					long limit = ((ArbitrarySetLazyValue<T>)fixtureSet).getLimit();
-					if (((ArbitrarySetLazyValue<T>)fixtureSet).isArbitraryValue()) {
-						fixtureSet = new ArbitrarySetArbitrary<>(arbitraryExpression, (Arbitrary<T>)value, limit);
-					} else {
-						fixtureSet = new ArbitrarySet<>(arbitraryExpression, (T)value, limit);
-					}
-				}
 				foundNode.apply(fixtureSet);
 				if (fixtureSet instanceof ArbitrarySet) {
 					traverser.traverse(foundNode, foundNode.isKeyOfMapStructure(), generator);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/AbstractArbitrarySet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/AbstractArbitrarySet.java
@@ -31,7 +31,7 @@ public abstract class AbstractArbitrarySet<T> extends AbstractArbitraryExpressio
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	public final void accept(ArbitraryBuilder arbitraryBuilder) {
+	public void accept(ArbitraryBuilder arbitraryBuilder) {
 		arbitraryBuilder.apply(this);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -140,10 +140,7 @@ public final class ArbitraryNode<T> {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void apply(PreArbitraryManipulator preArbitraryManipulator) {
-		boolean isArbitrarySetLazyValueArbitrary =
-			preArbitraryManipulator instanceof ArbitrarySetLazyValue
-				&& ((ArbitrarySetLazyValue)preArbitraryManipulator).isArbitraryValue();
-		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary || isArbitrarySetLazyValueArbitrary) {
+		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary) {
 			this.setFixed(true);
 			this.setArbitrary((Arbitrary<T>)preArbitraryManipulator.getApplicableValue());
 		} else if (preArbitraryManipulator instanceof AbstractArbitrarySet) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryNode.java
@@ -140,7 +140,10 @@ public final class ArbitraryNode<T> {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void apply(PreArbitraryManipulator preArbitraryManipulator) {
-		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary) {
+		boolean isArbitrarySetLazyValueArbitrary =
+			preArbitraryManipulator instanceof ArbitrarySetLazyValue
+				&& ((ArbitrarySetLazyValue)preArbitraryManipulator).isArbitraryValue();
+		if (preArbitraryManipulator instanceof ArbitrarySetArbitrary || isArbitrarySetLazyValueArbitrary) {
 			this.setFixed(true);
 			this.setArbitrary((Arbitrary<T>)preArbitraryManipulator.getApplicableValue());
 		} else if (preArbitraryManipulator instanceof AbstractArbitrarySet) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.arbitrary;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -23,13 +23,16 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 	private final Supplier<T> supplier;
-
 	private long limit;
 
 	public ArbitrarySetLazyValue(ArbitraryExpression arbitraryExpression, Supplier<T> supplier, long limit) {
@@ -45,11 +48,11 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 	@SuppressWarnings({"rawtypes"})
 	@Override
 	public void accept(ArbitraryBuilder arbitraryBuilder) {
-		BuilderManipulator builderManipulator;
 		ArbitraryExpression arbitraryExpression = this.getArbitraryExpression();
-		T value = this.getInputValue();
+		T value = this.getApplicableValue();
 		long limit = this.limit;
-		if (isArbitraryValue()) {
+		BuilderManipulator builderManipulator;
+		if (value instanceof Arbitrary) {
 			builderManipulator = new ArbitrarySetArbitrary<>(arbitraryExpression, (Arbitrary<?>)value, limit);
 		} else {
 			builderManipulator = new ArbitrarySet<>(arbitraryExpression, value, limit);
@@ -71,10 +74,6 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 	@Override
 	public boolean isApplicable() {
 		return limit > 0;
-	}
-
-	public boolean isArbitraryValue() {
-		return getInputValue() instanceof Arbitrary;
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
 
 import net.jqwik.api.Arbitrary;
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+
 public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 	private final Supplier<T> supplier;
 
@@ -40,8 +42,19 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 		this(arbitraryExpression, supplier, Long.MAX_VALUE);
 	}
 
-	public long getLimit() {
-		return limit;
+	@SuppressWarnings({"rawtypes"})
+	@Override
+	public void accept(ArbitraryBuilder arbitraryBuilder) {
+		BuilderManipulator builderManipulator;
+		ArbitraryExpression arbitraryExpression = this.getArbitraryExpression();
+		T value = this.getInputValue();
+		long limit = this.limit;
+		if (isArbitraryValue()) {
+			builderManipulator = new ArbitrarySetArbitrary<>(arbitraryExpression, (Arbitrary<?>)value, limit);
+		} else {
+			builderManipulator = new ArbitrarySet<>(arbitraryExpression, value, limit);
+		}
+		arbitraryBuilder.apply(builderManipulator);
 	}
 
 	@Nullable

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -1,0 +1,91 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.arbitrary;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import net.jqwik.api.Arbitrary;
+
+public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
+	private final Supplier<T> supplier;
+	private long limit;
+
+	public ArbitrarySetLazyValue(ArbitraryExpression arbitraryExpression, Supplier<T> supplier, long limit) {
+		super(arbitraryExpression);
+		this.supplier = supplier;
+		this.limit = limit;
+	}
+
+	public ArbitrarySetLazyValue(ArbitraryExpression arbitraryExpression, Supplier<T> supplier) {
+		this(arbitraryExpression, supplier, Long.MAX_VALUE);
+	}
+
+	@Nullable
+	@Override
+	public T getApplicableValue() {
+		if (this.limit > 0) {
+			limit--;
+			return getInputValue();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public boolean isApplicable() {
+		return limit > 0;
+	}
+
+	public boolean isArbitraryValue() {
+		return getInputValue() instanceof Arbitrary;
+	}
+
+	@Override
+	public T getInputValue() {
+		return supplier.get();
+	}
+
+	@Override
+	public ArbitrarySetLazyValue<T> copy() {
+		return new ArbitrarySetLazyValue<>(this.getArbitraryExpression(), this.supplier, this.limit);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		ArbitrarySetLazyValue<?> that = (ArbitrarySetLazyValue<?>)obj;
+		return getInputValue().equals(that.getInputValue());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), getInputValue());
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -83,26 +83,6 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 
 	@Override
 	public ArbitrarySetLazyValue<T> copy() {
-		return new ArbitrarySetLazyValue<>(this.getArbitraryExpression(), this.supplier, this.limit);
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
-		if (!super.equals(obj)) {
-			return false;
-		}
-		ArbitrarySetLazyValue<?> that = (ArbitrarySetLazyValue<?>)obj;
-		return supplier.equals(that.supplier);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), getInputValue());
+		return this;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -27,6 +27,7 @@ import net.jqwik.api.Arbitrary;
 
 public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 	private final Supplier<T> supplier;
+
 	private long limit;
 
 	public ArbitrarySetLazyValue(ArbitraryExpression arbitraryExpression, Supplier<T> supplier, long limit) {
@@ -37,6 +38,10 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 
 	public ArbitrarySetLazyValue(ArbitraryExpression arbitraryExpression, Supplier<T> supplier) {
 		this(arbitraryExpression, supplier, Long.MAX_VALUE);
+	}
+
+	public long getLimit() {
+		return limit;
 	}
 
 	@Nullable
@@ -81,7 +86,7 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 			return false;
 		}
 		ArbitrarySetLazyValue<?> that = (ArbitrarySetLazyValue<?>)obj;
-		return getInputValue().equals(that.getInputValue());
+		return supplier.equals(that.supplier);
 	}
 
 	@Override

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -1039,4 +1039,32 @@ class SimpleManipulatorTest {
 		).isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Unimplemented manipulator type");
 	}
+
+	@Property
+	void giveMeSetLazyValue() {
+		// given
+		ArbitraryBuilder<String> variable = SUT.giveMeBuilder(String.class);
+		ArbitraryBuilder<String> builder = SUT.giveMeBuilder(String.class)
+			.setLazy("$", () -> variable.sample());
+		variable.set("test");
+
+		// when
+		String actual = builder.sample();
+
+		then(actual).isEqualTo("test");
+	}
+
+	@Property(tries = 1)
+	void giveMeSetLazyValueSampleGivesDifferentValue() {
+		// given
+		ArbitraryBuilder<String> variable = SUT.giveMeBuilder(String.class);
+		ArbitraryBuilder<String> builder = SUT.giveMeBuilder(String.class)
+			.setLazy("$", () -> variable.sample());
+		String expected = builder.sample();
+
+		// when
+		String actual = builder.sample();
+
+		then(actual).isNotEqualTo(expected);
+	}
 }


### PR DESCRIPTION
기존 0.3.X 버젼의 FixtureMonkey ArbitraryBuilder에 setLazy 연산을 추가합니다. (0.4.X에서 사용 가능하도록)

다른 부분은 기존 0.3.X setLazy 코드를 그대로 가져왔는데 
값으로 set하는것과 Arbitrary로 set하는 것을 모두 지원하기 위해서 코드를 추가/수정한 부분이 있습니다.
코멘트 단 곳들 문제없을지 한번 확인해주시면 감사하겠습니다!