### PR TITLE
Add javax validation arbitrary for missing numerical types

### DIFF
--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
@@ -175,19 +175,61 @@ public final class JavaxValidationJavaArbitraryResolver implements JavaArbitrary
 	}
 
 	@Override
-	public Arbitrary<Double> doubles(
-		DoubleArbitrary doubleArbitrary,
-		ArbitraryGeneratorContext context
-	) {
-		throw new UnsupportedOperationException("Not implement yet.");
-	}
-
-	@Override
 	public Arbitrary<Float> floats(
 		FloatArbitrary floatArbitrary,
 		ArbitraryGeneratorContext context
 	) {
-		throw new UnsupportedOperationException("Not implement yet.");
+		JavaxValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				floatArbitrary = floatArbitrary.greaterThan(min.floatValue());
+			} else {
+				floatArbitrary = floatArbitrary.greaterOrEqual(min.floatValue());
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				floatArbitrary = floatArbitrary.lessThan(max.floatValue());
+			} else {
+				floatArbitrary = floatArbitrary.lessOrEqual(max.floatValue());
+			}
+		}
+
+		return floatArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Double> doubles(
+		DoubleArbitrary doubleArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JavaxValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				doubleArbitrary = doubleArbitrary.greaterThan(min.doubleValue());
+			} else {
+				doubleArbitrary = doubleArbitrary.greaterOrEqual(min.doubleValue());
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				doubleArbitrary = doubleArbitrary.lessThan(max.doubleValue());
+			} else {
+				doubleArbitrary = doubleArbitrary.lessOrEqual(max.doubleValue());
+			}
+		}
+
+		return doubleArbitrary;
 	}
 
 	@Override
@@ -214,7 +256,18 @@ public final class JavaxValidationJavaArbitraryResolver implements JavaArbitrary
 		LongArbitrary longArbitrary,
 		ArbitraryGeneratorContext context
 	) {
-		throw new UnsupportedOperationException("Not implement yet.");
+		JavaxValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			longArbitrary = longArbitrary.greaterOrEqual(min.longValueExact());
+		}
+		if (max != null) {
+			longArbitrary = longArbitrary.lessOrEqual(max.longValueExact());
+		}
+
+		return longArbitrary;
 	}
 
 	@Override
@@ -222,7 +275,18 @@ public final class JavaxValidationJavaArbitraryResolver implements JavaArbitrary
 		BigIntegerArbitrary bigIntegerArbitrary,
 		ArbitraryGeneratorContext context
 	) {
-		throw new UnsupportedOperationException("Not implement yet.");
+		JavaxValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			bigIntegerArbitrary = bigIntegerArbitrary.greaterOrEqual(min);
+		}
+		if (max != null) {
+			bigIntegerArbitrary = bigIntegerArbitrary.lessOrEqual(max);
+		}
+
+		return bigIntegerArbitrary;
 	}
 
 	@Override
@@ -230,6 +294,27 @@ public final class JavaxValidationJavaArbitraryResolver implements JavaArbitrary
 		BigDecimalArbitrary bigDecimalArbitrary,
 		ArbitraryGeneratorContext context
 	) {
-		throw new UnsupportedOperationException("Not implement yet.");
+		JavaxValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				bigDecimalArbitrary = bigDecimalArbitrary.greaterThan(min);
+			} else {
+				bigDecimalArbitrary = bigDecimalArbitrary.greaterOrEqual(min);
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				bigDecimalArbitrary = bigDecimalArbitrary.lessThan(max);
+			} else {
+				bigDecimalArbitrary = bigDecimalArbitrary.lessOrEqual(max);
+			}
+		}
+
+		return bigDecimalArbitrary;
 	}
 }

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/BigDecimalIntrospectorSpec.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/BigDecimalIntrospectorSpec.java
@@ -1,0 +1,50 @@
+package com.navercorp.fixturemonkey.javax.validation.introspector;
+
+import java.math.BigDecimal;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+public class BigDecimalIntrospectorSpec {
+	private BigDecimal bigDecimalValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private BigDecimal digitsValue;
+
+	@Min(100)
+	private BigDecimal minValue;
+
+	@Max(100)
+	private BigDecimal maxValue;
+
+	@DecimalMin(value = "100.1")
+	private BigDecimal decimalMin;
+
+	@DecimalMin(value = "100.1", inclusive = false)
+	private BigDecimal decimalMinExclusive;
+
+	@DecimalMax(value = "100.1")
+	private BigDecimal decimalMax;
+
+	@DecimalMax(value = "100.1", inclusive = false)
+	private BigDecimal decimalMaxExclusive;
+
+	@Negative
+	private BigDecimal negative;
+
+	@NegativeOrZero
+	private BigDecimal negativeOrZero;
+
+	@Positive
+	private BigDecimal positive;
+
+	@PositiveOrZero
+	private BigDecimal positiveOrZero;
+}

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/BigIntegerIntrospectorSpec.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/BigIntegerIntrospectorSpec.java
@@ -1,0 +1,50 @@
+package com.navercorp.fixturemonkey.javax.validation.introspector;
+
+import java.math.BigInteger;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+public class BigIntegerIntrospectorSpec {
+	private BigInteger bigIntegerValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private BigInteger digitsValue;
+
+	@Min(100)
+	private BigInteger minValue;
+
+	@Max(100)
+	private BigInteger maxValue;
+
+	@DecimalMin(value = "100")
+	private BigInteger decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private BigInteger decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private BigInteger decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private BigInteger decimalMaxExclusive;
+
+	@Negative
+	private BigInteger negative;
+
+	@NegativeOrZero
+	private BigInteger negativeOrZero;
+
+	@Positive
+	private BigInteger positive;
+
+	@PositiveOrZero
+	private BigInteger positiveOrZero;
+}

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/FloatIntrospectorSpec.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/FloatIntrospectorSpec.java
@@ -1,0 +1,48 @@
+package com.navercorp.fixturemonkey.javax.validation.introspector;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+public class FloatIntrospectorSpec {
+	private float floatValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private float digitsValue;
+
+	@Min(100)
+	private float minValue;
+
+	@Max(100)
+	private float maxValue;
+
+	@DecimalMin(value = "100.1")
+	private float decimalMin;
+
+	@DecimalMin(value = "100.1", inclusive = false)
+	private float decimalMinExclusive;
+
+	@DecimalMax(value = "100.1")
+	private float decimalMax;
+
+	@DecimalMax(value = "100.1", inclusive = false)
+	private float decimalMaxExclusive;
+
+	@Negative
+	private float negative;
+
+	@NegativeOrZero
+	private float negativeOrZero;
+
+	@Positive
+	private float positive;
+
+	@PositiveOrZero
+	private float positiveOrZero;
+}

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
@@ -21,15 +21,22 @@ package com.navercorp.fixturemonkey.javax.validation.introspector;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Property;
+import net.jqwik.api.arbitraries.BigDecimalArbitrary;
+import net.jqwik.api.arbitraries.BigIntegerArbitrary;
 import net.jqwik.api.arbitraries.ByteArbitrary;
 import net.jqwik.api.arbitraries.CharacterArbitrary;
