### PR TITLE
Refactor decompose iterator, stream

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.collection;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class IteratorCache {
+	private final static Map<Iterator<?>, List<?>> ITERATOR_TO_LIST = new HashMap<>();
+
+	public static List<?> getList(Iterator<?> iterator) {
+		if (ITERATOR_TO_LIST.containsKey(iterator)) {
+			return ITERATOR_TO_LIST.get(iterator);
+		}
+		List<?> list = toList(iterator);
+		ITERATOR_TO_LIST.put(iterator, list);
+		return list;
+	}
+
+	private static <T> List<T> toList(Iterator<T> iterator) {
+		List<T> list = new ArrayList<>();
+		while (iterator.hasNext()) {
+			list.add(iterator.next());
+		}
+		return list;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
@@ -29,7 +29,7 @@ import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class IteratorCache {
-	private final static Map<Iterator<?>, List<?>> ITERATOR_TO_LIST = new HashMap<>();
+	private static final Map<Iterator<?>, List<?>> ITERATOR_TO_LIST = new HashMap<>();
 
 	public static List<?> getList(Iterator<?> iterator) {
 		if (ITERATOR_TO_LIST.containsKey(iterator)) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/IteratorCache.java
@@ -19,17 +19,15 @@
 package com.navercorp.fixturemonkey.api.collection;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class IteratorCache {
-	private static final Map<Iterator<?>, List<?>> ITERATOR_TO_LIST = new HashMap<>();
+	private static final LruCache<Iterator<?>, List<?>> ITERATOR_TO_LIST = new LruCache<>(1000);
 
 	public static List<?> getList(Iterator<?> iterator) {
 		if (ITERATOR_TO_LIST.containsKey(iterator)) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/LruCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/LruCache.java
@@ -1,0 +1,18 @@
+package com.navercorp.fixturemonkey.api.collection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+	private final int maxSize;
+
+	public LruCache(int maxSize) {
+		super(maxSize + 1, 1, true);
+		this.maxSize = maxSize;
+	}
+
+	@Override
+	protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+		return size() > maxSize;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/LruCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/LruCache.java
@@ -3,10 +3,10 @@ package com.navercorp.fixturemonkey.api.collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class LruCache<K, V> extends LinkedHashMap<K, V> {
+final class LruCache<K, V> extends LinkedHashMap<K, V> {
 	private final int maxSize;
 
-	public LruCache(int maxSize) {
+	LruCache(int maxSize) {
 		super(maxSize + 1, 1, true);
 		this.maxSize = maxSize;
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
@@ -29,7 +29,7 @@ import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class StreamCache {
-	private final static Map<Stream<?>, List<?>> STREAM_TO_LIST = new HashMap<>();
+	private static final Map<Stream<?>, List<?>> STREAM_TO_LIST = new HashMap<>();
 
 	public static List<?> getList(Stream<?> stream) {
 		if (STREAM_TO_LIST.containsKey(stream)) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
@@ -18,9 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.collection;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,7 +27,7 @@ import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class StreamCache {
-	private static final Map<Stream<?>, List<?>> STREAM_TO_LIST = new HashMap<>();
+	private static final LruCache<Stream<?>, List<?>> STREAM_TO_LIST = new LruCache<>(1000);
 
 	public static List<?> getList(Stream<?> stream) {
 		if (STREAM_TO_LIST.containsKey(stream)) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/collection/StreamCache.java
@@ -1,0 +1,43 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.collection;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class StreamCache {
+	private final static Map<Stream<?>, List<?>> STREAM_TO_LIST = new HashMap<>();
+
+	public static List<?> getList(Stream<?> stream) {
+		if (STREAM_TO_LIST.containsKey(stream)) {
+			return STREAM_TO_LIST.get(stream);
+		}
+		List<?> list = stream.collect(Collectors.toList());
+		STREAM_TO_LIST.put(stream, list);
+		return list;
+	}
+
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ElementProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ElementProperty.java
@@ -23,7 +23,6 @@ import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,27 +129,12 @@ public final class ElementProperty implements Property {
 			return Array.get(obj, sequence);
 		}
 
-		if (!Iterable.class.isAssignableFrom(actualType)) {
-			throw new IllegalArgumentException("given value is not iterable, actual type : " + actualType);
-		}
-
 		if (List.class.isAssignableFrom(actualType)) {
 			List<?> list = (List<?>)obj;
 			if (list.isEmpty()) {
 				return null;
 			}
 			return list.get(sequence);
-		}
-
-		Iterable<?> iterable = (Iterable<?>)obj;
-		Iterator<?> iterator = iterable.iterator();
-		int iteratorSequence = 0;
-		while (iterator.hasNext()) {
-			Object value = iterator.next();
-			if (iteratorSequence == sequence) {
-				return value;
-			}
-			iteratorSequence++;
 		}
 
 		throw new IllegalArgumentException("given element value has no match sequence : " + sequence);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
@@ -114,7 +114,7 @@ public class LabMonkey extends FixtureMonkey {
 		manipulators.add(
 			new ArbitraryManipulator(
 				new RootNodeResolver(),
-				new NodeSetDecomposedValueManipulator<>(traverser, value)
+				new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value)
 			)
 		);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -119,7 +119,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		if (value instanceof Arbitrary) {
 			this.setLazy(expression, () -> ((Arbitrary<?>)value).sample(), limit);
 		} else if (value instanceof DefaultArbitraryBuilder) {
-			this.setLazy(expression, () -> ((DefaultArbitraryBuilder<?>) value).sample());
+			this.setLazy(expression, () -> ((DefaultArbitraryBuilder<?>)value).sample());
 		} else if (value == null) {
 			this.setNull(expression);
 		} else {
@@ -127,7 +127,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 				new ArbitraryManipulator(
 					nodeResolver,
 					new ApplyNodeCountManipulator(
-						new NodeSetDecomposedValueManipulator<>(traverser, value),
+						new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value),
 						limit
 					)
 				)
@@ -160,6 +160,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 				new ApplyNodeCountManipulator(
 					new NodeSetLazyManipulator<>(
 						traverser,
+						manipulateOptions,
 						lazyArbitrary
 					),
 					limit
@@ -177,7 +178,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	@Override
 	public ArbitraryBuilder<T> setInner(String expression, Consumer<InnerSpec> specSpecifier) {
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
-		InnerSpec innerSpec = new InnerSpec(traverser, nodeResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nodeResolver);
 		specSpecifier.accept(innerSpec);
 		List<ArbitraryManipulator> mapManipulators = innerSpec.getArbitraryManipulators();
 		manipulators.addAll(mapManipulators);
@@ -225,7 +226,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		this.manipulators.add(
 			new ArbitraryManipulator(
 				new RootNodeResolver(),
-				new NodeSetDecomposedValueManipulator<>(traverser, this.sample())
+				new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, this.sample())
 			)
 		);
 		return this;
@@ -252,6 +253,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 				new RootNodeResolver(),
 				new NodeSetLazyManipulator<>(
 					traverser,
+					manipulateOptions,
 					lazyArbitrary
 				)
 			)
@@ -436,7 +438,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		manipulators.add(
 			new ArbitraryManipulator(
 				new RootNodeResolver(),
-				new NodeSetLazyManipulator<>(traverser, lazyArbitrary)
+				new NodeSetLazyManipulator<>(traverser, manipulateOptions, lazyArbitrary)
 			)
 		);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -37,6 +37,7 @@ import com.navercorp.fixturemonkey.resolver.AddMapEntryNodeManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.resolver.ContainerElementNodeResolver;
+import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
 import com.navercorp.fixturemonkey.resolver.MapNodeManipulator;
 import com.navercorp.fixturemonkey.resolver.NodeKeyValueResolver;
 import com.navercorp.fixturemonkey.resolver.NodeLastEntryResolver;
@@ -51,11 +52,13 @@ import com.navercorp.fixturemonkey.resolver.PropertyNameNodeResolver;
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class InnerSpec {
 	private final ArbitraryTraverser traverser;
+	private final ManipulateOptions manipulateOptions;
 	private final NodeResolver treePathResolver;
 	private final List<ArbitraryManipulator> arbitraryManipulators;
 
-	public InnerSpec(ArbitraryTraverser traverser, NodeResolver treePathResolver) {
+	public InnerSpec(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions, NodeResolver treePathResolver) {
 		this.traverser = traverser;
+		this.manipulateOptions = manipulateOptions;
 		this.treePathResolver = treePathResolver;
 		this.arbitraryManipulators = new ArrayList<>();
 	}
@@ -105,7 +108,7 @@ public final class InnerSpec {
 			new NodeLastEntryResolver(this.treePathResolver),
 			true
 		);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -127,7 +130,7 @@ public final class InnerSpec {
 			new NodeLastEntryResolver(this.treePathResolver),
 			false
 		);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -160,7 +163,7 @@ public final class InnerSpec {
 			new NodeLastEntryResolver(this.treePathResolver),
 			false
 		);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -178,7 +181,7 @@ public final class InnerSpec {
 			new NodeLastEntryResolver(this.treePathResolver),
 			true
 		);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -196,7 +199,7 @@ public final class InnerSpec {
 		}
 
 		NodeResolver nextResolver = new ContainerElementNodeResolver(this.treePathResolver, index);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -214,7 +217,7 @@ public final class InnerSpec {
 		}
 
 		NodeResolver nextResolver = new PropertyNameNodeResolver(this.treePathResolver, property);
-		InnerSpec innerSpec = new InnerSpec(traverser, nextResolver);
+		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nextResolver);
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 	}
@@ -250,11 +253,15 @@ public final class InnerSpec {
 
 	private NodeManipulator convertToNodeManipulator(@Nullable Object value) {
 		if (value instanceof Arbitrary) {
-			return new NodeSetLazyManipulator<>(traverser, LazyArbitrary.lazy(() -> ((Arbitrary<?>)value).sample()));
+			return new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				LazyArbitrary.lazy(() -> ((Arbitrary<?>)value).sample())
+			);
 		} else if (value == null) {
 			return new NodeNullityManipulator(true);
 		} else {
-			return new NodeSetDecomposedValueManipulator<>(this.traverser, value);
+			return new NodeSetDecomposedValueManipulator<>(this.traverser, manipulateOptions, value);
 		}
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -107,6 +107,7 @@ public final class ArbitraryResolver {
 
 			NodeManipulator nodeManipulator = new NodeSetLazyManipulator<>(
 				traverser,
+				manipulateOptions,
 				LazyArbitrary.lazy(registeredArbitraryBuilder::sample)
 			);
 			manipulators.add(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DecomposableContainerValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DecomposableContainerValue.java
@@ -1,0 +1,41 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class DecomposableContainerValue {
+	private final Object container;
+	private final int size;
+
+	public DecomposableContainerValue(Object container, int size) {
+		this.container = container;
+		this.size = size;
+	}
+
+	public Object getContainer() {
+		return container;
+	}
+
+	public int getSize() {
+		return size;
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DecomposedContainerValueFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DecomposedContainerValueFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@FunctionalInterface
+public interface DecomposedContainerValueFactory {
+	DecomposableContainerValue from(Object object);
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultDecomposedContainerValueFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultDecomposedContainerValueFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import java.lang.reflect.Array;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.stream.Stream;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.collection.IteratorCache;
+import com.navercorp.fixturemonkey.api.collection.StreamCache;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class DefaultDecomposedContainerValueFactory implements DecomposedContainerValueFactory {
+	private final DecomposedContainerValueFactory additionalDecomposedContainerValueFactory;
+
+	public DefaultDecomposedContainerValueFactory(
+		DecomposedContainerValueFactory additionalDecomposedContainerValueFactory
+	) {
+		this.additionalDecomposedContainerValueFactory = additionalDecomposedContainerValueFactory;
+	}
+
+	@Override
+	public DecomposableContainerValue from(Object value) {
+		Class<?> actualType = value.getClass();
+
+		if (Iterable.class.isAssignableFrom(actualType)) {
+			Iterator<?> iterator = ((Iterable<?>)value).iterator();
+			List<?> list = IteratorCache.getList(iterator);
+			return new DecomposableContainerValue(list, list.size());
+		} else if (Iterator.class.isAssignableFrom(actualType)) {
+			Iterator<?> iterator = ((Iterator<?>)value);
+			List<?> list = IteratorCache.getList(iterator);
+			return new DecomposableContainerValue(list, list.size());
+		} else if (Stream.class.isAssignableFrom(actualType)) {
+			List<?> container = StreamCache.getList((Stream<?>)value);
+			return new DecomposableContainerValue(container, container.size());
+		} else if (actualType.isArray()) {
+			return new DecomposableContainerValue(value, Array.getLength(value));
+		} else if (Map.class.isAssignableFrom(actualType)) {
+			Map<?, ?> map = (Map<?, ?>)value;
+			return new DecomposableContainerValue(value, map.size());
+		} else if (Map.Entry.class.isAssignableFrom(actualType)) {
+			return new DecomposableContainerValue(value, 1);
+		} else if (isOptional(actualType)) {
+			return new DecomposableContainerValue(value, 1);
+		}
+
+		return additionalDecomposedContainerValueFactory.from(value);
+	}
+
+	private boolean isOptional(Class<?> type) {
+		return Optional.class.isAssignableFrom(type)
+			|| OptionalInt.class.isAssignableFrom(type)
+			|| OptionalLong.class.isAssignableFrom(type)
+			|| OptionalDouble.class.isAssignableFrom(type);
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulateOptions.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulateOptions.java
@@ -32,13 +32,16 @@ public final class ManipulateOptions {
 	private final MonkeyExpressionFactory defaultMonkeyExpressionFactory;
 
 	private final List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredArbitraryBuilders;
+	private final DecomposedContainerValueFactory decomposedContainerValueFactory;
 
 	public ManipulateOptions(
 		MonkeyExpressionFactory defaultMonkeyExpressionFactory,
-		List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredArbitraryBuilders
+		List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredArbitraryBuilders,
+		DecomposedContainerValueFactory decomposedContainerValueFactory
 	) {
 		this.defaultMonkeyExpressionFactory = defaultMonkeyExpressionFactory;
 		this.registeredArbitraryBuilders = registeredArbitraryBuilders;
+		this.decomposedContainerValueFactory = decomposedContainerValueFactory;
 	}
 
 	public MonkeyExpressionFactory getDefaultMonkeyExpressionFactory() {
@@ -47,6 +50,10 @@ public final class ManipulateOptions {
 
 	public List<MatcherOperator<? extends ArbitraryBuilder<?>>> getRegisteredArbitraryBuilders() {
 		return registeredArbitraryBuilders;
+	}
+
+	public DecomposedContainerValueFactory getDecomposedContainerValueFactory() {
+		return decomposedContainerValueFactory;
 	}
 
 	public static ManipulateOptionsBuilder builder() {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulateOptionsBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ManipulateOptionsBuilder.java
@@ -47,6 +47,8 @@ public final class ManipulateOptionsBuilder {
 
 	private List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredSampledArbitraryBuilders = new ArrayList<>();
 
+	private DecomposedContainerValueFactory additionalDecomposedContainerValueFactory = null;
+
 	ManipulateOptionsBuilder() {
 	}
 
@@ -67,6 +69,13 @@ public final class ManipulateOptionsBuilder {
 		return this;
 	}
 
+	public ManipulateOptionsBuilder additionalDecomposedContainerValueFactory(
+		DecomposedContainerValueFactory additionalDecomposedContainerValueFactory
+	) {
+		this.additionalDecomposedContainerValueFactory = additionalDecomposedContainerValueFactory;
+		return this;
+	}
+
 	public ManipulateOptions build() {
 		defaultMonkeyExpressionFactory = defaultIfNull(
 			this.defaultMonkeyExpressionFactory,
@@ -79,7 +88,15 @@ public final class ManipulateOptionsBuilder {
 				() -> new ApplyStrictModeResolver(currentMonkeyExpressionFactory.from(expression).toNodeResolver());
 		}
 
-		return new ManipulateOptions(defaultMonkeyExpressionFactory, registeredSampledArbitraryBuilders);
+		DecomposedContainerValueFactory decomposedContainerValueFactory = new DefaultDecomposedContainerValueFactory(
+			additionalDecomposedContainerValueFactory
+		);
+
+		return new ManipulateOptions(
+			defaultMonkeyExpressionFactory,
+			registeredSampledArbitraryBuilders,
+			decomposedContainerValueFactory
+		);
 	}
 
 	public void sampleRegisteredArbitraryBuilder(LabMonkey labMonkey) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
@@ -22,7 +22,6 @@ import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerat
 import static com.navercorp.fixturemonkey.api.type.Types.isAssignable;
 
 import java.lang.reflect.Array;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -111,10 +110,7 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 		private static DecomposedContainerValue<?> from(Object value) {
 			Class<?> actualType = value.getClass();
 
-			if (Collection.class.isAssignableFrom(actualType)) {
-				Collection<?> container = (Collection<?>)value;
-				return new DecomposedContainerValue<>(container, container.size());
-			} else if (Iterable.class.isAssignableFrom(actualType)) {
+			if (Iterable.class.isAssignableFrom(actualType)) {
 				Iterator<?> iterator = ((Iterable<?>)value).iterator();
 				List<?> list = IteratorCache.getList(iterator);
 				return new DecomposedContainerValue<>(list, list.size());

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetLazyManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetLazyManipulator.java
@@ -28,13 +28,16 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class NodeSetLazyManipulator<T> implements NodeManipulator {
 	private final ArbitraryTraverser traverser;
+	private final ManipulateOptions manipulateOptions;
 	private final LazyArbitrary<T> lazyArbitrary;
 
 	public NodeSetLazyManipulator(
 		ArbitraryTraverser traverser,
+		ManipulateOptions manipulateOptions,
 		LazyArbitrary<T> lazyArbitrary
 	) {
 		this.traverser = traverser;
+		this.manipulateOptions = manipulateOptions;
 		this.lazyArbitrary = lazyArbitrary;
 	}
 
@@ -54,7 +57,7 @@ public final class NodeSetLazyManipulator<T> implements NodeManipulator {
 		}
 
 		NodeSetDecomposedValueManipulator<T> nodeSetDecomposedValueManipulator =
-			new NodeSetDecomposedValueManipulator<>(traverser, value);
+			new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value);
 		nodeSetDecomposedValueManipulator.manipulate(arbitraryNode);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -19,8 +19,30 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import java.lang.reflect.AnnotatedType;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Builders;
+import net.jqwik.api.Builders.BuilderCombinator;
+
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.ElementProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 
 class FixtureMonkeyV04OptionsAdditionalTestSpecs {
@@ -31,5 +53,111 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 		public ArbitraryBuilder<String> string(LabMonkey labMonkey) {
 			return labMonkey.giveMeBuilder("test");
 		}
+	}
+
+	public static class Pair<S, T> {
+		private final S first;
+		private final T second;
+
+		public Pair(S first, T second) {
+			this.first = first;
+			this.second = second;
+		}
+
+		public S getFirst() {
+			return first;
+		}
+
+		public T getSecond() {
+			return second;
+		}
+	}
+
+	public static class PairArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
+		@Override
+		public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+			com.navercorp.fixturemonkey.api.property.Property property = context.getProperty();
+
+			List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
+			if (elementTypes.size() != 2) {
+				throw new IllegalArgumentException(
+					"Pair elementsTypes must be have 1 generics type for element. "
+						+ "propertyType: " + property.getType()
+						+ ", elementTypes: " + elementTypes
+				);
+			}
+
+			ArbitraryContainerInfo containerInfo = context.getContainerInfo();
+			if (containerInfo == null) {
+				containerInfo = context.getGenerateOptions()
+					.getArbitraryContainerInfoGenerator(property)
+					.generate(context);
+			}
+
+			int size = containerInfo.getRandomSize();
+			AnnotatedType firstElementType = elementTypes.get(0);
+			AnnotatedType secondElementType = elementTypes.get(1);
+			List<com.navercorp.fixturemonkey.api.property.Property> childProperties = new ArrayList<>();
+			childProperties.add(
+				new ElementProperty(
+					property,
+					firstElementType,
+					0,
+					0
+				)
+			);
+			childProperties.add(
+				new ElementProperty(
+					property,
+					secondElementType,
+					1,
+					1
+				)
+			);
+
+			double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
+				.generate(context, containerInfo);
+
+			return new ArbitraryProperty(
+				property,
+				context.getPropertyNameResolver(),
+				nullInject,
+				context.getElementIndex(),
+				childProperties,
+				containerInfo
+			);
+		}
+	}
+
+	public static class PairIntrospector implements ArbitraryIntrospector, Matcher {
+		private static final Matcher MATCHER = new AssignableTypeMatcher(Pair.class);
+
+		@Override
+		public boolean match(Property property) {
+			return MATCHER.match(property);
+		}
+
+		@Override
+		public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+			ArbitraryProperty property = context.getArbitraryProperty();
+			ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+			if (containerInfo == null) {
+				return ArbitraryIntrospectorResult.EMPTY;
+			}
+
+			List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+			BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
+			for (Arbitrary<?> childArbitrary : childrenArbitraries) {
+				builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {
+					list.add(element);
+					return list;
+				});
+			}
+
+			return new ArbitraryIntrospectorResult(
+				builderCombinator.build(it -> new Pair<>(it.get(0), it.get(1)))
+			);
+		}
+
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -23,8 +23,6 @@ import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Builders;
 import net.jqwik.api.Builders.BuilderCombinator;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -768,7 +768,8 @@ class FixtureMonkeyV04OptionsTest {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.pushAssignableTypeArbitraryPropertyGenerator(Pair.class, new PairArbitraryPropertyGenerator())
 			.pushContainerIntrospector(new PairIntrospector())
-			.defaultDecomposedContainerValueFactory((obj) -> {
+			.defaultDecomposedContainerValueFactory(
+				(obj) -> {
 					if (obj instanceof Pair) {
 						Pair<?, ?> pair = (Pair<?, ?>)obj;
 						List<Object> list = new ArrayList<>();

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -25,8 +25,10 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +37,8 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -1165,5 +1169,41 @@ class FixtureMonkeyV04Test {
 			.get(0);
 
 		then(actual.getStr()).isEqualTo(actual.getInteger() + "");
+	}
+
+	@Property
+	void setIterable() {
+		String expected = "test";
+
+		Iterable<String> actual = SUT.giveMeBuilder(ComplexObject.class)
+			.set("strIterable", Collections.singletonList(expected))
+			.sample()
+			.getStrIterable();
+
+		then(actual.iterator().next()).isEqualTo(expected);
+	}
+
+	@Property
+	void setIterator() {
+		String expected = "test";
+
+		Iterator<String> actual = SUT.giveMeBuilder(ComplexObject.class)
+			.set("strIterator", Stream.of(expected).iterator())
+			.sample()
+			.getStrIterator();
+
+		then(actual.next()).isEqualTo(expected);
+	}
+
+	@Property
+	void setStream() {
+		String expected = "test";
+
+		Stream<String> actual = SUT.giveMeBuilder(ComplexObject.class)
+			.set("strStream", Stream.of(expected))
+			.sample()
+			.getStrStream();
+
+		then(actual.collect(Collectors.toList()).get(0)).isEqualTo(expected);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -39,7 +41,7 @@ import lombok.Setter;
 class FixtureMonkeyV04TestSpecs {
 	@Setter
 	@Getter
-	@EqualsAndHashCode
+	@EqualsAndHashCode(exclude = {"strIterator", "strStream"})
 	public static class ComplexObject {
 		private String str;
 		private int integer;
@@ -54,6 +56,9 @@ class FixtureMonkeyV04TestSpecs {
 		private List<SimpleObject> list;
 		private Map<String, SimpleObject> map;
 		private Map.Entry<String, SimpleObject> mapEntry;
+		private Iterable<String> strIterable;
+		private Iterator<String> strIterator;
+		private Stream<String> strStream;
 	}
 
 	public enum SimpleEnum {


### PR DESCRIPTION
Iterator, Stream을 decompose하여 값을 설정할 수 있게 구조를 수정합니다.

`Iterator`, `Stream`은 한 번 사용하면 재사용할 수 없으므로 List로 변환하고 캐싱하여 사용합니다.
값을 decompose할 때는 `List`로 변환해서 처리합니다.
