### PR TITLE
Fix copy to include validOnly

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -399,7 +399,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 
 	@Override
 	public ArbitraryBuilder<T> copy() {
-		return new DefaultArbitraryBuilder<>(
+		DefaultArbitraryBuilder<T> copied = new DefaultArbitraryBuilder<>(
 			manipulateOptions,
 			rootProperty,
 			resolver,
@@ -408,6 +408,8 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 			new ArrayList<>(this.manipulators),
 			new HashSet<>(this.lazyArbitraries)
 		);
+		copied.validOnly(this.validOnly);
+		return copied;
 	}
 
 	private <R> DefaultArbitraryBuilder<R> generateArbitraryBuilderLazily(LazyArbitrary<R> lazyArbitrary) {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -18,6 +18,10 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -45,10 +49,8 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.NestedString
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringAndInt;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
-import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListWithAnnotation;
-
-import static org.assertj.core.api.BDDAssertions.*;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 
 class FixtureMonkeyV04Test {
 	private static final LabMonkey SUT = LabMonkey.labMonkey();

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -18,9 +18,6 @@
 
 package com.navercorp.fixturemonkey.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
-
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -49,6 +46,9 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringAndInt
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListWithAnnotation;
+
+import static org.assertj.core.api.BDDAssertions.*;
 
 class FixtureMonkeyV04Test {
 	private static final LabMonkey SUT = LabMonkey.labMonkey();
@@ -1043,5 +1043,15 @@ class FixtureMonkeyV04Test {
 			.getWrapperInteger();
 
 		then(integer).isEqualTo(1234);
+	}
+
+	@Property
+	void copyValidOnly() {
+		thenNoException()
+			.isThrownBy(() -> SUT.giveMeBuilder(ListWithAnnotation.class)
+				.size("values", 0)
+				.validOnly(false)
+				.copy()
+				.sample());
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -33,6 +33,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+
 class FixtureMonkeyV04TestSpecs {
 	@Setter
 	@Getter
@@ -69,5 +72,13 @@ class FixtureMonkeyV04TestSpecs {
 		private OptionalLong optionalLong;
 		private OptionalDouble optionalDouble;
 		private Instant instant;
+	}
+
+	@Getter
+	@Setter
+	@EqualsAndHashCode
+	public static class ListWithAnnotation {
+		@NotEmpty
+		private List<@NotBlank String> values;
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -29,12 +29,12 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 
 class FixtureMonkeyV04TestSpecs {
 	@Setter


### PR DESCRIPTION
DefaultArbitraryBuilder에서 copy()할 때 validOnly 값도 copy하도록 수정합니다.