+import net.jqwik.api.arbitraries.DoubleArbitrary;
+import net.jqwik.api.arbitraries.FloatArbitrary;
 import net.jqwik.api.arbitraries.IntegerArbitrary;
+import net.jqwik.api.arbitraries.LongArbitrary;
 import net.jqwik.api.arbitraries.ShortArbitrary;
 import net.jqwik.api.arbitraries.StringArbitrary;
 
@@ -1073,6 +1080,414 @@ class JavaxValidationArbitraryIntrospectorTest {
 	}
 
 	@Property
+	void floats() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"floatValue"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isNotNull();
+	}
+
+	@Property
+	void floatsDigitsValue() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"digitsValue"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isBetween(-10000F, 10000F);
+	}
+
+	@Property
+	void floatsMinValue() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"minValue"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100);
+	}
+
+	@Property
+	void floatsMaxValue() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"maxValue"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isLessThanOrEqualTo(100);
+	}
+
+	@Property
+	void floatsDecimalMin() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"decimalMin"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100.1F);
+	}
+
+	@Property
+	void floatsDecimalMinExclusive() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"decimalMinExclusive"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100.1F);
+	}
+
+	@Property
+	void floatsDecimalMax() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"decimalMax"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isLessThanOrEqualTo(100.1F);
+	}
+
+	@Property
+	void floatsDecimalMaxExclusive() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"decimalMaxExclusive"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isLessThanOrEqualTo(100.1F);
+	}
+
+	@Property
+	void floatsNegative() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"negative"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isLessThan(0);
+	}
+
+	@Property
+	void floatsNegativeOrZero() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"negativeOrZero"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isLessThanOrEqualTo(0);
+	}
+
+	@Property
+	void floatsPositive() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"positive"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isGreaterThan(0);
+	}
+
+	@Property
+	void floatsPositiveOrZero() {
+		// given
+		FloatArbitrary floatArbitrary = Arbitraries.floats();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<FloatIntrospectorSpec>(){},
+			"positiveOrZero"
+		);
+
+		// when
+		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+
+		// then
+		Float value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void doubles() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"doubleValue"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isNotNull();
+	}
+
+	@Property
+	void doublesDigitsValue() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"digitsValue"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isBetween(-10000D, 10000D);
+	}
+
+	@Property
+	void doublesMinValue() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"minValue"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100);
+	}
+
+	@Property
+	void doublesMaxValue() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"maxValue"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isLessThanOrEqualTo(100);
+	}
+
+	@Property
+	void doublesDecimalMin() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"decimalMin"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100.1D);
+	}
+
+	@Property
+	void doublesDecimalMinExclusive() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"decimalMinExclusive"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100.1D);
+	}
+
+	@Property
+	void doublesDecimalMax() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"decimalMax"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isLessThanOrEqualTo(100.1D);
+	}
+
+	@Property
+	void doublesDecimalMaxExclusive() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"decimalMaxExclusive"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isLessThanOrEqualTo(100.1D);
+	}
+
+	@Property
+	void doublesNegative() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"negative"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isLessThan(0);
+	}
+
+	@Property
+	void doublesNegativeOrZero() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"negativeOrZero"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isLessThanOrEqualTo(0);
+	}
+
+	@Property
+	void doublesPositive() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"positive"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isGreaterThan(0);
+	}
+
+	@Property
+	void doublesPositiveOrZero() {
+		// given
+		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<DoubleIntrospectorSpec>(){},
+			"positiveOrZero"
+		);
+
+		// when
+		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+
+		// then
+		Double value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
 	void integers() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
@@ -1455,4 +1870,637 @@ class JavaxValidationArbitraryIntrospectorTest {
 		Integer value = actual.sample();
 		then(value).isGreaterThanOrEqualTo(0);
 	}
