### PR TITLE
Add Java type ArbitraryGenerator options

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -52,8 +52,6 @@ import com.navercorp.fixturemonkey.api.introspector.UuidIntrospector;
 public final class DefaultArbitraryGenerator implements ArbitraryGenerator {
 	public static final ArbitraryIntrospector JAVA_INTROSPECTOR = new CompositeArbitraryIntrospector(
 		Arrays.asList(
-			new JavaArbitraryIntrospector(),
-			new JavaTimeArbitraryIntrospector(),
 			new BooleanIntrospector(),
 			new EnumIntrospector(),
 			new UuidIntrospector()

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -18,9 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -29,66 +26,17 @@ import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
-import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.EntryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.EnumIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.IterableIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.IteratorIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.ListIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.MapEntryElementIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.MapIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.OptionalIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.QueueIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.SetIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.StreamIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.TupleLikeElementsIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.UuidIntrospector;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class DefaultArbitraryGenerator implements ArbitraryGenerator {
-	public static final ArbitraryIntrospector JAVA_INTROSPECTOR = new CompositeArbitraryIntrospector(
-		Arrays.asList(
-			new BooleanIntrospector(),
-			new EnumIntrospector(),
-			new UuidIntrospector()
-		)
-	);
-	public static final ArbitraryIntrospector JAVA_CONTAINER_INTROSPECTOR = new CompositeArbitraryIntrospector(
-		Arrays.asList(
-			new OptionalIntrospector(),
-			new ListIntrospector(),
-			new SetIntrospector(),
-			new QueueIntrospector(),
-			new StreamIntrospector(),
-			new IterableIntrospector(),
-			new IteratorIntrospector(),
-			new MapIntrospector(),
-			new EntryIntrospector(),
-			new MapEntryElementIntrospector(),
-			new TupleLikeElementsIntrospector()
-		)
-	);
-
+public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 	private final ArbitraryIntrospector arbitraryIntrospector;
-
-	public DefaultArbitraryGenerator() {
-		this(
-			Arrays.asList(
-				JAVA_INTROSPECTOR,
-				JAVA_CONTAINER_INTROSPECTOR,
-				BeanArbitraryIntrospector.INSTANCE
-			)
-		);
-	}
-
-	public DefaultArbitraryGenerator(List<ArbitraryIntrospector> arbitraryIntrospectors) {
-		this.arbitraryIntrospector = new CompositeArbitraryIntrospector(arbitraryIntrospectors);
-	}
 
 	public DefaultArbitraryGenerator(ArbitraryIntrospector arbitraryIntrospector) {
 		this.arbitraryIntrospector = arbitraryIntrospector;
+	}
+
+	public static JavaDefaultArbitraryGeneratorBuilder javaBuilder() {
+		return new JavaDefaultArbitraryGeneratorBuilder();
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -36,8 +36,6 @@ import com.navercorp.fixturemonkey.api.introspector.EntryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.EnumIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IterableIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IteratorIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ListIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.MapEntryElementIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.MapIntrospector;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -1,0 +1,170 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.Arrays;
+import java.util.function.UnaryOperator;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.EntryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.EnumIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.IterableIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.IteratorIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.ListIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.MapEntryElementIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.MapIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.OptionalIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.QueueIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.SetIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.StreamIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.TupleLikeElementsIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.UuidIntrospector;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JavaDefaultArbitraryGeneratorBuilder {
+	public static final ArbitraryIntrospector JAVA_INTROSPECTOR = new CompositeArbitraryIntrospector(
+		Arrays.asList(
+			new BooleanIntrospector(),
+			new EnumIntrospector(),
+			new UuidIntrospector()
+		)
+	);
+	public static final ArbitraryIntrospector JAVA_CONTAINER_INTROSPECTOR = new CompositeArbitraryIntrospector(
+		Arrays.asList(
+			new OptionalIntrospector(),
+			new ListIntrospector(),
+			new SetIntrospector(),
+			new QueueIntrospector(),
+			new StreamIntrospector(),
+			new IterableIntrospector(),
+			new IteratorIntrospector(),
+			new MapIntrospector(),
+			new EntryIntrospector(),
+			new MapEntryElementIntrospector(),
+			new TupleLikeElementsIntrospector()
+		)
+	);
+
+	private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
+	};
+
+	private JavaArbitraryResolver javaArbitraryResolver = new JavaArbitraryResolver() {
+	};
+
+	private JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator = new JavaTimeTypeArbitraryGenerator() {
+	};
+
+	private JavaTimeArbitraryResolver javaTimeArbitraryResolver = new JavaTimeArbitraryResolver() {
+	};
+	private ArbitraryIntrospector priorityIntrospector = JavaDefaultArbitraryGeneratorBuilder.JAVA_INTROSPECTOR;
+	private ArbitraryIntrospector containerIntrospector =
+		JavaDefaultArbitraryGeneratorBuilder.JAVA_CONTAINER_INTROSPECTOR;
+	private ArbitraryIntrospector objectIntrospector = BeanArbitraryIntrospector.INSTANCE;
+
+	public JavaDefaultArbitraryGeneratorBuilder priorityIntrospector(ArbitraryIntrospector priorityIntrospector) {
+		this.priorityIntrospector = priorityIntrospector;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder priorityIntrospector(
+		UnaryOperator<ArbitraryIntrospector> priorityIntrospector
+	) {
+		this.priorityIntrospector = priorityIntrospector.apply(this.priorityIntrospector);
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder containerIntrospector(ArbitraryIntrospector containerIntrospector) {
+		this.containerIntrospector = containerIntrospector;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder containerIntrospector(
+		UnaryOperator<ArbitraryIntrospector> containerIntrospector
+	) {
+		this.containerIntrospector = containerIntrospector.apply(this.containerIntrospector);
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder objectIntrospector(ArbitraryIntrospector objectIntrospector) {
+		this.objectIntrospector = objectIntrospector;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder objectIntrospector(
+		UnaryOperator<ArbitraryIntrospector> objectIntrospector
+	) {
+		this.objectIntrospector = objectIntrospector.apply(this.objectIntrospector);
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder javaTypeArbitraryGenerator(
+		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
+	) {
+		this.javaTypeArbitraryGenerator = javaTypeArbitraryGenerator;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder javaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
+		this.javaArbitraryResolver = javaArbitraryResolver;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder javaTimeTypeArbitraryGenerator(
+		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
+	) {
+		this.javaTimeTypeArbitraryGenerator = javaTimeTypeArbitraryGenerator;
+		return this;
+	}
+
+	public JavaDefaultArbitraryGeneratorBuilder javaTimeArbitraryResolver(
+		JavaTimeArbitraryResolver javaTimeArbitraryResolver
+	) {
+		this.javaTimeArbitraryResolver = javaTimeArbitraryResolver;
+		return this;
+	}
+
+	public DefaultArbitraryGenerator build() {
+		return new DefaultArbitraryGenerator(
+			new CompositeArbitraryIntrospector(
+				Arrays.asList(
+					new JavaArbitraryIntrospector(javaTypeArbitraryGenerator, javaArbitraryResolver),
+					new JavaTimeArbitraryIntrospector(
+						javaTimeTypeArbitraryGenerator,
+						javaTimeArbitraryResolver
+					),
+					this.priorityIntrospector,
+					this.containerIntrospector,
+					this.objectIntrospector
+				)
+			)
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -89,6 +89,9 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 		JavaDefaultArbitraryGeneratorBuilder.JAVA_CONTAINER_INTROSPECTOR;
 	private ArbitraryIntrospector objectIntrospector = BeanArbitraryIntrospector.INSTANCE;
 
+	JavaDefaultArbitraryGeneratorBuilder() {
+	}
+
 	public JavaDefaultArbitraryGeneratorBuilder priorityIntrospector(ArbitraryIntrospector priorityIntrospector) {
 		this.priorityIntrospector = priorityIntrospector;
 		return this;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospector.java
@@ -39,18 +39,18 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 
 	public JavaArbitraryIntrospector() {
 		this(
-			new IntrospectorArbitraryGenerator() {
+			new JavaTypeArbitraryGenerator() {
 			},
-			new ArbitraryTypeIntrospector() {
+			new JavaArbitraryResolver() {
 			}
 		);
 	}
 
 	public JavaArbitraryIntrospector(
-		IntrospectorArbitraryGenerator introspectorArbitraryGenerator,
-		ArbitraryTypeIntrospector arbitraryIntrospector
+		JavaTypeArbitraryGenerator arbitraryGenerator,
+		JavaArbitraryResolver arbitraryResolver
 	) {
-		this.introspector = introspectors(introspectorArbitraryGenerator, arbitraryIntrospector);
+		this.introspector = introspectors(arbitraryGenerator, arbitraryResolver);
 	}
 
 	@Override
@@ -63,23 +63,23 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		Class<?> type = Types.getActualType(context.getType());
 		return this.introspector.getOrDefault(
-			type,
-			ctx -> ArbitraryIntrospectorResult.EMPTY
-		)
+				type,
+				ctx -> ArbitraryIntrospectorResult.EMPTY
+			)
 			.apply(context);
 	}
 
 	private static Map<Class<?>, Function<ArbitraryGeneratorContext, ArbitraryIntrospectorResult>> introspectors(
-		IntrospectorArbitraryGenerator introspectorArbitraryGenerator,
-		ArbitraryTypeIntrospector arbitraryIntrospector
+		JavaTypeArbitraryGenerator arbitraryGenerator,
+		JavaArbitraryResolver arbitraryResolver
 	) {
 		Map<Class<?>, Function<ArbitraryGeneratorContext, ArbitraryIntrospectorResult>> introspector = new HashMap<>();
 
 		introspector.put(
 			String.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.strings(
-					introspectorArbitraryGenerator.strings(),
+				arbitraryResolver.strings(
+					arbitraryGenerator.strings(),
 					ctx
 				)
 			)
@@ -88,8 +88,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			char.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.characters(
-					introspectorArbitraryGenerator.characters(),
+				arbitraryResolver.characters(
+					arbitraryGenerator.characters(),
 					ctx
 				)
 			)
@@ -98,8 +98,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Character.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.characters(
-					introspectorArbitraryGenerator.characters(),
+				arbitraryResolver.characters(
+					arbitraryGenerator.characters(),
 					ctx
 				)
 			)
@@ -108,8 +108,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			short.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.shorts(
-					introspectorArbitraryGenerator.shorts(),
+				arbitraryResolver.shorts(
+					arbitraryGenerator.shorts(),
 					ctx
 				)
 			)
@@ -118,8 +118,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Short.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.shorts(
-					introspectorArbitraryGenerator.shorts(),
+				arbitraryResolver.shorts(
+					arbitraryGenerator.shorts(),
 					ctx
 				)
 			)
@@ -128,8 +128,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			byte.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.bytes(
-					introspectorArbitraryGenerator.bytes(),
+				arbitraryResolver.bytes(
+					arbitraryGenerator.bytes(),
 					ctx
 				)
 			)
@@ -138,8 +138,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Byte.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.bytes(
-					introspectorArbitraryGenerator.bytes(),
+				arbitraryResolver.bytes(
+					arbitraryGenerator.bytes(),
 					ctx
 				)
 			)
@@ -148,8 +148,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			double.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.doubles(
-					introspectorArbitraryGenerator.doubles(),
+				arbitraryResolver.doubles(
+					arbitraryGenerator.doubles(),
 					ctx
 				)
 			)
@@ -158,8 +158,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Double.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.doubles(
-					introspectorArbitraryGenerator.doubles(),
+				arbitraryResolver.doubles(
+					arbitraryGenerator.doubles(),
 					ctx
 				)
 			)
@@ -168,8 +168,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			float.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.floats(
-					introspectorArbitraryGenerator.floats(),
+				arbitraryResolver.floats(
+					arbitraryGenerator.floats(),
 					ctx
 				)
 			)
@@ -178,8 +178,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Float.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.floats(
-					introspectorArbitraryGenerator.floats(),
+				arbitraryResolver.floats(
+					arbitraryGenerator.floats(),
 					ctx
 				)
 			)
@@ -188,8 +188,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			int.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.integers(
-					introspectorArbitraryGenerator.integers(),
+				arbitraryResolver.integers(
+					arbitraryGenerator.integers(),
 					ctx
 				)
 			)
@@ -198,8 +198,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Integer.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.integers(
-					introspectorArbitraryGenerator.integers(),
+				arbitraryResolver.integers(
+					arbitraryGenerator.integers(),
 					ctx
 				)
 			)
@@ -208,8 +208,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			long.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.longs(
-					introspectorArbitraryGenerator.longs(),
+				arbitraryResolver.longs(
+					arbitraryGenerator.longs(),
 					ctx
 				)
 			)
@@ -218,8 +218,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			Long.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.longs(
-					introspectorArbitraryGenerator.longs(),
+				arbitraryResolver.longs(
+					arbitraryGenerator.longs(),
 					ctx
 				)
 			)
@@ -228,8 +228,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			BigInteger.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.bigIntegers(
-					introspectorArbitraryGenerator.bigIntegers(),
+				arbitraryResolver.bigIntegers(
+					arbitraryGenerator.bigIntegers(),
 					ctx
 				)
 			)
@@ -238,8 +238,8 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		introspector.put(
 			BigDecimal.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				arbitraryIntrospector.bigDecimals(
-					introspectorArbitraryGenerator.bigDecimals(),
+				arbitraryResolver.bigDecimals(
+					arbitraryGenerator.bigDecimals(),
 					ctx
 				)
 			)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryResolver.java
@@ -39,7 +39,7 @@ import net.jqwik.api.arbitraries.StringArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public interface ArbitraryTypeIntrospector {
+public interface JavaArbitraryResolver {
 	default Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryGeneratorContext context) {
 		return stringArbitrary;
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospector.java
@@ -52,18 +52,18 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 
 	public JavaTimeArbitraryIntrospector() {
 		this(
-			new IntrospectorTimeArbitraryGenerator() {
+			new JavaTimeTypeArbitraryGenerator() {
 			},
-			new TimeArbitraryTypeIntrospector() {
+			new JavaTimeArbitraryResolver() {
 			}
 		);
 	}
 
 	public JavaTimeArbitraryIntrospector(
-		IntrospectorTimeArbitraryGenerator introspectorTimeArbitraryGenerator,
-		TimeArbitraryTypeIntrospector timeArbitraryIntrospector
+		JavaTimeTypeArbitraryGenerator arbitraryGenerator,
+		JavaTimeArbitraryResolver arbitraryResolver
 	) {
-		this.introspector = introspectors(introspectorTimeArbitraryGenerator, timeArbitraryIntrospector);
+		this.introspector = introspectors(arbitraryGenerator, arbitraryResolver);
 	}
 
 	@Override
@@ -83,16 +83,16 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 	}
 
 	private static Map<Class<?>, Function<ArbitraryGeneratorContext, ArbitraryIntrospectorResult>> introspectors(
-		IntrospectorTimeArbitraryGenerator introspectorTimeArbitraryGenerator,
-		TimeArbitraryTypeIntrospector timeArbitraryIntrospector
+		JavaTimeTypeArbitraryGenerator arbitraryGenerator,
+		JavaTimeArbitraryResolver arbitraryResolver
 	) {
 		Map<Class<?>, Function<ArbitraryGeneratorContext, ArbitraryIntrospectorResult>> introspector = new HashMap<>();
 
 		introspector.put(
 			Calendar.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.calendars(
-					introspectorTimeArbitraryGenerator.calendars(),
+				arbitraryResolver.calendars(
+					arbitraryGenerator.calendars(),
 					ctx
 				)
 			)
@@ -101,8 +101,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			Date.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.dates(
-					introspectorTimeArbitraryGenerator.dates(),
+				arbitraryResolver.dates(
+					arbitraryGenerator.dates(),
 					ctx
 				)
 			)
@@ -111,8 +111,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			Instant.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.instants(
-					introspectorTimeArbitraryGenerator.instants(),
+				arbitraryResolver.instants(
+					arbitraryGenerator.instants(),
 					ctx
 				)
 			)
@@ -121,8 +121,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			LocalDate.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.localDates(
-					introspectorTimeArbitraryGenerator.localDates(),
+				arbitraryResolver.localDates(
+					arbitraryGenerator.localDates(),
 					ctx
 				)
 			)
@@ -131,8 +131,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			LocalDateTime.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.localDateTimes(
-					introspectorTimeArbitraryGenerator.localDateTimes(),
+				arbitraryResolver.localDateTimes(
+					arbitraryGenerator.localDateTimes(),
 					ctx
 				)
 			)
@@ -141,8 +141,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			LocalTime.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.localTimes(
-					introspectorTimeArbitraryGenerator.localTimes(),
+				arbitraryResolver.localTimes(
+					arbitraryGenerator.localTimes(),
 					ctx
 				)
 			)
@@ -151,8 +151,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			ZonedDateTime.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.zonedDateTimes(
-					introspectorTimeArbitraryGenerator.zonedDateTimes(),
+				arbitraryResolver.zonedDateTimes(
+					arbitraryGenerator.zonedDateTimes(),
 					ctx
 				)
 			)
@@ -161,8 +161,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			MonthDay.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.monthDays(
-					introspectorTimeArbitraryGenerator.monthDays(),
+				arbitraryResolver.monthDays(
+					arbitraryGenerator.monthDays(),
 					ctx
 				)
 			)
@@ -171,8 +171,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			OffsetDateTime.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.offsetDateTimes(
-					introspectorTimeArbitraryGenerator.offsetDateTimes(),
+				arbitraryResolver.offsetDateTimes(
+					arbitraryGenerator.offsetDateTimes(),
 					ctx
 				)
 			)
@@ -181,8 +181,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			OffsetTime.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.offsetTimes(
-					introspectorTimeArbitraryGenerator.offsetTimes(),
+				arbitraryResolver.offsetTimes(
+					arbitraryGenerator.offsetTimes(),
 					ctx
 				)
 			)
@@ -191,8 +191,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			Period.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.periods(
-					introspectorTimeArbitraryGenerator.periods(),
+				arbitraryResolver.periods(
+					arbitraryGenerator.periods(),
 					ctx
 				)
 			)
@@ -201,8 +201,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			Duration.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.durations(
-					introspectorTimeArbitraryGenerator.durations(),
+				arbitraryResolver.durations(
+					arbitraryGenerator.durations(),
 					ctx
 				)
 			)
@@ -211,8 +211,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			Year.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.years(
-					introspectorTimeArbitraryGenerator.years(),
+				arbitraryResolver.years(
+					arbitraryGenerator.years(),
 					ctx
 				)
 			)
@@ -221,8 +221,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			YearMonth.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.yearMonths(
-					introspectorTimeArbitraryGenerator.yearMonths(),
+				arbitraryResolver.yearMonths(
+					arbitraryGenerator.yearMonths(),
 					ctx
 				)
 			)
@@ -231,8 +231,8 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 		introspector.put(
 			ZoneOffset.class,
 			ctx -> new ArbitraryIntrospectorResult(
-				timeArbitraryIntrospector.zoneOffsets(
-					introspectorTimeArbitraryGenerator.zoneOffsets(),
+				arbitraryResolver.zoneOffsets(
+					arbitraryGenerator.zoneOffsets(),
 					ctx
 				)
 			)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryResolver.java
@@ -57,7 +57,7 @@ import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public interface TimeArbitraryTypeIntrospector {
+public interface JavaTimeArbitraryResolver {
 	default Arbitrary<Calendar> calendars(CalendarArbitrary calendarArbitrary, ArbitraryGeneratorContext context) {
 		return calendarArbitrary;
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGenerator.java
@@ -51,7 +51,7 @@ import net.jqwik.time.api.arbitraries.ZoneOffsetArbitrary;
 import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public interface IntrospectorTimeArbitraryGenerator {
+public interface JavaTimeTypeArbitraryGenerator {
 
 	default CalendarArbitrary calendars() {
 		Instant now = Instant.now();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTypeArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTypeArbitraryGenerator.java
@@ -34,7 +34,7 @@ import net.jqwik.api.arbitraries.ShortArbitrary;
 import net.jqwik.api.arbitraries.StringArbitrary;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public interface IntrospectorArbitraryGenerator {
+public interface JavaTypeArbitraryGenerator {
 
 	default StringArbitrary strings() {
 		return Arbitraries.strings();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -60,8 +60,8 @@ public final class GenerateOptionsBuilder {
 	private ArbitraryContainerInfo defaultArbitraryContainerInfo;
 	private List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators = new ArrayList<>();
 	private ArbitraryGenerator defaultArbitraryGenerator;
-	private JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
-		new JavaDefaultArbitraryGeneratorBuilder();
+	private final JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
+		DefaultArbitraryGenerator.javaBuilder();
 
 	GenerateOptionsBuilder() {
 	}
@@ -351,7 +351,7 @@ public final class GenerateOptionsBuilder {
 				() -> new ArbitraryContainerInfo(0, defaultArbitraryContainerMaxSize)
 			);
 		ArbitraryGenerator defaultArbitraryGenerator =
-			defaultIfNull(this.defaultArbitraryGenerator, () -> this.javaDefaultArbitraryGeneratorBuilder.build());
+			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);
 
 		return new GenerateOptions(
 			this.arbitraryPropertyGenerators,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -37,13 +37,13 @@ import com.navercorp.fixturemonkey.api.generator.DefaultArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
-import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
@@ -315,7 +315,7 @@ public final class GenerateOptionsBuilder {
 	public GenerateOptionsBuilder javaArbitraryResolver(
 		JavaArbitraryResolver javaArbitraryResolver
 	) {
-		this.defaultArbitraryGeneratorBuilder.JavaArbitraryResolver(javaArbitraryResolver);
+		this.defaultArbitraryGeneratorBuilder.javaArbitraryResolver(javaArbitraryResolver);
 		return this;
 	}
 
@@ -426,7 +426,7 @@ public final class GenerateOptionsBuilder {
 			return this;
 		}
 
-		public DefaultArbitraryGeneratorBuilder JavaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
+		public DefaultArbitraryGeneratorBuilder javaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
 			this.javaArbitraryResolver = javaArbitraryResolver;
 			return this;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -37,7 +37,13 @@ import com.navercorp.fixturemonkey.api.generator.DefaultArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
@@ -299,6 +305,34 @@ public final class GenerateOptionsBuilder {
 		return this;
 	}
 
+	public GenerateOptionsBuilder javaTypeArbitraryGenerator(
+		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
+	) {
+		this.defaultArbitraryGeneratorBuilder.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator);
+		return this;
+	}
+
+	public GenerateOptionsBuilder javaArbitraryResolver(
+		JavaArbitraryResolver javaArbitraryResolver
+	) {
+		this.defaultArbitraryGeneratorBuilder.JavaArbitraryResolver(javaArbitraryResolver);
+		return this;
+	}
+
+	public GenerateOptionsBuilder javaTimeTypeArbitraryGenerator(
+		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
+	) {
+		this.defaultArbitraryGeneratorBuilder.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator);
+		return this;
+	}
+
+	public GenerateOptionsBuilder javaTimeArbitraryResolver(
+		JavaTimeArbitraryResolver javaTimeArbitraryResolver
+	) {
+		this.defaultArbitraryGeneratorBuilder.javaTimeArbitraryResolver(javaTimeArbitraryResolver);
+		return this;
+	}
+
 	public GenerateOptionsBuilder plugin(Plugin plugin) {
 		plugin.accept(this);
 		return this;
@@ -354,25 +388,71 @@ public final class GenerateOptionsBuilder {
 	}
 
 	private static class DefaultArbitraryGeneratorBuilder {
+
+		private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
+		};
+
+		private JavaArbitraryResolver javaArbitraryResolver = new JavaArbitraryResolver() {
+		};
+
+		private JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator = new JavaTimeTypeArbitraryGenerator() {
+		};
+
+		private JavaTimeArbitraryResolver javaTimeArbitraryResolver = new JavaTimeArbitraryResolver() {
+		};
 		private ArbitraryIntrospector priorityIntrospector = DefaultArbitraryGenerator.JAVA_INTROSPECTOR;
 		private ArbitraryIntrospector containerIntrospector = DefaultArbitraryGenerator.JAVA_CONTAINER_INTROSPECTOR;
 		private ArbitraryIntrospector objectIntrospector = BeanArbitraryIntrospector.INSTANCE;
 
-		public void priorityIntrospector(ArbitraryIntrospector priorityIntrospector) {
+		public DefaultArbitraryGeneratorBuilder priorityIntrospector(ArbitraryIntrospector priorityIntrospector) {
 			this.priorityIntrospector = priorityIntrospector;
+			return this;
 		}
 
-		public void containerIntrospector(ArbitraryIntrospector containerIntrospector) {
+		public DefaultArbitraryGeneratorBuilder containerIntrospector(ArbitraryIntrospector containerIntrospector) {
 			this.containerIntrospector = containerIntrospector;
+			return this;
 		}
 
-		public void objectIntrospector(ArbitraryIntrospector objectIntrospector) {
+		public DefaultArbitraryGeneratorBuilder objectIntrospector(ArbitraryIntrospector objectIntrospector) {
 			this.objectIntrospector = objectIntrospector;
+			return this;
+		}
+
+		public DefaultArbitraryGeneratorBuilder javaTypeArbitraryGenerator(
+			JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
+		) {
+			this.javaTypeArbitraryGenerator = javaTypeArbitraryGenerator;
+			return this;
+		}
+
+		public DefaultArbitraryGeneratorBuilder JavaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
+			this.javaArbitraryResolver = javaArbitraryResolver;
+			return this;
+		}
+
+		public DefaultArbitraryGeneratorBuilder javaTimeTypeArbitraryGenerator(
+			JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
+		) {
+			this.javaTimeTypeArbitraryGenerator = javaTimeTypeArbitraryGenerator;
+			return this;
+		}
+
+		public DefaultArbitraryGeneratorBuilder javaTimeArbitraryResolver(
+			JavaTimeArbitraryResolver javaTimeArbitraryResolver
+		) {
+			this.javaTimeArbitraryResolver = javaTimeArbitraryResolver;
+			return this;
 		}
 
 		public ArbitraryGenerator generate() {
 			return new DefaultArbitraryGenerator(
 				Arrays.asList(
+					new JavaArbitraryIntrospector(javaTypeArbitraryGenerator, javaArbitraryResolver),
+					new JavaTimeArbitraryIntrospector(
+						javaTimeTypeArbitraryGenerator,
+						javaTimeArbitraryResolver
+					),
 					this.priorityIntrospector,
 					this.containerIntrospector,
 					this.objectIntrospector

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -19,7 +19,6 @@
 package com.navercorp.fixturemonkey.api.option;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -35,12 +34,10 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.JavaDefaultArbitraryGeneratorBuilder;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
-import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
@@ -63,7 +60,8 @@ public final class GenerateOptionsBuilder {
 	private ArbitraryContainerInfo defaultArbitraryContainerInfo;
 	private List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators = new ArrayList<>();
 	private ArbitraryGenerator defaultArbitraryGenerator;
-	private DefaultArbitraryGeneratorBuilder defaultArbitraryGeneratorBuilder = new DefaultArbitraryGeneratorBuilder();
+	private JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
+		new JavaDefaultArbitraryGeneratorBuilder();
 
 	GenerateOptionsBuilder() {
 	}
@@ -281,55 +279,49 @@ public final class GenerateOptionsBuilder {
 	public GenerateOptionsBuilder priorityIntrospector(
 		UnaryOperator<ArbitraryIntrospector> priorityIntrospector
 	) {
-		ArbitraryIntrospector introspector =
-			priorityIntrospector.apply(this.defaultArbitraryGeneratorBuilder.priorityIntrospector);
-		this.defaultArbitraryGeneratorBuilder.priorityIntrospector(introspector);
+		this.javaDefaultArbitraryGeneratorBuilder.priorityIntrospector(priorityIntrospector);
 		return this;
 	}
 
 	public GenerateOptionsBuilder containerIntrospector(
 		UnaryOperator<ArbitraryIntrospector> containerIntrospector
 	) {
-		ArbitraryIntrospector introspector =
-			containerIntrospector.apply(this.defaultArbitraryGeneratorBuilder.containerIntrospector);
-		this.defaultArbitraryGeneratorBuilder.containerIntrospector(introspector);
+		this.javaDefaultArbitraryGeneratorBuilder.containerIntrospector(containerIntrospector);
 		return this;
 	}
 
 	public GenerateOptionsBuilder objectIntrospector(
 		UnaryOperator<ArbitraryIntrospector> objectIntrospector
 	) {
-		ArbitraryIntrospector introspector =
-			objectIntrospector.apply(this.defaultArbitraryGeneratorBuilder.objectIntrospector);
-		this.defaultArbitraryGeneratorBuilder.objectIntrospector(introspector);
+		this.javaDefaultArbitraryGeneratorBuilder.objectIntrospector(objectIntrospector);
 		return this;
 	}
 
 	public GenerateOptionsBuilder javaTypeArbitraryGenerator(
 		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
 	) {
-		this.defaultArbitraryGeneratorBuilder.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator);
+		this.javaDefaultArbitraryGeneratorBuilder.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator);
 		return this;
 	}
 
 	public GenerateOptionsBuilder javaArbitraryResolver(
 		JavaArbitraryResolver javaArbitraryResolver
 	) {
-		this.defaultArbitraryGeneratorBuilder.javaArbitraryResolver(javaArbitraryResolver);
+		this.javaDefaultArbitraryGeneratorBuilder.javaArbitraryResolver(javaArbitraryResolver);
 		return this;
 	}
 
 	public GenerateOptionsBuilder javaTimeTypeArbitraryGenerator(
 		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
 	) {
-		this.defaultArbitraryGeneratorBuilder.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator);
+		this.javaDefaultArbitraryGeneratorBuilder.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator);
 		return this;
 	}
 
 	public GenerateOptionsBuilder javaTimeArbitraryResolver(
 		JavaTimeArbitraryResolver javaTimeArbitraryResolver
 	) {
-		this.defaultArbitraryGeneratorBuilder.javaTimeArbitraryResolver(javaTimeArbitraryResolver);
+		this.javaDefaultArbitraryGeneratorBuilder.javaTimeArbitraryResolver(javaTimeArbitraryResolver);
 		return this;
 	}
 
@@ -359,7 +351,7 @@ public final class GenerateOptionsBuilder {
 				() -> new ArbitraryContainerInfo(0, defaultArbitraryContainerMaxSize)
 			);
 		ArbitraryGenerator defaultArbitraryGenerator =
-			defaultIfNull(this.defaultArbitraryGenerator, () -> this.defaultArbitraryGeneratorBuilder.generate());
+			defaultIfNull(this.defaultArbitraryGenerator, () -> this.javaDefaultArbitraryGeneratorBuilder.build());
 
 		return new GenerateOptions(
 			this.arbitraryPropertyGenerators,
@@ -385,79 +377,5 @@ public final class GenerateOptionsBuilder {
 		result.add(value);
 		result.addAll(list);
 		return result;
-	}
-
-	private static class DefaultArbitraryGeneratorBuilder {
-
-		private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
-		};
-
-		private JavaArbitraryResolver javaArbitraryResolver = new JavaArbitraryResolver() {
-		};
-
-		private JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator = new JavaTimeTypeArbitraryGenerator() {
-		};
-
-		private JavaTimeArbitraryResolver javaTimeArbitraryResolver = new JavaTimeArbitraryResolver() {
-		};
-		private ArbitraryIntrospector priorityIntrospector = DefaultArbitraryGenerator.JAVA_INTROSPECTOR;
-		private ArbitraryIntrospector containerIntrospector = DefaultArbitraryGenerator.JAVA_CONTAINER_INTROSPECTOR;
-		private ArbitraryIntrospector objectIntrospector = BeanArbitraryIntrospector.INSTANCE;
-
-		public DefaultArbitraryGeneratorBuilder priorityIntrospector(ArbitraryIntrospector priorityIntrospector) {
-			this.priorityIntrospector = priorityIntrospector;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder containerIntrospector(ArbitraryIntrospector containerIntrospector) {
-			this.containerIntrospector = containerIntrospector;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder objectIntrospector(ArbitraryIntrospector objectIntrospector) {
-			this.objectIntrospector = objectIntrospector;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder javaTypeArbitraryGenerator(
-			JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
-		) {
-			this.javaTypeArbitraryGenerator = javaTypeArbitraryGenerator;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder javaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
-			this.javaArbitraryResolver = javaArbitraryResolver;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder javaTimeTypeArbitraryGenerator(
-			JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
-		) {
-			this.javaTimeTypeArbitraryGenerator = javaTimeTypeArbitraryGenerator;
-			return this;
-		}
-
-		public DefaultArbitraryGeneratorBuilder javaTimeArbitraryResolver(
-			JavaTimeArbitraryResolver javaTimeArbitraryResolver
-		) {
-			this.javaTimeArbitraryResolver = javaTimeArbitraryResolver;
-			return this;
-		}
-
-		public ArbitraryGenerator generate() {
-			return new DefaultArbitraryGenerator(
-				Arrays.asList(
-					new JavaArbitraryIntrospector(javaTypeArbitraryGenerator, javaArbitraryResolver),
-					new JavaTimeArbitraryIntrospector(
-						javaTimeTypeArbitraryGenerator,
-						javaTimeArbitraryResolver
-					),
-					this.priorityIntrospector,
-					this.containerIntrospector,
-					this.objectIntrospector
-				)
-			);
-		}
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorTest.java
@@ -38,11 +38,11 @@ import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
-class DefaultArbitraryGeneratorTest {
+class JavaDefaultArbitraryGeneratorTest {
 	@Test
 	void generateString() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "str";
@@ -74,7 +74,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateInteger() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "integer";
@@ -106,7 +106,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateInstant() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "instant";
@@ -138,7 +138,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateLocalDateTime() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "localDateTime";
@@ -170,7 +170,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateBoolean() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "booleans";
@@ -202,7 +202,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateEnum() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "enums";
@@ -234,7 +234,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateUuid() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		String propertyName = "uuid";
@@ -266,7 +266,7 @@ class DefaultArbitraryGeneratorTest {
 	@Test
 	void generateBean() {
 		// given
-		DefaultArbitraryGenerator sut = new DefaultArbitraryGenerator();
+		DefaultArbitraryGenerator sut = DefaultArbitraryGenerator.javaBuilder().build();
 		TypeReference<SampleArbitraryGenerator> typeReference = new TypeReference<SampleArbitraryGenerator>() {
 		};
 		Property rootProperty = new RootProperty(typeReference.getAnnotatedType());

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGeneratorTests.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGeneratorTests.java
@@ -46,8 +46,8 @@ import net.jqwik.time.api.arbitraries.YearArbitrary;
 import net.jqwik.time.api.arbitraries.YearMonthArbitrary;
 import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 
-class IntrospectorTimeArbitraryGeneratorTests {
-	private final IntrospectorTimeArbitraryGenerator sut = new IntrospectorTimeArbitraryGenerator() {
+class JavaTimeTypeArbitraryGeneratorTests {
+	private final JavaTimeTypeArbitraryGenerator sut = new JavaTimeTypeArbitraryGenerator() {
 	};
 
 	@Property

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
@@ -46,20 +46,20 @@ import net.jqwik.api.arbitraries.StringArbitrary;
 import net.jqwik.web.api.Web;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.introspector.ArbitraryTypeIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class JavaxValidationArbitraryTypeIntrospector implements ArbitraryTypeIntrospector {
+public final class JavaxValidationJavaArbitraryResolver implements JavaArbitraryResolver {
 	private static final String CONTROL_BLOCK = "\u0000-\u001f\u007f";
 	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
 
 	private final JavaxValidationConstraintGenerator constraintGenerator;
 
-	public JavaxValidationArbitraryTypeIntrospector() {
+	public JavaxValidationJavaArbitraryResolver() {
 		this(new JavaxValidationConstraintGenerator());
 	}
 
-	public JavaxValidationArbitraryTypeIntrospector(JavaxValidationConstraintGenerator constraintGenerator) {
+	public JavaxValidationJavaArbitraryResolver(JavaxValidationConstraintGenerator constraintGenerator) {
 		this.constraintGenerator = constraintGenerator;
 	}
 

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaTimeArbitraryResolver.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaTimeArbitraryResolver.java
@@ -55,17 +55,17 @@ import net.jqwik.time.api.arbitraries.ZoneOffsetArbitrary;
 import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.introspector.TimeArbitraryTypeIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class JavaxValidationTimeArbitraryTypeIntrospector implements TimeArbitraryTypeIntrospector {
+public final class JavaxValidationJavaTimeArbitraryResolver implements JavaTimeArbitraryResolver {
 	private final JavaxValidationTimeConstraintGenerator constraintGenerator;
 
-	public JavaxValidationTimeArbitraryTypeIntrospector() {
+	public JavaxValidationJavaTimeArbitraryResolver() {
 		this(new JavaxValidationTimeConstraintGenerator());
 	}
 
-	public JavaxValidationTimeArbitraryTypeIntrospector(JavaxValidationTimeConstraintGenerator constraintGenerator) {
+	public JavaxValidationJavaTimeArbitraryResolver(JavaxValidationTimeConstraintGenerator constraintGenerator) {
 		this.constraintGenerator = constraintGenerator;
 	}
 

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/plugin/JavaxValidationPlugin.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/plugin/JavaxValidationPlugin.java
@@ -24,36 +24,34 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.IntrospectorArbitraryGenerator;
-import com.navercorp.fixturemonkey.api.introspector.IntrospectorTimeArbitraryGenerator;
-import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
 import com.navercorp.fixturemonkey.javax.validation.generator.JavaxValidationArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.javax.validation.generator.JavaxValidationNullInjectGenerator;
-import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationArbitraryTypeIntrospector;
+import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationJavaArbitraryResolver;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationBooleanIntrospector;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationConstraintGenerator;
-import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationTimeArbitraryTypeIntrospector;
+import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationJavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationTimeConstraintGenerator;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationPlugin implements Plugin {
-	private IntrospectorArbitraryGenerator introspectorArbitraryGenerator = new IntrospectorArbitraryGenerator() {
+	private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
 	};
 	private JavaxValidationConstraintGenerator javaxValidationConstraintGenerator =
 		new JavaxValidationConstraintGenerator();
-	private IntrospectorTimeArbitraryGenerator introspectorTimeArbitraryGenerator =
-		new IntrospectorTimeArbitraryGenerator() {
+	private JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator =
+		new JavaTimeTypeArbitraryGenerator() {
 		};
 	private JavaxValidationTimeConstraintGenerator javaxValidationTimeConstraintGenerator =
 		new JavaxValidationTimeConstraintGenerator();
 
-	public JavaxValidationPlugin introspectorArbitraryGenerator(
-		IntrospectorArbitraryGenerator introspectorArbitraryGenerator
+	public JavaxValidationPlugin javaTypeArbitraryGenerator(
+		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
 	) {
-		this.introspectorArbitraryGenerator = introspectorArbitraryGenerator;
+		this.javaTypeArbitraryGenerator = javaTypeArbitraryGenerator;
 		return this;
 	}
 
@@ -64,10 +62,10 @@ public final class JavaxValidationPlugin implements Plugin {
 		return this;
 	}
 
-	public JavaxValidationPlugin introspectorTimeArbitraryGenerator(
-		IntrospectorTimeArbitraryGenerator introspectorTimeArbitraryGenerator
+	public JavaxValidationPlugin javaTimeTypeArbitraryGenerator(
+		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
 	) {
-		this.introspectorTimeArbitraryGenerator = introspectorTimeArbitraryGenerator;
+		this.javaTimeTypeArbitraryGenerator = javaTimeTypeArbitraryGenerator;
 		return this;
 	}
 
@@ -86,19 +84,19 @@ public final class JavaxValidationPlugin implements Plugin {
 				prop -> true,
 				new JavaxValidationArbitraryContainerInfoGenerator()
 			)
+			.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator)
+			.javaArbitraryResolver(
+				new JavaxValidationJavaArbitraryResolver(this.javaxValidationConstraintGenerator)
+			)
+			.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator)
+			.javaTimeArbitraryResolver(
+				new JavaxValidationJavaTimeArbitraryResolver(
+					this.javaxValidationTimeConstraintGenerator
+				)
+			)
 			.priorityIntrospector(current ->
 				new CompositeArbitraryIntrospector(
 					Arrays.asList(
-						new JavaArbitraryIntrospector(
-							this.introspectorArbitraryGenerator,
-							new JavaxValidationArbitraryTypeIntrospector(this.javaxValidationConstraintGenerator)
-						),
-						new JavaTimeArbitraryIntrospector(
-							this.introspectorTimeArbitraryGenerator,
-							new JavaxValidationTimeArbitraryTypeIntrospector(
-								this.javaxValidationTimeConstraintGenerator
-							)
-						),
 						new JavaxValidationBooleanIntrospector(),
 						current
 					)

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/plugin/JavaxValidationPlugin.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/plugin/JavaxValidationPlugin.java
@@ -24,15 +24,15 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
 import com.navercorp.fixturemonkey.javax.validation.generator.JavaxValidationArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.javax.validation.generator.JavaxValidationNullInjectGenerator;
-import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationJavaArbitraryResolver;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationBooleanIntrospector;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationConstraintGenerator;
+import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationJavaArbitraryResolver;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationJavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.javax.validation.introspector.JavaxValidationTimeConstraintGenerator;
 

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
@@ -40,7 +40,7 @@ import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
 class JavaxValidationArbitraryIntrospectorTest {
-	private final JavaxValidationArbitraryTypeIntrospector sut = new JavaxValidationArbitraryTypeIntrospector();
+	private final JavaxValidationJavaArbitraryResolver sut = new JavaxValidationJavaArbitraryResolver();
 
 	@Property
 	void strings() {

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeJavaArbitraryResolverTest.java
@@ -53,8 +53,8 @@ import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
-class JavaxValidationTimeArbitraryTypeIntrospectorTest {
-	private final JavaxValidationTimeArbitraryTypeIntrospector sut = new JavaxValidationTimeArbitraryTypeIntrospector();
+class JavaxValidationTimeJavaArbitraryResolverTest {
+	private final JavaxValidationJavaTimeArbitraryResolver sut = new JavaxValidationJavaTimeArbitraryResolver();
 
 	@Property
 	void calendar() {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -26,9 +26,9 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
-import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
-import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -25,6 +25,10 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
@@ -157,6 +161,30 @@ public class LabMonkeyBuilder {
 
 	public LabMonkeyBuilder defaultArbitraryContainerInfo(ArbitraryContainerInfo defaultArbitraryContainerInfo) {
 		generateOptionsBuilder.defaultArbitraryContainerInfo(defaultArbitraryContainerInfo);
+		return this;
+	}
+
+	public LabMonkeyBuilder javaTypeArbitraryGenerator(
+		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
+	) {
+		generateOptionsBuilder.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder javaArbitraryResolver(JavaArbitraryResolver javaArbitraryResolver) {
+		generateOptionsBuilder.javaArbitraryResolver(javaArbitraryResolver);
+		return this;
+	}
+
+	public LabMonkeyBuilder javaTimeTypeArbitraryGenerator(
+		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
+	) {
+		generateOptionsBuilder.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder javaTimeArbitraryResolver(JavaTimeArbitraryResolver javaTimeArbitraryResolver) {
+		generateOptionsBuilder.javaTimeArbitraryResolver(javaTimeArbitraryResolver);
 		return this;
 	}
 


### PR DESCRIPTION
기본적인 자바 자료형 타입, 시간 타입을 변경할 수 있게 옵션을 추가합니다.
헷갈릴 수 있는 표현들을 정리합니다.
ex) 이전에는 `JavaxValidationArbitraryTypeIntrospector` 는 introspector임에도 Arbitrary를 직접 반환했습니다.

### ArbitraryGenerator
Arbitrary를 생성하여 반환합니다.

### ArbitraryResolver
입력받은 Arbitrary를 변경하고 반환합니다.
`com.navercorp.fixturemonkey.resolver.ArbitraryResolver`  와 이름이 겹칩니다.
더 적절한 이름이 있으면 변경할 예정입니다.

### ArbitraryIntrospector
ArbitraryGenerator + ArbitraryResolver 
항상 ArbitraryIntrospectorResult를 반환합니다.