### PR TITLE
Fix ExpressionGenerator returns boolean without is

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -688,7 +688,7 @@ private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) :
         if (getter.name.startsWith("get")) {
             getter.name.substringAfter("get")
                 .replaceFirstChar { it.lowercaseChar() }
-        } else if (getter.returnType == Boolean::class.java && getter.name.startsWith("is")) {
+        } else if (getter.returnType.javaType == Boolean::class.java && getter.name.startsWith("is")) {
             getter.name.substringAfter("is")
                 .replaceFirstChar { it.lowercaseChar() }
         } else {


### PR DESCRIPTION
boolean 타입의 이름에서 `is`를 제거하지 않고 그대로 반환하는 문제를 해결합니다.