+
+	@Property
+	void longs() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"longValue"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isNotNull();
+	}
+
+	@Property
+	void longsDigitsValue() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"digitsValue"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isBetween(-10000L, 10000L);
+	}
+
+	@Property
+	void longsMinValue() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"minValue"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100);
+	}
+
+	@Property
+	void longsMaxValue() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"maxValue"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isLessThanOrEqualTo(100);
+	}
+
+	@Property
+	void longsDecimalMin() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"decimalMin"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(100);
+	}
+
+	@Property
+	void longsDecimalMinExclusive() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"decimalMinExclusive"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(101);
+	}
+
+	@Property
+	void longsDecimalMax() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"decimalMax"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isLessThanOrEqualTo(100);
+	}
+
+	@Property
+	void longsDecimalMaxExclusive() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"decimalMaxExclusive"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isLessThanOrEqualTo(99);
+	}
+
+	@Property
+	void longsNegative() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"negative"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isLessThan(0);
+	}
+
+	@Property
+	void longsNegativeOrZero() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"negativeOrZero"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isLessThanOrEqualTo(0);
+	}
+
+	@Property
+	void longsPositive() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"positive"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isGreaterThan(0);
+	}
+
+	@Property
+	void longsPositiveOrZero() {
+		// given
+		LongArbitrary longArbitrary = Arbitraries.longs();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<LongIntrospectorSpec>(){},
+			"positiveOrZero"
+		);
+
+		// when
+		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+
+		// then
+		Long value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void bigIntegers() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"bigIntegerValue"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isNotNull();
+	}
+
+	@Property
+	void bigIntegersDigitsValue() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"digitsValue"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isBetween(BigInteger.valueOf(-10000), BigInteger.valueOf(10000));
+	}
+
+	@Property
+	void bigIntegersMinValue() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"minValue"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
+	}
+
+	@Property
+	void bigIntegersMaxValue() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"maxValue"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigInteger.valueOf(100));
+	}
+
+	@Property
+	void bigIntegersDecimalMin() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"decimalMin"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
+	}
+
+	@Property
+	void bigIntegersDecimalMinExclusive() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"decimalMinExclusive"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(101));
+	}
+
+	@Property
+	void bigIntegersDecimalMax() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"decimalMax"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigInteger.valueOf(100));
+	}
+
+	@Property
+	void bigIntegersDecimalMaxExclusive() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"decimalMaxExclusive"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigInteger.valueOf(99));
+	}
+
+	@Property
+	void bigIntegersNegative() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"negative"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isLessThan(BigInteger.valueOf(0));
+	}
+
+	@Property
+	void bigIntegersNegativeOrZero() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"negativeOrZero"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigInteger.valueOf(0));
+	}
+
+	@Property
+	void bigIntegersPositive() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"positive"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isGreaterThan(BigInteger.valueOf(0));
+	}
+
+	@Property
+	void bigIntegersPositiveOrZero() {
+		// given
+		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			"positiveOrZero"
+		);
+
+		// when
+		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+
+		// then
+		BigInteger value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(0));
+	}
+
+	@Property
+	void bigDecimals() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"bigDecimalValue"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isNotNull();
+	}
+
+	@Property
+	void bigDecimalsDigitsValue() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"digitsValue"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isBetween(BigDecimal.valueOf(-10000), BigDecimal.valueOf(10000));
+	}
+
+	@Property
+	void bigDecimalsMinValue() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"minValue"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100));
+	}
+
+	@Property
+	void bigDecimalsMaxValue() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"maxValue"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100));
+	}
+
+	@Property
+	void bigDecimalsDecimalMin() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"decimalMin"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
+	}
+
+	@Property
+	void bigDecimalsDecimalMinExclusive() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"decimalMinExclusive"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
+	}
+
+	@Property
+	void bigDecimalsDecimalMax() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"decimalMax"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
+	}
+
+	@Property
+	void bigDecimalsDecimalMaxExclusive() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"decimalMaxExclusive"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
+	}
+
+	@Property
+	void bigDecimalsNegative() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"negative"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isLessThan(BigDecimal.valueOf(0));
+	}
+
+	@Property
+	void bigDecimalsNegativeOrZero() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"negativeOrZero"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(0));
+	}
+
+	@Property
+	void bigDecimalsPositive() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"positive"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isGreaterThan(BigDecimal.valueOf(0));
+	}
+
+	@Property
+	void bigDecimalsPositiveOrZero() {
+		// given
+		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			"positiveOrZero"
+		);
+
+		// when
+		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+
+		// then
+		BigDecimal value = actual.sample();
+		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(0));
+	}
+
+	private <T> ArbitraryGeneratorContext makeContext(TypeReference<T> typeReference, String propertyName) {
+		com.navercorp.fixturemonkey.api.property.Property property =
+			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
+
+		return new ArbitraryGeneratorContext(
+			new ArbitraryProperty(
+				property,
+				PropertyNameResolver.IDENTITY,
+				0.0D,
+				null,
+				Collections.emptyList(),
+				null
+			),
+			Collections.emptyList(),
+			null,
+			(ctx, prop) -> Arbitraries.just(null),
+			Collections.emptyList()
+		);
+	}
+
 }

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationArbitraryIntrospectorTest.java
@@ -53,24 +53,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void strings() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "str";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"str"
 		);
 
 		// when
@@ -85,24 +70,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringsNotBlank() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "notBlank";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"notBlank"
 		);
 
 		// when
@@ -117,24 +87,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringsNotEmpty() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "notEmpty";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"notEmpty"
 		);
 
 		// when
@@ -149,24 +104,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringsSize() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "size";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"size"
 		);
 
 		// when
@@ -182,24 +122,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringDigits() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "digits";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"digits"
 		);
 
 		// when
@@ -215,24 +140,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringPattern() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "pattern";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"pattern"
 		);
 
 		// when
