### PR TITLE
Add map

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullArbitraryPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullArbitraryPropertyGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.Collections;
+
+public final class NullArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
+	public static final NullArbitraryPropertyGenerator INSTANCE = new NullArbitraryPropertyGenerator();
+
+	@Override
+	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+		return new ArbitraryProperty(
+			context.getProperty(),
+			context.getPropertyNameResolver(),
+			1.0d,
+			null,
+			Collections.emptyList(),
+			null
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
@@ -61,6 +61,7 @@ import com.navercorp.fixturemonkey.api.generator.ContainerArbitraryPropertyGener
 import com.navercorp.fixturemonkey.api.generator.EntryArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.MapArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.MapEntryElementArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.NullArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.OptionalArbitraryPropertyGenerator;
@@ -73,6 +74,7 @@ import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.TupleLikeElementsProperty;
+import com.navercorp.fixturemonkey.api.type.Types.UnidentifiableType;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class GenerateOptions {
@@ -284,7 +286,8 @@ public final class GenerateOptions {
 			new MatcherOperator<>(
 				property -> property.getClass() == TupleLikeElementsProperty.class,
 				TupleLikeElementsArbitraryPropertyGenerator.INSTANCE
-			)
+			),
+			MatcherOperator.exactTypeMatchOperator(UnidentifiableType.class, NullArbitraryPropertyGenerator.INSTANCE)
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
@@ -375,4 +375,9 @@ public class Types {
 			}
 		};
 	}
+
+	public static class UnidentifiableType {
+		private UnidentifiableType() {
+		}
+	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -642,4 +642,36 @@ class FixtureMonkeyV04Test {
 		).isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Wrong type filter is applied.");
 	}
+
+	@Property
+	void mapWhenNull() {
+		// when
+		String actual = SUT.giveMeBuilder(ComplexObject.class)
+			.setNull("str")
+			.map(ComplexObject::getStr)
+			.sample();
+
+		then(actual).isNull();
+	}
+
+	@Property
+	void mapWhenNotNull() {
+		// when
+		String actual = SUT.giveMeBuilder(ComplexObject.class)
+			.setNotNull("str")
+			.map(ComplexObject::getStr)
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@Property
+	void mapToFixedValue() {
+		// when
+		String actual = SUT.giveMeBuilder(ComplexObject.class)
+			.map(it -> "test")
+			.sample();
+
+		then(actual).isEqualTo("test");
+	}
 }


### PR DESCRIPTION
map 연산을 추가합니다.

map에서 타입이 식별 불가능한 경우 (값이 null인 경우) 에는 항상 null을 생성하는 NullArbitrayPropertyGenerator를 사용합니다.
ArbitraryBuilder에서 타입이 식별 불가능한 경우에는 연산을 적용하지 못합니다.