### PR TITLE
Fix NullPointerException when using IterableSpec any()

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -174,6 +174,7 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	public IterableSpec any(Object object) {
 		String allExpression = getFieldExpression(this.iterableName, "*", EMPTY_FIELD);
 		long limit = getRandomLimit();
+		limit = limit == 0 ? 1 : limit;
 		this.addSet(allExpression, object, limit);
 		return this;
 	}
@@ -218,13 +219,13 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	}
 
 	private long getRandomLimit() {
-		int minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE : this.minSize;
-		int maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE : this.maxSize;
-		if (minSize == maxSize) {
-			return minSize;
+		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1: this.minSize;
+		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
+		if (this.minSize.equals(this.maxSize)) {
+			return this.minSize;
 		}
 
-		return Randoms.nextInt(maxSize - minSize);
+		return Randoms.nextInt(this.maxSize - this.minSize);
 	}
 
 	private static class IterableSpecSet<T> {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -219,7 +219,7 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	}
 
 	private long getRandomLimit() {
-		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1: this.minSize;
+		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1 : this.minSize;
 		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
 		if (this.minSize.equals(this.maxSize)) {
 			return this.minSize;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -173,15 +173,11 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	@Override
 	public IterableSpec any(Object object) {
 		String allExpression = getFieldExpression(this.iterableName, "*", EMPTY_FIELD);
-		this.checkBoundary();
+		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1 : this.minSize;
+		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
 		long limit = getRandomLimit();
 		this.addSet(allExpression, object, limit);
 		return this;
-	}
-
-	private void checkBoundary() {
-		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1 : this.minSize;
-		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/DefaultIterableSpec.java
@@ -173,10 +173,15 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	@Override
 	public IterableSpec any(Object object) {
 		String allExpression = getFieldExpression(this.iterableName, "*", EMPTY_FIELD);
+		this.checkBoundary();
 		long limit = getRandomLimit();
-		limit = limit == 0 ? 1 : limit;
 		this.addSet(allExpression, object, limit);
 		return this;
+	}
+
+	private void checkBoundary() {
+		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1 : this.minSize;
+		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
 	}
 
 	@Override
@@ -219,13 +224,11 @@ final class DefaultIterableSpec implements IterableSpec, ExpressionSpecVisitor {
 	}
 
 	private long getRandomLimit() {
-		this.minSize = this.minSize == null ? DEFAULT_ELEMENT_MIN_SIZE + 1 : this.minSize;
-		this.maxSize = this.maxSize == null ? DEFAULT_ELEMENT_MAX_SIZE + this.minSize : this.maxSize;
 		if (this.minSize.equals(this.maxSize)) {
 			return this.minSize;
 		}
 
-		return Randoms.nextInt(this.maxSize - this.minSize);
+		return Randoms.nextInt(this.maxSize - this.minSize) + 1;
 	}
 
 	private static class IterableSpecSet<T> {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -645,11 +645,7 @@ class SimpleManipulatorTest {
 	void giveMeSpecListAnyWithoutSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values", it ->
-					it.any("set")
-				)
-			)
+			.spec(new ExpressionSpec().list("values", it -> it.any("set")))
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));
@@ -659,13 +655,10 @@ class SimpleManipulatorTest {
 	void giveMeSpecListAnyWithoutMaxSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values", it -> {
-						it.ofMinSize(2);
-						it.any("set");
-					}
-				)
-			)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofMinSize(2);
+				it.any("set");
+			}))
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));
@@ -675,13 +668,10 @@ class SimpleManipulatorTest {
 	void giveMeSpecListAnyWithoutMinSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values", it -> {
-						it.ofMaxSize(2);
-						it.any("set");
-					}
-				)
-			)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofMaxSize(2);
+				it.any("set");
+			}))
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -642,6 +642,52 @@ class SimpleManipulatorTest {
 	}
 
 	@Property
+	void giveMeSpecListAnyWithoutSize() {
+		// when
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values", it ->
+					it.any("set")
+				)
+			)
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecListAnyWithoutMaxSize() {
+		// when
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values", it -> {
+						it.ofMinSize(2);
+						it.any("set");
+					}
+				)
+			)
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecListAnyWithoutMinSize() {
+		// when
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values", it -> {
+						it.ofMaxSize(2);
+						it.any("set");
+					}
+				)
+			)
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
 	void giveMeSpecListAllSet() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SimpleManipulatorTest.java
@@ -656,7 +656,7 @@ class SimpleManipulatorTest {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
-				it.ofMinSize(2);
+				it.ofMinSize(5);
 				it.any("set");
 			}))
 			.sample();


### PR DESCRIPTION
Resolve #323 

IterableSpec any에서 size를 지정하지 않았을 때 ( 혹은 min , max 중 하나만 지정한 경우 ) , 발생하는 문제를 해결하였습니다.

#323 이슈에서 언급되었던 `Arbitraries.longs().between(this.minSize, this.maxSize).sample();` 코드는 39179a10a91be65e9a8a1883715748460869b6c8 에서 수정되었음을 확인했습니다.

따라서 다른 곳에서 문제점이 있음을 인지하고, 파악하였으며 파악한 문제점은 아래와 같습니다.

1. random에 의해 limit이 0으로 설정되었을 때, `ArbitrarySet` 클래스의 `getApplicableValue()`에 의해  sample이 생성되지 않는 경우
    - 리스트에 any에서 할당한 값이 설정되지 않는 경우
2. max가 설정되지 않고, min은 설정되었지만 min이 `DEFAULT_ELEMENT_MAX_SIZE`보다 큰 경우
    - boundary 관련 exception이 발생하는 경우
3. max, min이 둘 다 설정되지 않았을 때, `DEFAULT_ELEMENT_MIN_SIZE` 에 의해 size가 0인 list가 반환되는 경우
    - 반환된 리스트가 빈 리스트인 경우

위 3가지 문제를 해결하고, 테스트 코드를 추가하였습니다.