@@ -252,24 +162,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void stringEmail() {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
-		TypeReference<StringIntrospectorSpec> typeReference = new TypeReference<StringIntrospectorSpec>() {
-		};
-		String propertyName = "email";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<StringIntrospectorSpec>(){},
+			"email"
 		);
 
 		// when
@@ -284,24 +179,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void characters() {
 		// given
 		CharacterArbitrary characterArbitrary = Arbitraries.chars();
-		TypeReference<CharacterIntrospectorSpec> typeReference = new TypeReference<CharacterIntrospectorSpec>() {
-		};
-		String propertyName = "character";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<CharacterIntrospectorSpec>(){},
+			"character"
 		);
 
 		// when
@@ -315,24 +195,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shorts() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "shortValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"shortValue"
 		);
 
 		// when
@@ -347,24 +212,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortDigitsValue() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "digitsValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"digitsValue"
 		);
 
 		// when
@@ -379,24 +229,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortMinValue() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "minValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"minValue"
 		);
 
 		// when
@@ -411,24 +246,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortMaxValue() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "maxValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"maxValue"
 		);
 
 		// when
@@ -443,24 +263,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortDecimalMin() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMin";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"decimalMin"
 		);
 
 		// when
@@ -475,24 +280,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortDecimalMinExclusive() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMinExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"decimalMinExclusive"
 		);
 
 		// when
@@ -507,24 +297,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortDecimalMax() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMax";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"decimalMax"
 		);
 
 		// when
@@ -539,24 +314,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortDecimalMaxExclusive() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMaxExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"decimalMaxExclusive"
 		);
 
 		// when
@@ -571,24 +331,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortNegative() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "negative";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"negative"
 		);
 
 		// when
@@ -603,24 +348,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortNegativeOrZero() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "negativeOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"negativeOrZero"
 		);
 
 		// when
@@ -635,24 +365,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortPositive() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "positive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"positive"
 		);
 
 		// when
@@ -667,24 +382,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void shortPositiveOrZero() {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
-		TypeReference<ShortIntrospectorSpec> typeReference = new TypeReference<ShortIntrospectorSpec>() {
-		};
-		String propertyName = "positiveOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ShortIntrospectorSpec>(){},
+			"positiveOrZero"
 		);
 
 		// when
@@ -699,24 +399,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void bytes() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "byteValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"byteValue"
 		);
 
 		// when
@@ -731,24 +416,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteDigitsValue() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "digitsValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"digitsValue"
 		);
 
 		// when
@@ -763,24 +433,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteMinValue() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "minValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"minValue"
 		);
 
 		// when
@@ -795,24 +450,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteMaxValue() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "maxValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"maxValue"
 		);
 
 		// when
@@ -827,24 +467,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteDecimalMin() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMin";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"decimalMin"
 		);
 
 		// when
@@ -859,24 +484,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteDecimalMinExclusive() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMinExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"decimalMinExclusive"
 		);
 
 		// when
@@ -891,24 +501,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteDecimalMax() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMax";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"decimalMax"
 		);
 
 		// when
@@ -923,24 +518,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteDecimalMaxExclusive() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMaxExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"decimalMaxExclusive"
 		);
 
 		// when
@@ -955,24 +535,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteNegative() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "negative";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"negative"
 		);
 
 		// when
@@ -987,24 +552,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void byteNegativeOrZero() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "negativeOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"negativeOrZero"
 		);
 
 		// when
@@ -1019,24 +569,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void bytePositive() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "positive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"positive"
 		);
 
 		// when
@@ -1051,24 +586,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void bytePositiveOrZero() {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
-		TypeReference<ByteIntrospectorSpec> typeReference = new TypeReference<ByteIntrospectorSpec>() {
-		};
-		String propertyName = "positiveOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<ByteIntrospectorSpec>(){},
+			"positiveOrZero"
 		);
 
 		// when
@@ -1491,24 +1011,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integers() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "intValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"intValue"
 		);
 
 		// when
@@ -1523,24 +1028,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersDigitsValue() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "digitsValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"digitsValue"
 		);
 
 		// when
@@ -1555,24 +1045,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersMinValue() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "minValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"minValue"
 		);
 
 		// when
@@ -1587,24 +1062,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersMaxValue() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "maxValue";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"maxValue"
 		);
 
 		// when
@@ -1619,24 +1079,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersDecimalMin() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMin";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"decimalMin"
 		);
 
 		// when
@@ -1651,24 +1096,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersDecimalMinExclusive() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMinExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"decimalMinExclusive"
 		);
 
 		// when
@@ -1683,24 +1113,9 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersDecimalMax() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMax";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"decimalMax"
 		);
 
 		// when
@@ -1715,25 +1130,11 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersDecimalMaxExclusive() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "decimalMaxExclusive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"decimalMaxExclusive"
 		);
+
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1747,25 +1148,11 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersNegative() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "negative";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"negative"
 		);
+
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1779,25 +1166,11 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersNegativeOrZero() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "negativeOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"negativeOrZero"
 		);
+
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1811,25 +1184,11 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersPositive() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "positive";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"positive"
 		);
+
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1843,25 +1202,11 @@ class JavaxValidationArbitraryIntrospectorTest {
 	void integersPositiveOrZero() {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
-		TypeReference<IntIntrospectorSpec> typeReference = new TypeReference<IntIntrospectorSpec>() {
-		};
-		String propertyName = "positiveOrZero";
-		com.navercorp.fixturemonkey.api.property.Property property =
-			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
+		ArbitraryGeneratorContext context = makeContext(
+			new TypeReference<IntIntrospectorSpec>(){},
+			"positiveOrZero"
 		);
+
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
@@ -54,7 +54,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"str"
 		);
 
@@ -71,7 +72,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"notBlank"
 		);
 
