### PR TITLE
Add ArbitraryPropertyGenerator options

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -22,6 +22,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.expression.MonkeyExpressionFactory;
@@ -52,6 +53,31 @@ public class LabMonkeyBuilder {
 
 	public LabMonkeyBuilder defaultArbitraryPropertyGenerator(ArbitraryPropertyGenerator arbitraryPropertyGenerator) {
 		generateOptionsBuilder.defaultArbitraryPropertyGenerator(arbitraryPropertyGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushAssignableTypeArbitraryPropertyGenerator(
+		Class<?> type,
+		ArbitraryPropertyGenerator arbitraryPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(type, arbitraryPropertyGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushExactTypeArbitraryPropertyGenerator(
+		Class<?> type,
+		ArbitraryPropertyGenerator arbitraryPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(
+			MatcherOperator.exactTypeMatchOperator(type, arbitraryPropertyGenerator)
+		);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushArbitraryPropertyGenerator(
+		MatcherOperator<ArbitraryPropertyGenerator> arbitraryPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(arbitraryPropertyGenerator);
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -1,0 +1,27 @@
+
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.test;
+
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
+
+class FixtureMonkeyV04OptionsAdditionalTestSpecs {
+	public static class SimpleObjectChild extends SimpleObject {
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -25,9 +25,13 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.resolver.RootNodeResolver;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.SimpleObjectChild;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 
 class FixtureMonkeyV04OptionsTest {
 	@Property
@@ -76,6 +80,70 @@ class FixtureMonkeyV04OptionsTest {
 			.build();
 
 		ComplexObject actual = sut.giveMeOne(ComplexObject.class);
+
+		then(actual).isNull();
+	}
+
+	@Property
+	void pushAssignableTypeArbitraryPropertyGenerator() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.pushAssignableTypeArbitraryPropertyGenerator(
+				SimpleObject.class,
+				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+					.withNullInject(1.0)
+			)
+			.build();
+
+		SimpleObjectChild actual = sut.giveMeOne(SimpleObjectChild.class);
+
+		then(actual).isNull();
+	}
+
+	@Property
+	void pushExactTypeArbitraryPropertyGenerator() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.pushExactTypeArbitraryPropertyGenerator(
+				SimpleObjectChild.class,
+				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+					.withNullInject(1.0)
+			)
+			.build();
+
+		SimpleObjectChild actual = sut.giveMeOne(SimpleObjectChild.class);
+
+		then(actual).isNull();
+	}
+
+	@Property
+	void pushExactTypeArbitraryPropertyGeneratorNotAffectsAssignable() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.pushExactTypeArbitraryPropertyGenerator(
+				SimpleObject.class,
+				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+					.withNullInject(1.0)
+			)
+			.build();
+
+		SimpleObjectChild actual = sut.giveMeOne(SimpleObjectChild.class);
+
+		then(actual).isNotNull();
+	}
+
+	@Property
+	void pushArbitraryPropertyGenerator() {
+		ArbitraryPropertyGenerator arbitraryPropertyGenerator = (context) ->
+			ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+				.withNullInject(1.0);
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.pushArbitraryPropertyGenerator(
+				MatcherOperator.exactTypeMatchOperator(
+					SimpleObject.class,
+					arbitraryPropertyGenerator
+				)
+			)
+			.build();
+
+		SimpleObject actual = sut.giveMeOne(SimpleObject.class);
 
 		then(actual).isNull();
 	}


### PR DESCRIPTION
ArbitraryPropertyGenerator를 변경하는 옵션을 추가합니다.

insertFirst가 의미가 Stack의 연산인 `push`와 동일한 의미이고, 사용자 입장에서 표현이 간결한 것 같아 변경해보았습니다.
의견 부탁드립니다.