### PR TITLE
Enhance checks and reporting by GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.Java }}
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Check with Gradle
-        run: ./gradlew check
+      - name: Execute check
+        uses: gradle/gradle-build-action@v2.2.1
+        with:
+          arguments: check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,36 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
-    name: JDK ${{ matrix.java }}
+  static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 8
+      - name: Execute check without tests
+        uses: gradle/gradle-build-action@v2.2.1
+        with:
+          arguments: check -x test
+
+      - name: Publish SpotBugs report
+        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        if: always()
+        with:
+          name: SpotBugs Report
+          path: '**/build/reports/spotbugs/main.xml'
+
+      - name: Publish Checkstyle report
+        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        if: always()
+        with:
+          name: Checkstyle Report
+          path: '**/build/reports/checkstyle/*.xml'
+  test:
+    name: Testing on JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,24 +49,10 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.Java }}
-      - name: Execute check
+      - name: Execute tests
         uses: gradle/gradle-build-action@v2.2.1
         with:
-          arguments: check
-
-      - name: Publish SpotBugs report
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
-        if: always()
-        with:
-          name: SpotBugs Report on JDK ${{ matrix.Java }}
-          path: '**/build/reports/spotbugs/main.xml'
-
-      - name: Publish Checkstyle report
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
-        if: always()
-        with:
-          name: Checkstyle Report on JDK ${{ matrix.Java }}
-          path: '**/build/reports/checkstyle/*.xml'
+          arguments: test
 
       - name: Publish test report
         uses: mikepenz/action-junit-report@v3.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Execute check without tests
         uses: gradle/gradle-build-action@v2.2.1
@@ -47,7 +47,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.Java }}
       - name: Execute tests
         uses: gradle/gradle-build-action@v2.2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,30 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.1
         with:
           arguments: check
+
+      - name: Publish SpotBugs report
+        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        if: always()
+        with:
+          name: SpotBugs Report on JDK ${{ matrix.Java }}
+          path: '**/build/reports/spotbugs/main.xml'
+
+      - name: Publish Checkstyle report
+        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        if: always()
+        with:
+          name: Checkstyle Report on JDK ${{ matrix.Java }}
+          path: '**/build/reports/checkstyle/*.xml'
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v3.0.3
+        if: always() # always run even if the previous step fails
+        with:
+          check_name: JUnit Test Report on JDK ${{ matrix.Java }}
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      - name: Test Summary
+        uses: test-summary/action@v1
+        if: always()
+        with:
+          paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Gradle check
 
 on:
   push:
@@ -8,11 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  check:
+    name: JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '16', '17' ]
+        java: [ '8', '11', '17' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -22,5 +23,5 @@ jobs:
           java-version: ${{ matrix.Java }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: Check with Gradle
+        run: ./gradlew check


### PR DESCRIPTION
- Remove JDK 16 from job matrix
    - Support LTS version of JDKs for efficiency. 
- Remove duplicated executions of SpotBugs, Checkstyle on every JDK versoins. 
- Change testing job names including 'JDK {version}', it makes more readability.
    - Before : ![image](https://user-images.githubusercontent.com/910151/178132760-0d286945-fcd3-460a-9a4b-e555a621ae3b.png)
    - After : ![image](https://user-images.githubusercontent.com/910151/178138706-04082c09-0ba2-46f5-b7e6-0108c9017b4f.png)
- Execute 'check' task, instead of 'build' task.
    - This workflow does not need  'jar' files.
- Use gradle-build-action for more efficient caching.
    - https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action 
- Add GtiHub Actions for reporting
    - [test-summary/action](https://github.com/test-summary/action)
    - [mikepenz/action-junit-report](https://github.com/mikepenz/action-junit-report)
    - [jwgmeligmeyling/spotbugs-github-action](https://github.com/jwgmeligmeyling/spotbugs-github-action)
    - [jwgmeligmeyling/checkstyle-github-action](https://github.com/jwgmeligmeyling/checkstyle-github-action)
- Change JDK distribution from AdoptOpenJDK to Temurin
    -  Temurin is successor of AdoptOpenJDK.