@@ -88,7 +90,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"notEmpty"
 		);
 
@@ -105,7 +108,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"size"
 		);
 
@@ -123,7 +127,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"digits"
 		);
 
@@ -141,7 +146,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"pattern"
 		);
 
@@ -163,7 +169,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		StringArbitrary stringArbitrary = Arbitraries.strings();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<StringIntrospectorSpec>(){},
+			new TypeReference<StringIntrospectorSpec>() {
+			},
 			"email"
 		);
 
@@ -180,7 +187,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		CharacterArbitrary characterArbitrary = Arbitraries.chars();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<CharacterIntrospectorSpec>(){},
+			new TypeReference<CharacterIntrospectorSpec>() {
+			},
 			"character"
 		);
 
@@ -196,7 +204,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"shortValue"
 		);
 
@@ -213,7 +222,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -230,7 +240,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -247,7 +258,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -264,7 +276,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -281,7 +294,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -298,7 +312,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -315,7 +330,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -332,7 +348,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -349,7 +366,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -366,7 +384,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -383,7 +402,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ShortArbitrary shortArbitrary = Arbitraries.shorts();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ShortIntrospectorSpec>(){},
+			new TypeReference<ShortIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -400,7 +420,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"byteValue"
 		);
 
@@ -417,7 +438,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -434,7 +456,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -451,7 +474,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -468,7 +492,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -485,7 +510,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -502,7 +528,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -519,7 +546,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -536,7 +564,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -553,7 +582,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -570,7 +600,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -587,7 +618,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		ByteArbitrary byteArbitrary = Arbitraries.bytes();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<ByteIntrospectorSpec>(){},
+			new TypeReference<ByteIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -604,7 +636,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"floatValue"
 		);
 
@@ -621,7 +654,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -638,7 +672,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -655,7 +690,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -672,7 +708,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -689,7 +726,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -706,7 +744,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -723,7 +762,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -740,7 +780,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -757,7 +798,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -774,7 +816,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -791,7 +834,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		FloatArbitrary floatArbitrary = Arbitraries.floats();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<FloatIntrospectorSpec>(){},
+			new TypeReference<FloatIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -808,7 +852,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"doubleValue"
 		);
 
@@ -825,7 +870,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -842,7 +888,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -859,7 +906,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -876,7 +924,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -893,7 +942,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -910,7 +960,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -927,7 +978,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -944,7 +996,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -961,7 +1014,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -978,7 +1032,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -995,7 +1050,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		DoubleArbitrary doubleArbitrary = Arbitraries.doubles();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<DoubleIntrospectorSpec>(){},
+			new TypeReference<DoubleIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -1012,7 +1068,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"intValue"
 		);
 
@@ -1029,7 +1086,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -1046,7 +1104,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -1063,7 +1122,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -1080,7 +1140,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -1097,7 +1158,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -1114,7 +1176,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -1131,10 +1194,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
-
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1149,10 +1212,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"negative"
 		);
-
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1167,10 +1230,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
-
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1185,10 +1248,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"positive"
 		);
-
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1203,10 +1266,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		IntegerArbitrary integerArbitrary = Arbitraries.integers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<IntIntrospectorSpec>(){},
+			new TypeReference<IntIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
-
 
 		// when
 		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
@@ -1221,7 +1284,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"longValue"
 		);
 
@@ -1238,7 +1302,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -1255,7 +1320,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -1272,7 +1338,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -1289,7 +1356,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -1306,7 +1374,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -1323,7 +1392,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -1340,7 +1410,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -1357,7 +1428,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -1374,7 +1446,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -1391,7 +1464,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -1408,7 +1482,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		LongArbitrary longArbitrary = Arbitraries.longs();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<LongIntrospectorSpec>(){},
+			new TypeReference<LongIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -1425,7 +1500,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"bigIntegerValue"
 		);
 
@@ -1442,7 +1518,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -1459,7 +1536,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -1476,7 +1554,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -1493,7 +1572,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -1510,7 +1590,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -1527,7 +1608,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -1544,7 +1626,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -1561,7 +1644,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -1578,7 +1662,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -1595,7 +1680,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -1612,7 +1698,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigIntegerArbitrary bigIntegerArbitrary = Arbitraries.bigIntegers();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigIntegerIntrospectorSpec>(){},
+			new TypeReference<BigIntegerIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 
@@ -1629,7 +1716,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"bigDecimalValue"
 		);
 
@@ -1646,7 +1734,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"digitsValue"
 		);
 
@@ -1663,7 +1752,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"minValue"
 		);
 
@@ -1680,7 +1770,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"maxValue"
 		);
 
@@ -1697,7 +1788,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"decimalMin"
 		);
 
@@ -1714,7 +1806,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"decimalMinExclusive"
 		);
 
@@ -1731,7 +1824,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"decimalMax"
 		);
 
@@ -1748,7 +1842,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"decimalMaxExclusive"
 		);
 
@@ -1765,7 +1860,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"negative"
 		);
 
@@ -1782,7 +1878,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"negativeOrZero"
 		);
 
@@ -1799,7 +1896,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"positive"
 		);
 
