### PR TITLE
Fix exp resolves property name when not record type

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -685,11 +685,13 @@ private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) :
     private fun resolvePropertyName(): String =
         if (getter.name.startsWith("get")) {
             getter.name.substringAfter("get")
+                .replaceFirstChar { it.lowercaseChar() }
         } else if (getter.returnType == Boolean::class.java && getter.name.startsWith("is")) {
             getter.name.substringAfter("is")
+                .replaceFirstChar { it.lowercaseChar() }
         } else {
             getter.name
-        }.replaceFirstChar { it.lowercaseChar() }
+        }
 
     private val property: KProperty<*>? = try {
         callerType.getDeclaredField(name).kotlinProperty


### PR DESCRIPTION
record 타입이 아닌 경우 getter에서 파싱한 프로퍼티 명의 첫글자가 대문자인 문제를 해결합니다.

기록차 남기고 바로 머지하겠습니다.