### PR TITLE
Fix register apply order

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -100,7 +100,7 @@ public final class ArbitraryResolver {
 
 		for (Entry<Property, List<ArbitraryNode>> nodeByType : nodesByType.entrySet()) {
 			Property property = nodeByType.getKey();
-			List<ArbitraryNode> arbitraryNodes = nodesByType.get(property);
+			List<ArbitraryNode> arbitraryNodes = nodeByType.getValue();
 
 			ArbitraryBuilder<?> registeredArbitraryBuilder = registeredArbitraryBuilders.stream()
 				.filter(it -> it.match(property))

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementNodeResolver.java
@@ -57,7 +57,6 @@ public final class ContainerElementNodeResolver implements NodeResolver {
 
 			ElementProperty elementProperty = (ElementProperty)property;
 			if (sequence == NO_OR_ALL_INDEX_INTEGER_VALUE || sequence == elementProperty.getSequence()) {
-				node.setArbitrary(null);
 				node.setArbitraryProperty(node.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
 				result.add(node);
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.resolver;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ final class MetadataCollector {
 
 	public MetadataCollector(ArbitraryNode rootNode) {
 		this.rootNode = rootNode;
-		this.nodesByProperty = new HashMap<>();
+		this.nodesByProperty = new LinkedHashMap<>();
 	}
 
 	public ArbitraryTreeMetadata collect() {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
@@ -19,7 +19,6 @@
 package com.navercorp.fixturemonkey.resolver;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyValueResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyValueResolver.java
@@ -47,7 +47,6 @@ public final class NodeKeyValueResolver implements NodeResolver {
 			} else {
 				child = selectedNode.getChildren().get(1);
 			}
-			child.setArbitrary(null);
 			child.setArbitraryProperty(child.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
 			nextNodes.add(child);
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeLastEntryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeLastEntryResolver.java
@@ -41,7 +41,6 @@ public final class NodeLastEntryResolver implements NodeResolver {
 		for (ArbitraryNode selectedNode : nodes) {
 			ArbitraryNode child = selectedNode.getChildren().get(selectedNode.getChildren().size() - 1);
 			child.setArbitraryProperty(child.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
-			child.setArbitrary(null);
 			nextNodes.add(child);
 		}
 		return nextNodes;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
@@ -36,6 +36,11 @@ public class NodeNullityManipulator implements NodeManipulator {
 					.withNullInject(ALWAYS_NULL_INJECT)
 			);
 		} else {
+			if (arbitraryNode.getArbitrary() != null) {
+				if (arbitraryNode.getArbitrary().sample() == null) { // without nullInject
+					arbitraryNode.setArbitrary(null);
+				}
+			}
 			arbitraryNode.setArbitraryProperty(
 				arbitraryNode.getArbitraryProperty()
 					.withNullInject(NOT_NULL_INJECT)

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
@@ -37,6 +37,7 @@ public class NodeNullityManipulator implements NodeManipulator {
 			);
 		} else {
 			if (arbitraryNode.getArbitrary() != null) {
+				//noinspection ConstantConditions
 				if (arbitraryNode.getArbitrary().sample() == null) { // without nullInject
 					arbitraryNode.setArbitrary(null);
 				}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
@@ -49,7 +49,6 @@ public final class PropertyNameNodeResolver implements NodeResolver {
 		for (ArbitraryNode node : previousNodes) {
 			String nodePropertyName = node.getArbitraryProperty().getResolvePropertyName();
 			if (propertyName.equals(ALL_INDEX_STRING) || propertyName.equals(nodePropertyName)) {
-				node.setArbitrary(null);
 				node.setArbitraryProperty(node.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
 				result.add(node);
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/RootNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/RootNodeResolver.java
@@ -35,7 +35,6 @@ public final class RootNodeResolver implements NodeResolver {
 	public List<ArbitraryNode> resolve(ArbitraryTree arbitraryTree) {
 		ArbitraryNode root = arbitraryTree.findRoot();
 		root.setArbitraryProperty(root.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
-		root.setArbitrary(null);
 		return Collections.singletonList(root);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -876,4 +876,20 @@ class FixtureMonkeyV04OptionsTest {
 
 		then(actual).isEqualTo(null);
 	}
+
+	@Property
+	void registerMultipleTimesWithHierarchyReturnsCorrectOrder() {
+		String expected = "test";
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.register(String.class, fixture -> fixture.giveMeBuilder(String.class).set(expected))
+			.register(SimpleObject.class, fixture -> fixture.giveMeBuilder(SimpleObject.class).set("integer", 1))
+			.build();
+
+		String actual = sut.giveMeBuilder(SimpleObject.class)
+			.setNotNull("str")
+			.sample()
+			.getStr();
+
+		then(actual).isEqualTo(expected);
+	}
 }


### PR DESCRIPTION
register를 했을 때 중첩되는 객체가 무시되지 않도록 순서를 조정합니다.
상위 노드에 있는 노드를 항상 먼저 조회합니다.