@@ -1816,7 +1914,8 @@ class JavaxValidationJavaArbitraryResolverTest {
 		// given
 		BigDecimalArbitrary bigDecimalArbitrary = Arbitraries.bigDecimals();
 		ArbitraryGeneratorContext context = makeContext(
-			new TypeReference<BigDecimalIntrospectorSpec>(){},
+			new TypeReference<BigDecimalIntrospectorSpec>() {
+			},
 			"positiveOrZero"
 		);
 

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
@@ -46,7 +46,7 @@ import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
-class JavaxValidationArbitraryIntrospectorTest {
+class JavaxValidationJavaArbitraryResolverTest {
 	private final JavaxValidationJavaArbitraryResolver sut = new JavaxValidationJavaArbitraryResolver();
 
 	@Property

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
@@ -60,11 +60,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -78,11 +77,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value).isNotBlank();
+		then(actual).isNotBlank();
 	}
 
 	@Property
@@ -96,11 +94,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value).isNotEmpty();
+		then(actual).isNotEmpty();
 	}
 
 	@Property
@@ -114,12 +111,11 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value.length()).isGreaterThanOrEqualTo(5);
-		then(value.length()).isLessThanOrEqualTo(10);
+		then(actual.length()).isGreaterThanOrEqualTo(5);
+		then(actual.length()).isLessThanOrEqualTo(10);
 	}
 
 	@Property
@@ -133,12 +129,11 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value.length()).isLessThanOrEqualTo(10);
-		thenNoException().isThrownBy(() -> Long.parseLong(value));
+		then(actual.length()).isLessThanOrEqualTo(10);
+		thenNoException().isThrownBy(() -> Long.parseLong(actual));
 	}
 
 	@Property
@@ -152,14 +147,13 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
 		Pattern pattern = Pattern.compile("[e-o]");
-		then(pattern.asPredicate().test(value)).isTrue();
-		for (int i = 0; i < value.length(); i++) {
-			char ch = value.charAt(i);
+		then(pattern.asPredicate().test(actual)).isTrue();
+		for (int i = 0; i < actual.length(); i++) {
+			char ch = actual.charAt(i);
 			then(ch).isBetween('e', 'o');
 		}
 	}
@@ -175,11 +169,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<String> actual = this.sut.strings(stringArbitrary, context);
+		String actual = this.sut.strings(stringArbitrary, context).sample();
 
 		// then
-		String value = actual.sample();
-		then(value).containsOnlyOnce("@");
+		then(actual).containsOnlyOnce("@");
 	}
 
 	@Property
@@ -210,11 +203,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -228,11 +220,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isBetween((short)-10000, (short)10000);
+		then(actual).isBetween((short)-10000, (short)10000);
 	}
 
 	@Property
@@ -246,11 +237,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((short)100);
+		then(actual).isGreaterThanOrEqualTo((short)100);
 	}
 
 	@Property
@@ -264,11 +254,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isLessThanOrEqualTo((short)100);
+		then(actual).isLessThanOrEqualTo((short)100);
 	}
 
 	@Property
@@ -282,11 +271,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((short)100);
+		then(actual).isGreaterThanOrEqualTo((short)100);
 	}
 
 	@Property
@@ -300,11 +288,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((short)101);
+		then(actual).isGreaterThanOrEqualTo((short)101);
 	}
 
 	@Property
@@ -318,11 +305,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isLessThanOrEqualTo((short)100);
+		then(actual).isLessThanOrEqualTo((short)100);
 	}
 
 	@Property
@@ -336,11 +322,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isLessThanOrEqualTo((short)99);
+		then(actual).isLessThanOrEqualTo((short)99);
 	}
 
 	@Property
@@ -354,11 +339,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isLessThan((short)0);
+		then(actual).isLessThan((short)0);
 	}
 
 	@Property
@@ -372,11 +356,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isLessThanOrEqualTo((short)0);
+		then(actual).isLessThanOrEqualTo((short)0);
 	}
 
 	@Property
@@ -390,11 +373,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isGreaterThan((short)0);
+		then(actual).isGreaterThan((short)0);
 	}
 
 	@Property
@@ -408,11 +390,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Short> actual = this.sut.shorts(shortArbitrary, context);
+		Short actual = this.sut.shorts(shortArbitrary, context).sample();
 
 		// then
-		short value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((short)0);
+		then(actual).isGreaterThanOrEqualTo((short)0);
 	}
 
 	@Property
@@ -426,11 +407,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -444,11 +424,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isBetween((byte)-100, (byte)100);
+		then(actual).isBetween((byte)-100, (byte)100);
 	}
 
 	@Property
@@ -462,11 +441,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((byte)100);
+		then(actual).isGreaterThanOrEqualTo((byte)100);
 	}
 
 	@Property
@@ -480,11 +458,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isLessThanOrEqualTo((byte)100);
+		then(actual).isLessThanOrEqualTo((byte)100);
 	}
 
 	@Property
@@ -498,11 +475,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((byte)100);
+		then(actual).isGreaterThanOrEqualTo((byte)100);
 	}
 
 	@Property
@@ -516,11 +492,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((byte)101);
+		then(actual).isGreaterThanOrEqualTo((byte)101);
 	}
 
 	@Property
@@ -534,11 +509,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isLessThanOrEqualTo((byte)100);
+		then(actual).isLessThanOrEqualTo((byte)100);
 	}
 
 	@Property
@@ -552,11 +526,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isLessThanOrEqualTo((byte)99);
+		then(actual).isLessThanOrEqualTo((byte)99);
 	}
 
 	@Property
@@ -570,11 +543,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isLessThan((byte)0);
+		then(actual).isLessThan((byte)0);
 	}
 
 	@Property
@@ -588,11 +560,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isLessThanOrEqualTo((byte)0);
+		then(actual).isLessThanOrEqualTo((byte)0);
 	}
 
 	@Property
@@ -606,11 +577,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isGreaterThan((byte)0);
+		then(actual).isGreaterThan((byte)0);
 	}
 
 	@Property
