### PR TITLE
Add InnerSpec entry

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -195,6 +197,50 @@ class InnerSpecTest {
 			.map(SimpleObject::getStr).collect(Collectors.toList());
 
 		then(fieldList).contains("test");
+	}
+
+	@Property
+	void mapSetEntryKeyAddEntry() {
+		MapObject actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner("mapValueMap", m -> {
+				m.entry("key1", v-> {
+					v.entry("key2", "value");
+				});
+			})
+			.sample();
+
+		Map<String, String> value = actual.getMapValueMap().get("key1");
+		then(value.get("key2")).isEqualTo("value");
+	}
+
+	@Property
+	void mapSetEntryValueAddEntry() {
+		MapObject actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner("mapKeyMap", m -> {
+				m.entry(k-> {
+					k.entry("key", "value2");
+				}, "value1");
+			})
+			.sample();
+
+		Map<String, String> key = null;
+		for (Entry<Map<String, String>, String> entry : actual.getMapKeyMap().entrySet()) {
+			if (entry.getValue() != null && entry.getValue().equals("value1")) {
+				key = entry.getKey();
+			}
+		}
+		then(key.get("key")).isEqualTo("value2");
+	}
+
+	@Property
+	void mapSetEntryValueNull() {
+		MapObject actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner("strMap", m -> {
+				m.entry("key", null);
+			})
+			.sample();
+
+		then(actual.getStrMap().get("key")).isNull();
 	}
 
 	@Property

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -98,14 +98,14 @@ class InnerSpecTest {
 	void mapAddKeyAddKey() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapKeyMap", m -> {
-				m.key(k-> {
+				m.key(k -> {
 					k.key("key");
 				});
 			})
 			.sample();
 
 		List<String> keyList = actual.getMapKeyMap().keySet().stream()
-			.flatMap(it->it.keySet().stream()).collect(Collectors.toList());
+			.flatMap(it -> it.keySet().stream()).collect(Collectors.toList());
 		then(keyList).contains("key");
 	}
 
@@ -113,14 +113,14 @@ class InnerSpecTest {
 	void mapAddKeyAddValue() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapKeyMap", m -> {
-				m.key(k-> {
+				m.key(k -> {
 					k.value("value");
 				});
 			})
 			.sample();
 
 		List<String> keyList = actual.getMapKeyMap().keySet().stream()
-			.flatMap(it->it.values().stream()).collect(Collectors.toList());
+			.flatMap(it -> it.values().stream()).collect(Collectors.toList());
 		then(keyList).contains("value");
 	}
 
@@ -128,14 +128,14 @@ class InnerSpecTest {
 	void mapAddValueAddKey() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapValueMap", m -> {
-				m.value(v-> {
+				m.value(v -> {
 					v.key("key");
 				});
 			})
 			.sample();
 
 		List<String> valueList = actual.getMapValueMap().values().stream()
-			.flatMap(it-> it.keySet().stream()).collect(Collectors.toList());
+			.flatMap(it -> it.keySet().stream()).collect(Collectors.toList());
 		then(valueList).contains("key");
 	}
 
@@ -143,14 +143,14 @@ class InnerSpecTest {
 	void mapAddValueAddValue() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapValueMap", m -> {
-				m.value(v-> {
+				m.value(v -> {
 					v.value("value");
 				});
 			})
 			.sample();
 
 		List<String> valueList = actual.getMapValueMap().values().stream()
-			.flatMap(it-> it.values().stream()).collect(Collectors.toList());
+			.flatMap(it -> it.values().stream()).collect(Collectors.toList());
 		then(valueList).contains("value");
 	}
 
@@ -158,11 +158,12 @@ class InnerSpecTest {
 	void mapSetValueSize() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("listValueMap", m -> {
-				m.value(v-> {
+				m.value(v -> {
 					v.size(10);
 				});
 			})
 			.sample();
+
 		List<Integer> sizeList = actual.getListValueMap().values().stream()
 			.map(List::size).collect(Collectors.toList());
 		then(sizeList).contains(10);
@@ -172,12 +173,13 @@ class InnerSpecTest {
 	void mapSetValueListElement() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("listValueMap", m -> {
-				m.value(v-> {
+				m.value(v -> {
 					v.size(1);
 					v.listElement(0, "test");
 				});
 			})
 			.sample();
+
 		List<String> elementList = actual.getListValueMap().values().stream()
 			.flatMap(List::stream).collect(Collectors.toList());
 		then(elementList).contains("test");
@@ -187,7 +189,7 @@ class InnerSpecTest {
 	void mapSetValueProperty() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("objectValueMap", m -> {
-				m.value(v-> {
+				m.value(v -> {
 					v.property("str", "test");
 				});
 			})
@@ -195,7 +197,6 @@ class InnerSpecTest {
 
 		List<String> fieldList = actual.getObjectValueMap().values().stream().filter(Objects::nonNull)
 			.map(SimpleObject::getStr).collect(Collectors.toList());
-
 		then(fieldList).contains("test");
 	}
 
@@ -203,7 +204,7 @@ class InnerSpecTest {
 	void mapSetEntryKeyAddEntry() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapValueMap", m -> {
-				m.entry("key1", v-> {
+				m.entry("key1", v -> {
 					v.entry("key2", "value");
 				});
 			})
@@ -217,19 +218,20 @@ class InnerSpecTest {
 	void mapSetEntryValueAddEntry() {
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner("mapKeyMap", m -> {
-				m.entry(k-> {
+				m.entry(k -> {
 					k.entry("key", "value2");
 				}, "value1");
 			})
 			.sample();
 
-		Map<String, String> key = null;
-		for (Entry<Map<String, String>, String> entry : actual.getMapKeyMap().entrySet()) {
-			if (entry.getValue() != null && entry.getValue().equals("value1")) {
-				key = entry.getKey();
-			}
-		}
-		then(key.get("key")).isEqualTo("value2");
+		Map<String, String> expected = actual.getMapKeyMap().entrySet()
+			.stream()
+			.filter(it -> "value1".equals(it.getValue()))
+			.findAny()
+			.get()
+			.getKey();
+
+		then(expected.get("key")).isEqualTo("value2");
 	}
 
 	@Property
@@ -248,7 +250,7 @@ class InnerSpecTest {
 		ListObject actual = SUT.giveMeBuilder(ListObject.class)
 			.setInner("listListStr", m -> {
 				m.size(1);
-				m.listElement(0, l-> {
+				m.listElement(0, l -> {
 					l.size(1);
 					l.listElement(0, "test");
 				});
@@ -262,7 +264,7 @@ class InnerSpecTest {
 	void objectSetPropertySetProperty() {
 		ObjectObject actual = SUT.giveMeBuilder(ObjectObject.class)
 			.setInner("complexObject", m -> {
-				m.property("simpleObject", o-> {
+				m.property("simpleObject", o -> {
 					o.property("str", "test");
 				});
 			})


### PR DESCRIPTION
InnerSpec의 key(consumer), value(consumer) 메소드를 사용하여 entry를 추가할 때 각각 해당 entry의 value, key 노드는 설정할 수 없는 문제가 있었습니다.
이를 해결하기 위해 consumer를 받는 새로운 entry 메소드 2개를 추가합니다.

- **entry(Object key, Consumer<InnerSpec> consumer)**: key가 설정된 Entry추가, value는 consumer로 설정
- **entry(Consumer<InnerSpec> consumer, @Nullable Object value)**: value가 설정된 entry추가, key는 consumer로 설정

