### PR TITLE
Fix enumIntrospector works with wildcard

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EnumIntrospector.java
@@ -29,6 +29,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.Matchers;
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class EnumIntrospector implements ArbitraryIntrospector, Matcher {
@@ -40,7 +41,7 @@ public final class EnumIntrospector implements ArbitraryIntrospector, Matcher {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		Type type = context.getType();
+		Type type = Types.getActualType(context.getType());
 		return new ArbitraryIntrospectorResult(Arbitraries.of((Class<Enum>)type));
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -59,6 +59,7 @@ import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.NestedString
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringAndInt;
 import com.navercorp.fixturemonkey.test.ComplexManipulatorTestSpecs.StringValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.EnumObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListWithAnnotation;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.StringPair;
@@ -1283,5 +1284,13 @@ class FixtureMonkeyV04Test {
 			.getStr();
 
 		then(actual).isNull();
+	}
+
+	@Property
+	void giveMeListWildcardEnum() {
+		List<? extends EnumObject> actual = SUT.giveMeOne(new TypeReference<List<? extends EnumObject>>() {
+		});
+
+		then(actual).isNotNull();
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -95,4 +95,10 @@ class FixtureMonkeyV04TestSpecs {
 		@NotEmpty
 		private List<@NotBlank String> values;
 	}
+
+	public enum EnumObject {
+		ONE,
+		TWO,
+		THREE
+	}
 }


### PR DESCRIPTION
코틀린에서 타입 추론시 컴파일러에서 와일드카드를 넣을 수 있습니다.
와일드카드가 들어간 경우에도 Enum을 생성할 수 있도록 EnumIntrospector를 수정합니다.