@@ -624,11 +594,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Byte> actual = this.sut.bytes(byteArbitrary, context);
+		Byte actual = this.sut.bytes(byteArbitrary, context).sample();
 
 		// then
-		byte value = actual.sample();
-		then(value).isGreaterThanOrEqualTo((byte)0);
+		then(actual).isGreaterThanOrEqualTo((byte)0);
 	}
 
 	@Property
@@ -642,11 +611,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -660,11 +628,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isBetween(-10000F, 10000F);
+		then(actual).isBetween(-10000F, 10000F);
 	}
 
 	@Property
@@ -678,11 +645,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -696,11 +662,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -714,11 +679,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100.1F);
+		then(actual).isGreaterThanOrEqualTo(100.1F);
 	}
 
 	@Property
@@ -732,11 +696,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100.1F);
+		then(actual).isGreaterThanOrEqualTo(100.1F);
 	}
 
 	@Property
@@ -750,11 +713,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isLessThanOrEqualTo(100.1F);
+		then(actual).isLessThanOrEqualTo(100.1F);
 	}
 
 	@Property
@@ -768,11 +730,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isLessThanOrEqualTo(100.1F);
+		then(actual).isLessThanOrEqualTo(100.1F);
 	}
 
 	@Property
@@ -786,11 +747,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isLessThan(0);
+		then(actual).isLessThan(0);
 	}
 
 	@Property
@@ -804,11 +764,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isLessThanOrEqualTo(0);
+		then(actual).isLessThanOrEqualTo(0);
 	}
 
 	@Property
@@ -822,11 +781,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isGreaterThan(0);
+		then(actual).isGreaterThan(0);
 	}
 
 	@Property
@@ -840,11 +798,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Float> actual = this.sut.floats(floatArbitrary, context);
+		Float actual = this.sut.floats(floatArbitrary, context).sample();
 
 		// then
-		Float value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(0);
+		then(actual).isGreaterThanOrEqualTo(0);
 	}
 
 	@Property
@@ -858,11 +815,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -876,11 +832,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isBetween(-10000D, 10000D);
+		then(actual).isBetween(-10000D, 10000D);
 	}
 
 	@Property
@@ -894,11 +849,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -912,11 +866,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -930,11 +883,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100.1D);
+		then(actual).isGreaterThanOrEqualTo(100.1D);
 	}
 
 	@Property
@@ -948,11 +900,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100.1D);
+		then(actual).isGreaterThanOrEqualTo(100.1D);
 	}
 
 	@Property
@@ -966,11 +917,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isLessThanOrEqualTo(100.1D);
+		then(actual).isLessThanOrEqualTo(100.1D);
 	}
 
 	@Property
@@ -984,11 +934,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isLessThanOrEqualTo(100.1D);
+		then(actual).isLessThanOrEqualTo(100.1D);
 	}
 
 	@Property
@@ -1002,11 +951,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isLessThan(0);
+		then(actual).isLessThan(0);
 	}
 
 	@Property
@@ -1020,11 +968,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isLessThanOrEqualTo(0);
+		then(actual).isLessThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1038,11 +985,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isGreaterThan(0);
+		then(actual).isGreaterThan(0);
 	}
 
 	@Property
@@ -1056,11 +1002,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Double> actual = this.sut.doubles(doubleArbitrary, context);
+		Double actual = this.sut.doubles(doubleArbitrary, context).sample();
 
 		// then
-		Double value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(0);
+		then(actual).isGreaterThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1074,11 +1019,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -1092,11 +1036,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isBetween(-10000, 10000);
+		then(actual).isBetween(-10000, 10000);
 	}
 
 	@Property
@@ -1110,11 +1053,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1128,11 +1070,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1146,11 +1087,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1164,11 +1104,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(101);
+		then(actual).isGreaterThanOrEqualTo(101);
 	}
 
 	@Property
@@ -1182,11 +1121,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1200,11 +1138,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isLessThanOrEqualTo(99);
+		then(actual).isLessThanOrEqualTo(99);
 	}
 
 	@Property
@@ -1218,11 +1155,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isLessThan(0);
+		then(actual).isLessThan(0);
 	}
 
 	@Property
@@ -1236,11 +1172,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isLessThanOrEqualTo(0);
+		then(actual).isLessThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1254,11 +1189,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isGreaterThan(0);
+		then(actual).isGreaterThan(0);
 	}
 
 	@Property
@@ -1272,11 +1206,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Integer> actual = this.sut.integers(integerArbitrary, context);
+		Integer actual = this.sut.integers(integerArbitrary, context).sample();
 
 		// then
-		Integer value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(0);
+		then(actual).isGreaterThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1290,11 +1223,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -1308,11 +1240,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isBetween(-10000L, 10000L);
+		then(actual).isBetween(-10000L, 10000L);
 	}
 
 	@Property
@@ -1326,11 +1257,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1344,11 +1274,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1362,11 +1291,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(100);
+		then(actual).isGreaterThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1380,11 +1308,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(101);
+		then(actual).isGreaterThanOrEqualTo(101);
 	}
 
 	@Property
@@ -1398,11 +1325,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isLessThanOrEqualTo(100);
+		then(actual).isLessThanOrEqualTo(100);
 	}
 
 	@Property
@@ -1416,11 +1342,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isLessThanOrEqualTo(99);
+		then(actual).isLessThanOrEqualTo(99);
 	}
 
 	@Property
@@ -1434,11 +1359,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isLessThan(0);
+		then(actual).isLessThan(0);
 	}
 
 	@Property
@@ -1452,11 +1376,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isLessThanOrEqualTo(0);
+		then(actual).isLessThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1470,11 +1393,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isGreaterThan(0);
+		then(actual).isGreaterThan(0);
 	}
 
 	@Property
