### PR TITLE
Refactor LazyValue similar to Kotlin Lazy

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/lazy/LazyArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/lazy/LazyArbitrary.java
@@ -1,0 +1,52 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.lazy;
+
+import java.util.function.Supplier;
+
+public interface LazyArbitrary<T> {
+	T getValue();
+
+	boolean isInitialized();
+
+	void clear();
+
+	static <T> LazyArbitrary<T> lazy(Supplier<T> initializer, boolean fixed, LazyThreadSafetyMode mode) {
+		if (mode == LazyThreadSafetyMode.NONE) {
+			return new UnSafeLazyArbitraryImpl<>(initializer, fixed);
+		}
+		throw new IllegalArgumentException("Unsupported lazy thread safety mode: " + mode);
+	}
+
+	static <T> LazyArbitrary<T> lazy(Supplier<T> initializer, LazyThreadSafetyMode mode) {
+		return lazy(initializer, false, mode);
+	}
+
+	static <T> LazyArbitrary<T> lazy(Supplier<T> initializer) {
+		return lazy(initializer, LazyThreadSafetyMode.NONE);
+	}
+
+	static <T> LazyArbitrary<T> lazy(Supplier<T> initializer, boolean fixed) {
+		return lazy(initializer, fixed, LazyThreadSafetyMode.NONE);
+	}
+
+	enum LazyThreadSafetyMode {
+		NONE
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArrayArbitraryNodeGenerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import net.jqwik.api.Arbitraries;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.generator.FieldNameResolver;
 
 public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenerator {
@@ -36,14 +37,14 @@ public class ArrayArbitraryNodeGenerator implements ContainerArbitraryNodeGenera
 		ArbitraryType<T> clazz = containerNode.getType();
 		ArbitraryType<?> childType = clazz.getArrayArbitraryType();
 		String propertyName = containerNode.getPropertyName();
-		LazyValue<T> lazyValue = containerNode.getValue();
+		LazyArbitrary<T> lazyValue = containerNode.getValue();
 
 		List<ArbitraryNode<?>> generatedNodeList = new ArrayList<>();
 
 		int elementSize = containerNode.getElementSize();
 
 		if (lazyValue != null) {
-			T value = lazyValue.get();
+			T value = lazyValue.getValue();
 
 			if (value == null) {
 				containerNode.setArbitrary(Arbitraries.just(null));

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/DefaultContainerArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/DefaultContainerArbitraryNodeGenerator.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import net.jqwik.api.Arbitraries;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.generator.FieldNameResolver;
 
 public class DefaultContainerArbitraryNodeGenerator implements ContainerArbitraryNodeGenerator {
@@ -37,7 +38,7 @@ public class DefaultContainerArbitraryNodeGenerator implements ContainerArbitrar
 		int currentIndex = 0;
 
 		ArbitraryType<T> clazz = containerNode.getType();
-		LazyValue<T> lazyValue = containerNode.getValue();
+		LazyArbitrary<T> lazyValue = containerNode.getValue();
 		String propertyName = containerNode.getPropertyName();
 		ArbitraryType<?> elementType = clazz.getGenericArbitraryType(0);
 
@@ -46,11 +47,11 @@ public class DefaultContainerArbitraryNodeGenerator implements ContainerArbitrar
 		int elementSize = containerNode.getElementSize();
 
 		if (lazyValue != null) {
-			if (lazyValue.isEmpty()) {
+			if (lazyValue.getValue() == null) {
 				containerNode.setArbitrary(Arbitraries.just(null));
 				return generatedNodeList;
 			}
-			T value = lazyValue.get();
+			T value = lazyValue.getValue();
 
 			if (!(value instanceof Collection || value instanceof Iterator || value instanceof Stream)) {
 				throw new IllegalArgumentException(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/MapArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/MapArbitraryNodeGenerator.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import net.jqwik.api.Arbitraries;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.generator.FieldNameResolver;
 
 @SuppressWarnings("unchecked")
@@ -33,9 +34,9 @@ public class MapArbitraryNodeGenerator implements ContainerArbitraryNodeGenerato
 	public <T> List<ArbitraryNode<?>> generate(ArbitraryNode<T> containerNode) {
 		List<ArbitraryNode<?>> generatedNodeList = new ArrayList<>();
 
-		LazyValue<T> lazyValue = containerNode.getValue();
+		LazyArbitrary<T> lazyValue = containerNode.getValue();
 		if (lazyValue != null) {
-			containerNode.setArbitrary(Arbitraries.just(lazyValue.get()));
+			containerNode.setArbitrary(Arbitraries.just(lazyValue.getValue()));
 			return generatedNodeList;
 		}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/OptionalArbitraryNodeGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/OptionalArbitraryNodeGenerator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.generator.FieldNameResolver;
 
 public class OptionalArbitraryNodeGenerator implements ContainerArbitraryNodeGenerator {
@@ -35,9 +36,9 @@ public class OptionalArbitraryNodeGenerator implements ContainerArbitraryNodeGen
 		ArbitraryType<?> elementType = arbitraryType.getGenericArbitraryType(0);
 		String propertyName = containerNode.getPropertyName();
 
-		LazyValue<?> nextLazyValue = getNextLazyValue(containerNode.getValue());
+		LazyArbitrary<?> nextLazyValue = getNextLazyValue(containerNode.getValue());
 
-		if (nextLazyValue != null && nextLazyValue.isEmpty()) {
+		if (nextLazyValue != null && nextLazyValue.getValue() == null) {
 			// can not generate Optional empty by ArbitraryGenerator
 			return generatedNodeList;
 		}
@@ -63,15 +64,15 @@ public class OptionalArbitraryNodeGenerator implements ContainerArbitraryNodeGen
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T, U> LazyValue<U> getNextLazyValue(LazyValue<T> lazyValue) {
+	private <T, U> LazyArbitrary<U> getNextLazyValue(LazyArbitrary<T> lazyValue) {
 		if (lazyValue == null) {
 			return null;
 		}
 
-		T value = lazyValue.get();
+		T value = lazyValue.getValue();
 
 		Optional<U> optional = ((Optional<U>)value);
 		U nextObject = optional.orElse(null);
-		return new LazyValue<>(() -> nextObject);
+		return LazyArbitrary.lazy(() -> nextObject, true);
 	}
 }


### PR DESCRIPTION
LazyValue를 LazyArbitrary로 변경하고 api 모듈로 이동합니다.
LazyArbitrary는 Kotlin의 Lazy와 유사한 구조로 변경하여 일반적인 Lazy 객체 표현에 사용할 수 있습니다.