### PR TITLE
Fix Register manipulator have no priority

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
@@ -71,6 +71,7 @@ import com.navercorp.fixturemonkey.arbitrary.ContainerSizeConstraint;
 import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
+import com.navercorp.fixturemonkey.arbitrary.PriorityManipulatorDelegator;
 import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizer;
 import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizers;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
@@ -632,6 +633,11 @@ public class OldArbitraryBuilderImpl<T> implements ArbitraryBuilder<T> {
 			activeManipulators.add(builderManipulator);
 		}
 		return activeManipulators;
+	}
+
+	public OldArbitraryBuilderImpl<T> pushBuilderManipulator(BuilderManipulator builderManipulator) {
+		this.builderManipulators.add(new PriorityManipulatorDelegator(builderManipulator));
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryTraverser.java
@@ -222,7 +222,7 @@ public final class ArbitraryTraverser {
 
 	@SuppressWarnings("unchecked")
 	private <T> void initializeDefaultArbitrary(ArbitraryNode<T> node) {
-		if (!node.isHead() && node.getValue() == null) {
+		if (!node.isHead() && node.getValue() == null && node.isNotSetContainerSize()) {
 			Class<?> clazz = node.getType().getType();
 			ArbitraryBuilder<?> defaultArbitraryBuilder = arbitraryOption.getDefaultArbitraryBuilder(clazz);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/PriorityManipulatorDelegator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/PriorityManipulatorDelegator.java
@@ -1,0 +1,60 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.arbitrary;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.OldArbitraryBuilderImpl;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class PriorityManipulatorDelegator implements MetadataManipulator {
+	private final ArbitraryExpression arbitraryExpression = ArbitraryExpression.from("$");
+	private final BuilderManipulator builderManipulator;
+
+	public PriorityManipulatorDelegator(BuilderManipulator builderManipulator) {
+		this.builderManipulator = builderManipulator;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public void accept(OldArbitraryBuilderImpl arbitraryBuilder) {
+		builderManipulator.accept(arbitraryBuilder);
+	}
+
+	@Override
+	public BuilderManipulator copy() {
+		return this;
+	}
+
+	@Override
+	public Priority getPriority() {
+		return Priority.HIGH;
+	}
+
+	@Override
+	public ArbitraryExpression getArbitraryExpression() {
+		return arbitraryExpression;
+	}
+
+	@Override
+	public void addPrefix(String expression) {
+		arbitraryExpression.addFirst(expression);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/ComplexManipulatorTest.java
@@ -941,4 +941,58 @@ class ComplexManipulatorTest {
 
 		then(actual).isNotNull();
 	}
+
+	@Property
+	void registerEmptyListSize() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.register(
+				NestedStringList.class,
+				fixture -> fixture.giveMeBuilder(NestedStringList.class).set("values", new ArrayList<>())
+			)
+			.build();
+
+		List<StringValue> actual = sut.giveMeBuilder(NestedStringList.class)
+			.size("values", 1)
+			.sample()
+			.getValues();
+
+		then(actual).hasSize(1);
+	}
+
+	@Property
+	void registerReturnsDiff() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.register(
+				Complex.class,
+				fixture -> fixture.giveMeBuilder(Complex.class)
+			)
+			.build();
+
+		Complex actual = sut.giveMeBuilder(Complex.class)
+			.sample();
+
+		Complex notExpected = sut.giveMeBuilder(Complex.class)
+			.sample();
+		then(actual).isNotEqualTo(notExpected);
+	}
+
+	@Property
+	void registerTypeReferenceEmptyListSize() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.register(
+				NestedStringList.class,
+				fixture -> fixture.giveMeBuilder(NestedStringList.class).set("values", new ArrayList<>())
+			)
+			.build();
+
+		List<StringValue> actual = sut.giveMeBuilder(new TypeReference<List<NestedStringList>>() {
+			})
+			.size("$", 1)
+			.size("$[0].values", 1)
+			.sample()
+			.get(0)
+			.getValues();
+
+		then(actual).hasSize(1);
+	}
 }


### PR DESCRIPTION
0.3.0 에서 register에 설정한 연산이 테스트에서 설정한 연산보다 항상 높은 우선순위를 가지도록 수정합니다.