@@ -1488,11 +1410,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<Long> actual = this.sut.longs(longArbitrary, context);
+		Long actual = this.sut.longs(longArbitrary, context).sample();
 
 		// then
-		Long value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(0);
+		then(actual).isGreaterThanOrEqualTo(0);
 	}
 
 	@Property
@@ -1506,11 +1427,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -1524,11 +1444,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isBetween(BigInteger.valueOf(-10000), BigInteger.valueOf(10000));
+		then(actual).isBetween(BigInteger.valueOf(-10000), BigInteger.valueOf(10000));
 	}
 
 	@Property
@@ -1542,11 +1461,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
 	}
 
 	@Property
@@ -1560,11 +1478,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual).isLessThanOrEqualTo(BigInteger.valueOf(100));
 	}
 
 	@Property
@@ -1578,11 +1495,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
 	}
 
 	@Property
@@ -1596,11 +1512,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(101));
+		then(actual).isGreaterThanOrEqualTo(BigInteger.valueOf(101));
 	}
 
 	@Property
@@ -1614,11 +1529,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual).isLessThanOrEqualTo(BigInteger.valueOf(100));
 	}
 
 	@Property
@@ -1632,11 +1546,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigInteger.valueOf(99));
+		then(actual).isLessThanOrEqualTo(BigInteger.valueOf(99));
 	}
 
 	@Property
@@ -1650,11 +1563,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isLessThan(BigInteger.valueOf(0));
+		then(actual).isLessThan(BigInteger.valueOf(0));
 	}
 
 	@Property
@@ -1668,11 +1580,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigInteger.valueOf(0));
+		then(actual).isLessThanOrEqualTo(BigInteger.valueOf(0));
 	}
 
 	@Property
@@ -1686,11 +1597,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isGreaterThan(BigInteger.valueOf(0));
+		then(actual).isGreaterThan(BigInteger.valueOf(0));
 	}
 
 	@Property
@@ -1704,11 +1614,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigInteger> actual = this.sut.bigIntegers(bigIntegerArbitrary, context);
+		BigInteger actual = this.sut.bigIntegers(bigIntegerArbitrary, context).sample();
 
 		// then
-		BigInteger value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigInteger.valueOf(0));
+		then(actual).isGreaterThanOrEqualTo(BigInteger.valueOf(0));
 	}
 
 	@Property
@@ -1722,11 +1631,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isNotNull();
+		then(actual).isNotNull();
 	}
 
 	@Property
@@ -1740,11 +1648,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isBetween(BigDecimal.valueOf(-10000), BigDecimal.valueOf(10000));
+		then(actual).isBetween(BigDecimal.valueOf(-10000), BigDecimal.valueOf(10000));
 	}
 
 	@Property
@@ -1758,11 +1665,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100));
+		then(actual).isGreaterThanOrEqualTo(BigDecimal.valueOf(100));
 	}
 
 	@Property
@@ -1776,11 +1682,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100));
+		then(actual).isLessThanOrEqualTo(BigDecimal.valueOf(100));
 	}
 
 	@Property
@@ -1794,11 +1699,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
 	}
 
 	@Property
@@ -1812,11 +1716,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
 	}
 
 	@Property
@@ -1830,11 +1733,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
 	}
 
 	@Property
@@ -1848,11 +1750,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
 	}
 
 	@Property
@@ -1866,11 +1767,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isLessThan(BigDecimal.valueOf(0));
+		then(actual).isLessThan(BigDecimal.valueOf(0));
 	}
 
 	@Property
@@ -1884,11 +1784,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isLessThanOrEqualTo(BigDecimal.valueOf(0));
+		then(actual).isLessThanOrEqualTo(BigDecimal.valueOf(0));
 	}
 
 	@Property
@@ -1902,11 +1801,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isGreaterThan(BigDecimal.valueOf(0));
+		then(actual).isGreaterThan(BigDecimal.valueOf(0));
 	}
 
 	@Property
@@ -1920,11 +1818,10 @@ class JavaxValidationJavaArbitraryResolverTest {
 		);
 
 		// when
-		Arbitrary<BigDecimal> actual = this.sut.bigDecimals(bigDecimalArbitrary, context);
+		BigDecimal actual = this.sut.bigDecimals(bigDecimalArbitrary, context).sample();
 
 		// then
-		BigDecimal value = actual.sample();
-		then(value).isGreaterThanOrEqualTo(BigDecimal.valueOf(0));
+		then(actual).isGreaterThanOrEqualTo(BigDecimal.valueOf(0));
 	}
 
 	private <T> ArbitraryGeneratorContext makeContext(TypeReference<T> typeReference, String propertyName) {

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/LongIntrospectorSpec.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/LongIntrospectorSpec.java
@@ -1,0 +1,48 @@
+package com.navercorp.fixturemonkey.javax.validation.introspector;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+public class LongIntrospectorSpec {
+	private long longValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private long digitsValue;
+
+	@Min(100)
+	private long minValue;
+
+	@Max(100)
+	private long maxValue;
+
+	@DecimalMin(value = "100")
+	private long decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private long decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private long decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private long decimalMaxExclusive;
+
+	@Negative
+	private long negative;
+
+	@NegativeOrZero
+	private long negativeOrZero;
+
+	@Positive
+	private long positive;
+
+	@PositiveOrZero
+	private long positiveOrZero;
+}


### PR DESCRIPTION
JavaxValidationJavaArbitraryResolver 에서 미구현되어 있던 메소드들을 구현합니다.
- doubles, floats, longs, bigIntegers, bigDecimals