### PR TITLE
Refactor Exp for resolving ambiguity

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -42,10 +42,10 @@ class Exp<T> internal constructor(private val delegate: ExpressionGenerator) : E
         Exp(delegate.join(PropertyExpressionGenerator(KotlinProperty(property))))
 
     @JvmName("getterBoolean")
-    infix fun into(getter: KFunction1<T, Boolean>): Exp<Boolean> =
+    infix fun intoGetter(getter: KFunction1<T, Boolean>): Exp<Boolean> =
         Exp(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
 
-    infix fun <R> into(getter: KFunction1<T, R?>): Exp<R> =
+    infix fun <R> intoGetter(getter: KFunction1<T, R?>): Exp<R> =
         Exp(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
 
     infix fun <R> into(exp: ExpList<T, R>): Exp<R> = Exp(delegate.join(exp))
@@ -55,7 +55,7 @@ class Exp<T> internal constructor(private val delegate: ExpressionGenerator) : E
         ExpList(delegate.join(PropertyExpressionGenerator(KotlinProperty(property))))
 
     @JvmName("getterIntoList")
-    infix fun <R : Collection<E>, E : Any> into(getter: KFunction1<T, R?>): ExpList<T, E> =
+    infix fun <R : Collection<E>, E : Any> intoGetter(getter: KFunction1<T, R?>): ExpList<T, E> =
         ExpList(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
 }
 
@@ -63,10 +63,11 @@ fun <T, R> Exp(expList: ExpList<T, R>) = Exp<R>(expList)
 
 fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<R>(PropertyExpressionGenerator(KotlinProperty(property)))
 
-fun <T, R> Exp(property: KFunction1<T, R?>) = Exp<R>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
+fun <T, R> ExpGetter(property: KFunction1<T, R?>) = Exp<R>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
 
 @JvmName("getterBoolean")
-fun Exp(property: KFunction1<*, Boolean>) = Exp<Boolean>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
+fun ExpGetter(property: KFunction1<*, Boolean>) =
+    Exp<Boolean>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
 
 fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
     this.set(PropertyExpressionGenerator(KotlinProperty(property)), value)
@@ -74,26 +75,16 @@ fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?): Arb
 fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
     this.set(PropertyExpressionGenerator(KotlinProperty(property)), value, limit.toInt())
 
-fun <T> ArbitraryBuilder<T>.set(property: KFunction1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinGetterProperty(property)), value)
-
-fun <T> ArbitraryBuilder<T>.set(property: KFunction1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
-    this.set(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        value,
-        limit.toInt()
-    )
-
 fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
     this.set(PropertyExpressionGenerator(KotlinProperty(property)), value)
 
 fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
     this.set(PropertyExpressionGenerator(KotlinProperty(property)), value, limit.toInt())
 
-fun <T> ArbitraryBuilder<T>.setExp(property: KFunction1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
+fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
     this.set(PropertyExpressionGenerator(KotlinGetterProperty(property)), value)
 
-fun <T> ArbitraryBuilder<T>.setExp(property: KFunction1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
+fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
     this.set(
         PropertyExpressionGenerator(KotlinGetterProperty(property)),
         value,
@@ -113,13 +104,10 @@ fun <T> ArbitraryBuilder<T>.setExp(
 fun <T> ArbitraryBuilder<T>.setNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
     this.setNull(PropertyExpressionGenerator(KotlinProperty(property)))
 
-fun <T> ArbitraryBuilder<T>.setNull(property: KFunction1<T, *>): ArbitraryBuilder<T> =
-    this.setNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
 fun <T> ArbitraryBuilder<T>.setNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
     this.setNull(PropertyExpressionGenerator(KotlinProperty(property)))
 
-fun <T> ArbitraryBuilder<T>.setNullExp(property: KFunction1<T, *>): ArbitraryBuilder<T> =
+fun <T> ArbitraryBuilder<T>.setNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
     this.setNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
 
 fun <T> ArbitraryBuilder<T>.setNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
@@ -128,13 +116,10 @@ fun <T> ArbitraryBuilder<T>.setNullExp(expressionGenerator: ExpressionGenerator)
 fun <T> ArbitraryBuilder<T>.setNotNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
     this.setNotNull(PropertyExpressionGenerator(KotlinProperty(property)))
 
-fun <T> ArbitraryBuilder<T>.setNotNull(property: KFunction1<T, *>): ArbitraryBuilder<T> =
-    this.setNotNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
 fun <T> ArbitraryBuilder<T>.setNotNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
     this.setNotNull(PropertyExpressionGenerator(KotlinProperty(property)))
 
-fun <T> ArbitraryBuilder<T>.setNotNullExp(property: KFunction1<T, *>): ArbitraryBuilder<T> =
+fun <T> ArbitraryBuilder<T>.setNotNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
     this.setNotNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
 
 fun <T> ArbitraryBuilder<T>.setNotNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
@@ -143,7 +128,7 @@ fun <T> ArbitraryBuilder<T>.setNotNullExp(expressionGenerator: ExpressionGenerat
 fun <T, U> ArbitraryBuilder<T>.setPostCondition(
     property: KProperty1<T, *>,
     clazz: Class<U>,
-    filter: Predicate<U>,
+    filter: Predicate<U>
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinProperty(property)),
@@ -152,23 +137,10 @@ fun <T, U> ArbitraryBuilder<T>.setPostCondition(
     )
 
 fun <T, U> ArbitraryBuilder<T>.setPostCondition(
-    property: KFunction1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long,
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostCondition(
     property: KProperty1<T, *>,
     clazz: Class<U>,
     filter: Predicate<U>,
-    limit: Long,
+    limit: Long
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinProperty(property)),
@@ -177,21 +149,10 @@ fun <T, U> ArbitraryBuilder<T>.setPostCondition(
         limit.toInt()
     )
 
-fun <T, U> ArbitraryBuilder<T>.setPostCondition(
-    property: KFunction1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        clazz,
-        filter
-    )
-
 fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
     property: KProperty1<T, *>,
     clazz: Class<U>,
-    filter: Predicate<U>,
+    filter: Predicate<U>
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinProperty(property)),
@@ -199,11 +160,11 @@ fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
         filter
     )
 
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
     property: KFunction1<T, *>,
     clazz: Class<U>,
     filter: Predicate<U>,
-    limit: Long,
+    limit: Long
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinGetterProperty(property)),
@@ -216,7 +177,7 @@ fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
     property: KProperty1<T, *>,
     clazz: Class<U>,
     filter: Predicate<U>,
-    limit: Long,
+    limit: Long
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinProperty(property)),
@@ -225,10 +186,10 @@ fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
         limit.toInt()
     )
 
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
     property: KFunction1<T, *>,
     clazz: Class<U>,
-    filter: Predicate<U>,
+    filter: Predicate<U>
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         PropertyExpressionGenerator(KotlinGetterProperty(property)),
@@ -240,7 +201,7 @@ fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
     expressionGenerator: ExpressionGenerator,
     clazz: Class<U>,
     filter: Predicate<U>,
-    limit: Long,
+    limit: Long
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         expressionGenerator,
@@ -252,7 +213,7 @@ fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
 fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
     expressionGenerator: ExpressionGenerator,
     clazz: Class<U>,
-    filter: Predicate<U>,
+    filter: Predicate<U>
 ): ArbitraryBuilder<T> =
     this.setPostCondition(
         expressionGenerator,
@@ -265,12 +226,6 @@ fun <T> ArbitraryBuilder<T>.size(
     size: Int
 ): ArbitraryBuilder<T> =
     this.size(PropertyExpressionGenerator(KotlinProperty(property)), size)
-
-fun <T> ArbitraryBuilder<T>.size(
-    property: KFunction1<T, *>,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinGetterProperty(property)), size)
 
 fun <T> ArbitraryBuilder<T>.size(
     property: KProperty1<T, *>,
@@ -279,20 +234,13 @@ fun <T> ArbitraryBuilder<T>.size(
 ): ArbitraryBuilder<T> =
     this.size(PropertyExpressionGenerator(KotlinProperty(property)), min, max)
 
-fun <T> ArbitraryBuilder<T>.size(
-    property: KFunction1<T, *>,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinGetterProperty(property)), min, max)
-
 fun <T> ArbitraryBuilder<T>.sizeExp(
     property: KProperty1<T, *>,
     size: Int
 ): ArbitraryBuilder<T> =
     this.size(PropertyExpressionGenerator(KotlinProperty(property)), size)
 
-fun <T> ArbitraryBuilder<T>.sizeExp(
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
     property: KFunction1<T, *>,
     size: Int
 ): ArbitraryBuilder<T> =
@@ -311,7 +259,7 @@ fun <T> ArbitraryBuilder<T>.sizeExp(
 ): ArbitraryBuilder<T> =
     this.size(PropertyExpressionGenerator(KotlinProperty(property)), min, max)
 
-fun <T> ArbitraryBuilder<T>.sizeExp(
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
     property: KFunction1<T, *>,
     min: Int,
     max: Int
@@ -331,19 +279,13 @@ fun <T> ArbitraryBuilder<T>.minSize(
 ): ArbitraryBuilder<T> =
     this.minSize(PropertyExpressionGenerator(KotlinProperty(property)), min)
 
-fun <T> ArbitraryBuilder<T>.minSize(
-    property: KFunction1<T, *>,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(PropertyExpressionGenerator(KotlinGetterProperty(property)), min)
-
 fun <T> ArbitraryBuilder<T>.minSizeExp(
     property: KProperty1<T, *>,
     min: Int
 ): ArbitraryBuilder<T> =
     this.minSize(PropertyExpressionGenerator(KotlinProperty(property)), min)
 
-fun <T> ArbitraryBuilder<T>.minSizeExp(
+fun <T> ArbitraryBuilder<T>.minSizeExpGetter(
     property: KFunction1<T, *>,
     min: Int
 ): ArbitraryBuilder<T> =
@@ -361,19 +303,13 @@ fun <T> ArbitraryBuilder<T>.maxSize(
 ): ArbitraryBuilder<T> =
     this.maxSize(PropertyExpressionGenerator(KotlinProperty(property)), max)
 
-fun <T> ArbitraryBuilder<T>.maxSize(
-    property: KFunction1<T, *>,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(PropertyExpressionGenerator(KotlinGetterProperty(property)), max)
-
 fun <T> ArbitraryBuilder<T>.maxSizeExp(
     property: KProperty1<T, *>,
     max: Int
 ): ArbitraryBuilder<T> =
     this.maxSize(PropertyExpressionGenerator(KotlinProperty(property)), max)
 
-fun <T> ArbitraryBuilder<T>.maxSizeExp(
+fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
     property: KFunction1<T, *>,
     max: Int
 ): ArbitraryBuilder<T> =
@@ -407,7 +343,7 @@ infix fun <T, R, E> KProperty1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
         )
     )
 
-infix fun <T, R, E> KFunction1<T, R?>.into(property: KFunction1<R, E?>): Exp<E> =
+infix fun <T, R, E> KFunction1<T, R?>.intoGetter(property: KFunction1<R, E?>): Exp<E> =
     Exp(
         JoinExpressionGenerator(
             listOf(
@@ -429,12 +365,10 @@ infix fun <T, R, E> KFunction1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
         )
     )
 
-infix operator
-fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): ExpList<T, E> =
+infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): ExpList<T, E> =
     ExpList(ArrayExpressionGenerator(KotlinProperty(this), index))
 
-infix operator
-fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, E> =
+infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, E> =
     ExpList(MapExpressionGenerator(KotlinProperty(this), key))
 
 @JvmName("getNestedList")

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
@@ -431,7 +431,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDogs
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getDogs
 
         // when
         val actual = generator.generate()
@@ -442,7 +442,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionFieldWithConstructor() {
         // given
-        val generator = Exp(PersonJava::getDogs)
+        val generator = ExpGetter(PersonJava::getDogs)
 
         // when
         val actual = generator.generate()
@@ -453,7 +453,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDog into DogJava::getName
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -464,7 +464,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithConstructor() {
         // given
-        val generator = Exp(PersonJava::getDog into DogJava::getName)
+        val generator = Exp(PersonJava::getDog intoGetter DogJava::getName)
 
         // when
         val actual = generator.generate()
@@ -475,7 +475,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithoutExp() {
         // given
-        val generator = PersonJava::getDog into DogJava::getName
+        val generator = PersonJava::getDog intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -486,7 +486,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDog into DogJava::getLoves[0]
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog into DogJava::getLoves[0]
 
         // when
         val actual = generator.generate()
@@ -508,7 +508,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithAllIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDog into DogJava::getLoves["*"]
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog into DogJava::getLoves["*"]
 
         // when
         val actual = generator.generate()
@@ -596,7 +596,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithAllIndexTwiceWithField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs["*"]["*"] into DogJava::getName
+        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs["*"]["*"] intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -607,7 +607,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression1() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs[1][2] into DogJava::getName
+        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs[1][2] intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -618,7 +618,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression2() {
         // given
-        val generator = Exp<PersonJava>() into (PersonJava::getNestedDogs get 1 get 2) into DogJava::getName
+        val generator = Exp<PersonJava>() into (PersonJava::getNestedDogs get 1 get 2) intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -631,7 +631,7 @@ class ExpressionGeneratorsTest {
         // given
         val generator = Exp<PersonJava>()
             .into((PersonJava::getNestedDogs)[1][2])
-            .into(DogJava::getName)
+            .intoGetter(DogJava::getName)
 
         // when
         val actual = generator.generate()
@@ -644,7 +644,7 @@ class ExpressionGeneratorsTest {
         // given
         val generator = Exp<PersonJava>()
             .into(PersonJava::getNestedDogs[1][2])
-            .into(DogJava::getName)
+            .intoGetter(DogJava::getName)
 
         // when
         val actual = generator.generate()
@@ -669,7 +669,7 @@ class ExpressionGeneratorsTest {
         // given
         val generator = Exp<PersonJava>()
             .into(PersonJava::getNestedThriceDogs[1][2][2])
-            .into(DogJava::getName)
+            .intoGetter(DogJava::getName)
 
         // when
         val actual = generator.generate()
@@ -680,7 +680,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun notGetter() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::notGetter
+        val generator = Exp<PersonJava>() intoGetter PersonJava::notGetter
 
         // when
         val actual = generator.generate()
@@ -691,7 +691,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNullableDog into DogJava::getName
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getNullableDog intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -702,7 +702,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableFieldWithConstructor() {
         // given
-        val generator = Exp(PersonJava::getNullableDog into DogJava::getName)
+        val generator = Exp(PersonJava::getNullableDog intoGetter DogJava::getName)
 
         // when
         val actual = generator.generate()
@@ -713,7 +713,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableFieldWithoutExp() {
         // given
-        val generator = PersonJava::getNullableDog into DogJava::getName
+        val generator = PersonJava::getNullableDog intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -724,7 +724,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableNestedField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNullableDog into DogJava::getNullableName
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getNullableDog intoGetter DogJava::getNullableName
 
         // when
         val actual = generator.generate()
@@ -735,7 +735,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableNestedFieldWithConstructor() {
         // given
-        val generator = Exp(PersonJava::getNullableDog into DogJava::getNullableName)
+        val generator = Exp(PersonJava::getNullableDog intoGetter DogJava::getNullableName)
 
         // when
         val actual = generator.generate()
@@ -900,7 +900,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterBoolean() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::isMarried
+        val generator = Exp<PersonJava>() intoGetter PersonJava::isMarried
 
         // when
         val actual = generator.generate()
@@ -911,7 +911,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterBooleanWithConstructor() {
         // given
-        val generator = Exp(PersonJava::isMarried)
+        val generator = ExpGetter(PersonJava::isMarried)
 
         // when
         val actual = generator.generate()
@@ -922,7 +922,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableBoolean() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getHappy
+        val generator = Exp<PersonJava>() intoGetter PersonJava::getHappy
 
         // when
         val actual = generator.generate()
@@ -933,7 +933,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableBooleanWithConstructor() {
         // given
-        val generator = Exp(PersonJava::getHappy)
+        val generator = ExpGetter(PersonJava::getHappy)
 
         // when
         val actual = generator.generate()


### PR DESCRIPTION
Exp의 기본 입력 타입을 `KProperty` 으로 설정하고 Java Getter를 입력받는 경우는 suffix `Getter`를 붙여 
입력한 메소드 레퍼런스 타입의 ambiguity를 해결합니다.