### PR TITLE
Fix PropertyNameNodeResolver to match all index string

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
+import static com.navercorp.fixturemonkey.Constants.ALL_INDEX_STRING;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.NOT_NULL_INJECT;
 
 import java.util.ArrayList;
@@ -47,7 +48,7 @@ public final class PropertyNameNodeResolver implements NodeResolver {
 
 		for (ArbitraryNode node : previousNodes) {
 			String nodePropertyName = node.getArbitraryProperty().getResolvePropertyName();
-			if (propertyName.equals(nodePropertyName)) {
+			if (propertyName.equals(ALL_INDEX_STRING) || propertyName.equals(nodePropertyName)) {
 				node.setArbitrary(null);
 				node.setArbitraryProperty(node.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
 				result.add(node);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -51,6 +51,7 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListWithAnnotation;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.StringPair;
 
 class FixtureMonkeyV04Test {
 	private static final LabMonkey SUT = LabMonkey.labMonkey();
@@ -285,6 +286,17 @@ class FixtureMonkeyV04Test {
 			.getOptionalDouble();
 
 		then(actual).isEqualTo(expected);
+	}
+
+	@Property
+	void setAllFields() {
+		// when
+		StringPair actual = SUT.giveMeBuilder(StringPair.class)
+			.set("*", "str")
+			.sample();
+
+		then(actual.getValue1()).isEqualTo("str");
+		then(actual.getValue2()).isEqualTo("str");
 	}
 
 	@Property

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -78,6 +78,14 @@ class FixtureMonkeyV04TestSpecs {
 	@Getter
 	@Setter
 	@EqualsAndHashCode
+	public static class StringPair {
+		private String value1;
+		private String value2;
+	}
+
+	@Getter
+	@Setter
+	@EqualsAndHashCode
 	public static class ListWithAnnotation {
 		@NotEmpty
 		private List<@NotBlank String> values;


### PR DESCRIPTION
PropertyNameNodeResolver 에서 객체 내부 모든 필드를 가리키는 * 표현식을 처리하지 못하는 문제를 해결합니다.

- 관련 테스트: SimpleManipulatorTest.giveMeSetAllName