### PR TITLE
Refactor split into ObjectPropertyGenerator, ContainerPropertyGenerator

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryContainerInfoGenerator.java
@@ -24,5 +24,5 @@ import org.apiguardian.api.API.Status;
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 @FunctionalInterface
 public interface ArbitraryContainerInfoGenerator {
-	ArbitraryContainerInfo generate(ArbitraryPropertyGeneratorContext context);
+	ArbitraryContainerInfo generate(ContainerPropertyGeneratorContext context);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -74,7 +74,7 @@ public final class ArbitraryGeneratorContext {
 	}
 
 	public Property getProperty() {
-		return this.getArbitraryProperty().getProperty();
+		return this.getArbitraryProperty().getObjectProperty().getProperty();
 	}
 
 	public AnnotatedType getAnnotatedType() {
@@ -100,9 +100,13 @@ public final class ArbitraryGeneratorContext {
 			childrenValues.put(child, arbitrary);
 		}
 
-		ChildArbitraryContext childArbitraryContext = new ChildArbitraryContext(property.getProperty(), childrenValues);
+		ChildArbitraryContext childArbitraryContext = new ChildArbitraryContext(
+			property.getObjectProperty().getProperty(),
+			childrenValues
+		);
+
 		arbitraryCustomizers.stream()
-			.filter(it -> it.match(property.getProperty()))
+			.filter(it -> it.match(property.getObjectProperty().getProperty()))
 			.map(MatcherOperator::getOperator)
 			.findFirst()
 			.ifPresent(customizer -> customizer.customizeProperties(childArbitraryContext));
@@ -116,7 +120,7 @@ public final class ArbitraryGeneratorContext {
 	}
 
 	public boolean isRootContext() {
-		return this.property.isRoot();
+		return this.property.getObjectProperty().isRoot();
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
@@ -26,109 +26,56 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class ArbitraryProperty {
-	private final Property property;
-
-	private final PropertyNameResolver propertyNameResolver;
-
-	private final double nullInject;
+	private final ObjectProperty objectProperty;
 
 	@Nullable
-	private final Integer elementIndex;
-
-	private final List<Property> childProperties;
-
-	@Nullable
-	private final ArbitraryContainerInfo containerInfo;
+	private final ContainerProperty containerProperty;
 
 	public ArbitraryProperty(
-		Property property,
-		PropertyNameResolver propertyNameResolver,
-		double nullInject,
-		@Nullable Integer elementIndex,
-		List<Property> childProperties,
-		@Nullable ArbitraryContainerInfo containerInfo
+		ObjectProperty objectProperty,
+		@Nullable ContainerProperty containerProperty
 	) {
-		this.property = property;
-		this.propertyNameResolver = propertyNameResolver;
-		this.nullInject = nullInject;
-		this.elementIndex = elementIndex;
-		this.childProperties = childProperties;
-		this.containerInfo = containerInfo;
+		this.objectProperty = objectProperty;
+		this.containerProperty = containerProperty;
 	}
 
-	public Property getProperty() {
-		return this.property;
-	}
-
-	public PropertyNameResolver getPropertyNameResolver() {
-		return this.propertyNameResolver;
-	}
-
-	public String getResolvePropertyName() {
-		return this.getPropertyNameResolver().resolve(this.property);
-	}
-
-	public double getNullInject() {
-		return this.nullInject;
+	public ObjectProperty getObjectProperty() {
+		return objectProperty;
 	}
 
 	@Nullable
-	public Integer getElementIndex() {
-		return this.elementIndex;
-	}
-
-	public List<Property> getChildProperties() {
-		return this.childProperties;
-	}
-
-	@Nullable
-	public ArbitraryContainerInfo getContainerInfo() {
-		return this.containerInfo;
-	}
-
-	public boolean isRoot() {
-		return this.property instanceof RootProperty;
-	}
-
-	public boolean isContainer() {
-		return this.containerInfo != null;
-	}
-
-	public ArbitraryProperty withChildProperties(List<Property> childProperties) {
-		return new ArbitraryProperty(
-			this.property,
-			this.propertyNameResolver,
-			this.nullInject,
-			this.elementIndex,
-			childProperties,
-			this.containerInfo
-		);
-	}
-
-	public ArbitraryProperty withContainerInfo(@Nullable ArbitraryContainerInfo containerInfo) {
-		return new ArbitraryProperty(
-			this.property,
-			this.propertyNameResolver,
-			this.nullInject,
-			this.elementIndex,
-			this.childProperties,
-			containerInfo
-		);
+	public ContainerProperty getContainerProperty() {
+		return containerProperty;
 	}
 
 	public ArbitraryProperty withNullInject(double nullInject) {
 		return new ArbitraryProperty(
-			this.property,
-			this.propertyNameResolver,
-			nullInject,
-			this.elementIndex,
-			this.childProperties,
-			this.containerInfo
+			this.objectProperty.withNullInject(nullInject),
+			this.containerProperty
+		);
+	}
+
+	public ArbitraryProperty withElementProperties(List<Property> elementProperties) {
+		return new ArbitraryProperty(
+			this.objectProperty,
+			this.containerProperty.withElementProperties(elementProperties)
+		);
+	}
+
+	public ArbitraryProperty withContainerInfo(ArbitraryContainerInfo containerInfo) {
+		return new ArbitraryProperty(
+			this.objectProperty,
+			this.containerProperty.withContainerInfo(containerInfo)
+		);
+	}
+
+	public ArbitraryProperty withContainerProperty(ContainerProperty containerProperty) {
+		return new ArbitraryProperty(
+			this.objectProperty,
+			containerProperty
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -53,19 +53,21 @@ public final class ChildArbitraryContext {
 	public void replaceArbitrary(Matcher matcher, Arbitrary<?> arbitrary) {
 		for (Entry<ArbitraryProperty, Arbitrary<?>> arbitraryByChildProperty : arbitrariesByChildProperty.entrySet()) {
 			ArbitraryProperty arbitraryProperty = arbitraryByChildProperty.getKey();
-			if (matcher.match(arbitraryProperty.getProperty())) {
+			ObjectProperty objectProperty = arbitraryProperty.getObjectProperty();
+			if (matcher.match(objectProperty.getProperty())) {
 				arbitrariesByChildProperty.put(arbitraryProperty, arbitrary);
 			}
 		}
 	}
 
 	public void removeArbitrary(Matcher matcher) {
-		arbitrariesByChildProperty.entrySet().removeIf(it -> matcher.match(it.getKey().getProperty()));
+		arbitrariesByChildProperty.entrySet()
+			.removeIf(it -> matcher.match(it.getKey().getObjectProperty().getProperty()));
 	}
 
 	public Map<String, Arbitrary<?>> getArbitrariesByResolvedName() {
 		return arbitrariesByChildProperty.entrySet().stream()
-			.collect(toMap(it -> it.getKey().getResolvePropertyName(), Entry::getValue));
+			.collect(toMap(it -> it.getKey().getObjectProperty().getResolvePropertyName(), Entry::getValue));
 	}
 
 	public List<Arbitrary<?>> getArbitraries() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -67,7 +67,7 @@ public final class ChildArbitraryContext {
 
 	public Map<String, Arbitrary<?>> getArbitrariesByResolvedName() {
 		return arbitrariesByChildProperty.entrySet().stream()
-			.collect(toMap(it -> it.getKey().getObjectProperty().getResolvePropertyName(), Entry::getValue));
+			.collect(toMap(it -> it.getKey().getObjectProperty().getResolvedPropertyName(), Entry::getValue));
 	}
 
 	public List<Arbitrary<?>> getArbitraries() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerProperty.java
@@ -1,0 +1,63 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.property.Property;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ContainerProperty {
+	private final List<Property> elementProperties;
+
+	private final ArbitraryContainerInfo containerInfo;
+
+	public ContainerProperty(
+		List<Property> elementProperties,
+		ArbitraryContainerInfo containerInfo
+	) {
+		this.elementProperties = elementProperties;
+		this.containerInfo = containerInfo;
+	}
+
+	public List<Property> getElementProperties() {
+		return Collections.unmodifiableList(elementProperties);
+	}
+
+	public ArbitraryContainerInfo getContainerInfo() {
+		return containerInfo;
+	}
+
+	public ContainerProperty withElementProperties(List<Property> elementProperties) {
+		return new ContainerProperty(
+			elementProperties,
+			this.containerInfo
+		);
+	}
+
+	public ContainerProperty withContainerInfo(ArbitraryContainerInfo containerInfo) {
+		return new ContainerProperty(
+			this.elementProperties,
+			containerInfo
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGenerator.java
@@ -18,20 +18,11 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.Collections;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 
-public final class NullArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final NullArbitraryPropertyGenerator INSTANCE = new NullArbitraryPropertyGenerator();
-
-	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
-		return new ArbitraryProperty(
-			context.getProperty(),
-			context.getPropertyNameResolver(),
-			1.0d,
-			null,
-			Collections.emptyList(),
-			null
-		);
-	}
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@FunctionalInterface
+public interface ContainerPropertyGenerator {
+	ContainerProperty generate(ContainerPropertyGeneratorContext context);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGeneratorContext.java
@@ -18,77 +18,55 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class ArbitraryPropertyGeneratorContext {
+public final class ContainerPropertyGeneratorContext {
 	private final Property property;
 
 	@Nullable
 	private final Integer elementIndex;
 
 	@Nullable
-	private final ArbitraryProperty ownerProperty;
-
-	@Nullable
 	private final ArbitraryContainerInfo containerInfo;
 
 	private final GenerateOptions generateOptions;
 
-	public ArbitraryPropertyGeneratorContext(
+	public ContainerPropertyGeneratorContext(
 		Property property,
 		@Nullable Integer elementIndex,
-		@Nullable ArbitraryProperty ownerProperty,
 		@Nullable ArbitraryContainerInfo containerInfo,
 		GenerateOptions generateOptions
 	) {
 		this.property = property;
 		this.elementIndex = elementIndex;
-		this.ownerProperty = ownerProperty;
 		this.containerInfo = containerInfo;
 		this.generateOptions = generateOptions;
 	}
 
 	public Property getProperty() {
-		return this.property;
+		return property;
 	}
 
 	@Nullable
 	public Integer getElementIndex() {
-		return this.elementIndex;
+		return elementIndex;
 	}
 
-	@Nullable
-	public ArbitraryProperty getOwnerProperty() {
-		return this.ownerProperty;
+	public GenerateOptions getGenerateOptions() {
+		return generateOptions;
 	}
 
 	@Nullable
 	public ArbitraryContainerInfo getContainerInfo() {
 		return containerInfo;
-	}
-
-	public List<MatcherOperator<PropertyNameResolver>> getPropertyNameResolvers() {
-		return this.generateOptions.getPropertyNameResolvers();
-	}
-
-	public GenerateOptions getGenerateOptions() {
-		return this.generateOptions;
-	}
-
-	public PropertyNameResolver getPropertyNameResolver() {
-		return generateOptions.getPropertyNameResolver(property);
 	}
 
 	public boolean isRootContext() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -43,7 +43,7 @@ public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 	public Arbitrary<?> generate(ArbitraryGeneratorContext context) {
 		ArbitraryIntrospectorResult result = this.arbitraryIntrospector.introspect(context);
 		if (result.getValue() != null) {
-			double nullInject = context.getArbitraryProperty().getNullInject();
+			double nullInject = context.getArbitraryProperty().getObjectProperty().getNullInject();
 			return result.getValue()
 				.injectNull(nullInject);
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultNullInjectGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultNullInjectGenerator.java
@@ -26,8 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -126,10 +124,7 @@ public final class DefaultNullInjectGenerator implements NullInjectGenerator {
 	}
 
 	@Override
-	public double generate(
-		ArbitraryPropertyGeneratorContext context,
-		@Nullable ArbitraryContainerInfo containerInfo
-	) {
+	public double generate(ObjectPropertyGeneratorContext context) {
 		if (context.isRootContext()) {
 			return NOT_NULL_INJECT;
 		}
@@ -143,11 +138,11 @@ public final class DefaultNullInjectGenerator implements NullInjectGenerator {
 			nullable = !this.defaultNotNull;
 		}
 
-		if (containerInfo != null && context.getProperty().isNullable() == null) {
+		if (context.isContainer() && context.getProperty().isNullable() == null) {
 			nullable = this.nullableContainer;
 		}
 
-		if (context.getOwnerProperty() != null && context.getOwnerProperty().getContainerInfo() != null) {
+		if (context.getOwnerProperty() != null && context.getOwnerProperty().getContainerProperty() != null) {
 			nullable = this.nullableElement;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
@@ -18,29 +18,32 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class SingleValueArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final SingleValueArbitraryPropertyGenerator INSTANCE = new SingleValueArbitraryPropertyGenerator();
+public final class DefaultObjectPropertyGenerator implements ObjectPropertyGenerator {
+	public static final DefaultObjectPropertyGenerator INSTANCE =
+		new DefaultObjectPropertyGenerator();
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
 		Property property = context.getProperty();
+		List<Property> childProperties = PropertyCache.getProperties(property.getAnnotatedType());
 		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-			.generate(context, null);
-		return new ArbitraryProperty(
+			.generate(context);
+
+		return new ObjectProperty(
 			property,
 			context.getPropertyNameResolver(),
 			nullInject,
 			context.getElementIndex(),
-			Collections.emptyList(),
-			null
+			childProperties
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapContainerPropertyGenerator.java
@@ -32,11 +32,11 @@ import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class MapArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final MapArbitraryPropertyGenerator INSTANCE = new MapArbitraryPropertyGenerator();
+public final class MapContainerPropertyGenerator implements ContainerPropertyGenerator {
+	public static final MapContainerPropertyGenerator INSTANCE = new MapContainerPropertyGenerator();
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 
 		List<AnnotatedType> genericsTypes = Types.getGenericsTypes(property.getAnnotatedType());
@@ -79,14 +79,7 @@ public final class MapArbitraryPropertyGenerator implements ArbitraryPropertyGen
 			);
 		}
 
-		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-			.generate(context, containerInfo);
-
-		return new ArbitraryProperty(
-			property,
-			context.getPropertyNameResolver(),
-			nullInject,
-			context.getElementIndex(),
+		return new ContainerProperty(
 			childProperties,
 			containerInfo
 		);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapEntryElementContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MapEntryElementContainerPropertyGenerator.java
@@ -27,15 +27,14 @@ import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class MapEntryElementArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final MapEntryElementArbitraryPropertyGenerator INSTANCE =
-		new MapEntryElementArbitraryPropertyGenerator();
+public final class MapEntryElementContainerPropertyGenerator implements ContainerPropertyGenerator {
+	public static final MapEntryElementContainerPropertyGenerator INSTANCE =
+		new MapEntryElementContainerPropertyGenerator();
 
 	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(1, 1);
-	private static final double NULL_INJECT = 0.0d;
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 		if (property.getClass() != MapEntryElementProperty.class) {
 			throw new IllegalArgumentException(
@@ -45,11 +44,7 @@ public final class MapEntryElementArbitraryPropertyGenerator implements Arbitrar
 
 		MapEntryElementProperty mapEntryElementProperty = (MapEntryElementProperty)property;
 
-		return new ArbitraryProperty(
-			property,
-			context.getPropertyNameResolver(),
-			NULL_INJECT,
-			null,
+		return new ContainerProperty(
 			Arrays.asList(mapEntryElementProperty.getKeyProperty(), mapEntryElementProperty.getValueProperty()),
 			CONTAINER_INFO
 		);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectGenerator.java
@@ -18,13 +18,11 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 @FunctionalInterface
 public interface NullInjectGenerator {
-	double generate(ArbitraryPropertyGeneratorContext context, @Nullable ArbitraryContainerInfo containerInfo);
+	double generate(ObjectPropertyGeneratorContext context);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullObjectPropertyGenerator.java
@@ -16,29 +16,25 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.resolver;
-
-import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.NOT_NULL_INJECT;
+package com.navercorp.fixturemonkey.api.generator;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class IdentityNodeResolver implements NodeResolver {
-	public static final IdentityNodeResolver INSTANCE = new IdentityNodeResolver();
-
-	private IdentityNodeResolver() {
-	}
+public final class NullObjectPropertyGenerator implements ObjectPropertyGenerator {
+	public static final NullObjectPropertyGenerator INSTANCE = new NullObjectPropertyGenerator();
 
 	@Override
-	public List<ArbitraryNode> resolve(ArbitraryNode arbitraryNode) {
-		ArbitraryProperty arbitraryProperty = arbitraryNode.getArbitraryProperty();
-		arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
-		return Collections.singletonList(arbitraryNode);
+	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
+		return new ObjectProperty(
+			context.getProperty(),
+			context.getPropertyNameResolver(),
+			1.0d,
+			null,
+			Collections.emptyList()
+		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
@@ -65,7 +65,7 @@ public final class ObjectProperty {
 		return this.propertyNameResolver;
 	}
 
-	public String getResolvePropertyName() {
+	public String getResolvedPropertyName() {
 		return this.getPropertyNameResolver().resolve(this.property);
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
@@ -1,0 +1,98 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
+import com.navercorp.fixturemonkey.api.property.RootProperty;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ObjectProperty {
+	private final Property property;
+
+	private final PropertyNameResolver propertyNameResolver;
+
+	private final double nullInject;
+
+	@Nullable
+	private final Integer elementIndex;
+
+	private final List<Property> childProperties;
+
+	public ObjectProperty(
+		Property property,
+		PropertyNameResolver propertyNameResolver,
+		double nullInject,
+		@Nullable Integer elementIndex,
+		List<Property> childProperties
+	) {
+		this.property = property;
+		this.propertyNameResolver = propertyNameResolver;
+		this.nullInject = nullInject;
+		this.elementIndex = elementIndex;
+		this.childProperties = childProperties;
+	}
+
+	public Property getProperty() {
+		return this.property;
+	}
+
+	public PropertyNameResolver getPropertyNameResolver() {
+		return this.propertyNameResolver;
+	}
+
+	public String getResolvePropertyName() {
+		return this.getPropertyNameResolver().resolve(this.property);
+	}
+
+	public double getNullInject() {
+		return this.nullInject;
+	}
+
+	@Nullable
+	public Integer getElementIndex() {
+		return this.elementIndex;
+	}
+
+	public List<Property> getChildProperties() {
+		return Collections.unmodifiableList(this.childProperties);
+	}
+
+	public boolean isRoot() {
+		return this.property instanceof RootProperty;
+	}
+
+	public ObjectProperty withNullInject(double nullInject) {
+		return new ObjectProperty(
+			this.property,
+			this.propertyNameResolver,
+			nullInject,
+			this.elementIndex,
+			this.childProperties
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGenerator.java
@@ -23,6 +23,6 @@ import org.apiguardian.api.API.Status;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 @FunctionalInterface
-public interface ArbitraryPropertyGenerator {
-	ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context);
+public interface ObjectPropertyGenerator {
+	ObjectProperty generate(ObjectPropertyGeneratorContext context);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
@@ -1,0 +1,88 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
+import com.navercorp.fixturemonkey.api.property.RootProperty;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ObjectPropertyGeneratorContext {
+	private final Property property;
+
+	@Nullable
+	private final Integer elementIndex;
+
+	@Nullable
+	private final ArbitraryProperty ownerProperty;
+
+	private final boolean container;
+
+	private final GenerateOptions generateOptions;
+
+	public ObjectPropertyGeneratorContext(
+		Property property,
+		@Nullable Integer elementIndex,
+		@Nullable ArbitraryProperty ownerProperty,
+		boolean container,
+		GenerateOptions generateOptions
+	) {
+		this.property = property;
+		this.elementIndex = elementIndex;
+		this.ownerProperty = ownerProperty;
+		this.container = container;
+		this.generateOptions = generateOptions;
+	}
+
+	public Property getProperty() {
+		return property;
+	}
+
+	@Nullable
+	public Integer getElementIndex() {
+		return elementIndex;
+	}
+
+	@Nullable
+	public ArbitraryProperty getOwnerProperty() {
+		return ownerProperty;
+	}
+
+	public boolean isContainer() {
+		return container;
+	}
+
+	public GenerateOptions getGenerateOptions() {
+		return generateOptions;
+	}
+
+	public PropertyNameResolver getPropertyNameResolver() {
+		return generateOptions.getPropertyNameResolver(property);
+	}
+
+	public boolean isRootContext() {
+		return this.property instanceof RootProperty;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
@@ -57,29 +57,29 @@ public final class ObjectPropertyGeneratorContext {
 	}
 
 	public Property getProperty() {
-		return property;
+		return this.property;
 	}
 
 	@Nullable
 	public Integer getElementIndex() {
-		return elementIndex;
+		return this.elementIndex;
 	}
 
 	@Nullable
 	public ArbitraryProperty getOwnerProperty() {
-		return ownerProperty;
+		return this.ownerProperty;
 	}
 
 	public boolean isContainer() {
-		return container;
+		return this.container;
 	}
 
 	public GenerateOptions getGenerateOptions() {
-		return generateOptions;
+		return this.generateOptions;
 	}
 
 	public PropertyNameResolver getPropertyNameResolver() {
-		return generateOptions.getPropertyNameResolver(property);
+		return this.generateOptions.getPropertyNameResolver(property);
 	}
 
 	public boolean isRootContext() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/OptionalContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/OptionalContainerPropertyGenerator.java
@@ -36,8 +36,8 @@ import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class OptionalArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final OptionalArbitraryPropertyGenerator INSTANCE = new OptionalArbitraryPropertyGenerator();
+public final class OptionalContainerPropertyGenerator implements ContainerPropertyGenerator {
+	public static final OptionalContainerPropertyGenerator INSTANCE = new OptionalContainerPropertyGenerator();
 
 	private static final AnnotatedType INTEGER_TYPE = generateAnnotatedTypeWithoutAnnotation(Integer.class);
 	private static final AnnotatedType LONG_TYPE = generateAnnotatedTypeWithoutAnnotation(Long.class);
@@ -45,7 +45,7 @@ public final class OptionalArbitraryPropertyGenerator implements ArbitraryProper
 	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(0, 1);
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 
 		AnnotatedType valueAnnotatedType = getValueAnnotatedType(property);
@@ -56,14 +56,7 @@ public final class OptionalArbitraryPropertyGenerator implements ArbitraryProper
 			0
 		);
 
-		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-			.generate(context, CONTAINER_INFO);
-
-		return new ArbitraryProperty(
-			property,
-			context.getPropertyNameResolver(),
-			nullInject,
-			context.getElementIndex(),
+		return new ContainerProperty(
 			Collections.singletonList(valueProperty),
 			CONTAINER_INFO
 		);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueObjectPropertyGenerator.java
@@ -18,38 +18,29 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
+import java.util.Collections;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.TupleLikeElementsProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class TupleLikeElementsArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final TupleLikeElementsArbitraryPropertyGenerator INSTANCE =
-		new TupleLikeElementsArbitraryPropertyGenerator();
-
-	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(1, 1);
-	private static final double NULL_INJECT = 0.0d;
+public final class SingleValueObjectPropertyGenerator implements ObjectPropertyGenerator {
+	public static final SingleValueObjectPropertyGenerator INSTANCE = new SingleValueObjectPropertyGenerator();
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
 		Property property = context.getProperty();
-		if (property.getClass() != TupleLikeElementsProperty.class) {
-			throw new IllegalArgumentException(
-				"property should be TupleLikeElementsProperty. property: " + property.getClass()
-			);
-		}
+		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
+			.generate(context);
 
-		TupleLikeElementsProperty tupleLikeElementsProperty = (TupleLikeElementsProperty)property;
-
-		return new ArbitraryProperty(
+		return new ObjectProperty(
 			property,
 			context.getPropertyNameResolver(),
-			NULL_INJECT,
+			nullInject,
 			context.getElementIndex(),
-			tupleLikeElementsProperty.getElementsProperties(),
-			CONTAINER_INFO
+			Collections.emptyList()
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/StreamContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/StreamContainerPropertyGenerator.java
@@ -36,15 +36,15 @@ import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class StreamArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final StreamArbitraryPropertyGenerator INSTANCE = new StreamArbitraryPropertyGenerator();
+public final class StreamContainerPropertyGenerator implements ContainerPropertyGenerator {
+	public static final StreamContainerPropertyGenerator INSTANCE = new StreamContainerPropertyGenerator();
 
 	private static final AnnotatedType INTEGER_TYPE = generateAnnotatedTypeWithoutAnnotation(Integer.class);
 	private static final AnnotatedType LONG_TYPE = generateAnnotatedTypeWithoutAnnotation(Long.class);
 	private static final AnnotatedType DOUBLE_TYPE = generateAnnotatedTypeWithoutAnnotation(Double.class);
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 
 		AnnotatedType elementAnnotatedType = getElementAnnotatedType(property);
@@ -69,14 +69,7 @@ public final class StreamArbitraryPropertyGenerator implements ArbitraryProperty
 			);
 		}
 
-		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-			.generate(context, containerInfo);
-
-		return new ArbitraryProperty(
-			property,
-			context.getPropertyNameResolver(),
-			nullInject,
-			context.getElementIndex(),
+		return new ContainerProperty(
 			childProperties,
 			containerInfo
 		);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/TupleLikeElementsPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/TupleLikeElementsPropertyGenerator.java
@@ -18,31 +18,33 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.List;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.PropertyCache;
+import com.navercorp.fixturemonkey.api.property.TupleLikeElementsProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class ObjectArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
-	public static final ObjectArbitraryPropertyGenerator INSTANCE = new ObjectArbitraryPropertyGenerator();
+public final class TupleLikeElementsPropertyGenerator implements ContainerPropertyGenerator {
+	public static final TupleLikeElementsPropertyGenerator INSTANCE =
+		new TupleLikeElementsPropertyGenerator();
+
+	private static final ArbitraryContainerInfo CONTAINER_INFO = new ArbitraryContainerInfo(1, 1);
 
 	@Override
-	public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
-		List<Property> childProperties = PropertyCache.getProperties(property.getAnnotatedType());
-		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-			.generate(context, null);
-		return new ArbitraryProperty(
-			property,
-			context.getPropertyNameResolver(),
-			nullInject,
-			context.getElementIndex(),
-			childProperties,
-			null
+		if (property.getClass() != TupleLikeElementsProperty.class) {
+			throw new IllegalArgumentException(
+				"property should be TupleLikeElementsProperty. property: " + property.getClass()
+			);
+		}
+
+		TupleLikeElementsProperty tupleLikeElementsProperty = (TupleLikeElementsProperty)property;
+
+		return new ContainerProperty(
+			tupleLikeElementsProperty.getElementsProperties(),
+			CONTAINER_INFO
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -32,6 +32,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
@@ -46,7 +47,13 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
@@ -54,7 +61,7 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
 		BuilderCombinator<ArrayBuilder> builderCombinator = Builders.withBuilder(() ->
 			new ArrayBuilder(
-				Types.getArrayComponentType(property.getProperty().getAnnotatedType()),
+				Types.getArrayComponentType(property.getObjectProperty().getProperty().getAnnotatedType()),
 				childrenArbitraries.size()
 			)
 		);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -59,14 +59,14 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptors(type);
 		BuilderCombinator<?> builderCombinator = Builders.withBuilder(() -> ReflectionUtils.newInstance(type));
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-			String originPropertyName = arbitraryProperty.getProperty().getName();
+			String originPropertyName = arbitraryProperty.getObjectProperty().getProperty().getName();
 			PropertyDescriptor propertyDescriptor = propertyDescriptors.get(originPropertyName);
 			Method writeMethod = propertyDescriptor.getWriteMethod();
 			if (writeMethod == null) {
 				continue;
 			}
 
-			String resolvePropertyName = arbitraryProperty.getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 			if (arbitrary != null) {
 				builderCombinator = builderCombinator.use(arbitrary).in((b, v) -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -66,7 +66,7 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 				continue;
 			}
 
-			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvedPropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 			if (arbitrary != null) {
 				builderCombinator = builderCombinator.use(arbitrary).in((b, v) -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -77,7 +77,7 @@ public final class BuilderArbitraryIntrospector
 			String methodName = getFieldName(arbitraryProperty.getObjectProperty().getProperty());
 			String buildFieldMethodName = builderType.getName() + "#" + methodName;
 
-			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvedPropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 
 			Method method = BUILD_FIELD_METHOD_CACHE.computeIfAbsent(buildFieldMethodName, f -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -74,10 +74,10 @@ public final class BuilderArbitraryIntrospector
 			ReflectionUtils.invokeMethod(builderMethod, null));
 
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-			String methodName = getFieldName(arbitraryProperty.getProperty());
+			String methodName = getFieldName(arbitraryProperty.getObjectProperty().getProperty());
 			String buildFieldMethodName = builderType.getName() + "#" + methodName;
 
-			String resolvePropertyName = arbitraryProperty.getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 
 			Method method = BUILD_FIELD_METHOD_CACHE.computeIfAbsent(buildFieldMethodName, f -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -30,6 +31,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty.MapEntryElementType;
@@ -47,7 +49,13 @@ public final class EntryIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
 
 		if (containerInfo == null) {
@@ -62,6 +70,7 @@ public final class EntryIntrospector implements ArbitraryIntrospector, Matcher {
 
 		Arbitrary<Entry<?, ?>> arbitrary = childrenArbitraries.get(0)
 			.map(it -> (MapEntryElementType)it)
+			.filter(Objects::nonNull)
 			.map(it -> new SimpleEntry<>(it.getKey(), it.getValue()));
 
 		return new ArbitraryIntrospectorResult(arbitrary);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -57,14 +57,14 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 		Map<String, Field> fields = PropertyCache.getFields(type);
 		BuilderCombinator<?> builderCombinator = Builders.withBuilder(() -> ReflectionUtils.newInstance(type));
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-			String originPropertyName = arbitraryProperty.getProperty().getName();
+			String originPropertyName = arbitraryProperty.getObjectProperty().getProperty().getName();
 			Field field = fields.get(originPropertyName);
 
 			if (field == null || Modifier.isFinal(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
 				continue;
 			}
 
-			String resolvePropertyName = arbitraryProperty.getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 			builderCombinator = builderCombinator.use(arbitrary).in((object, value) -> {
 				try {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -64,7 +64,7 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 				continue;
 			}
 
-			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvedPropertyName();
 			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
 			builderCombinator = builderCombinator.use(arbitrary).in((object, value) -> {
 				try {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
@@ -31,6 +31,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -47,7 +48,13 @@ public final class ListIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
@@ -29,6 +29,7 @@ import net.jqwik.api.Builders;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty.MapEntryElementType;
@@ -44,7 +45,13 @@ public final class MapEntryElementIntrospector implements ArbitraryIntrospector,
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
@@ -32,6 +32,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty.MapEntryElementType;
@@ -49,7 +50,13 @@ public final class MapIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
@@ -32,6 +32,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -48,7 +49,13 @@ public final class QueueIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
@@ -32,6 +32,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -48,7 +49,13 @@ public final class SetIntrospector implements ArbitraryIntrospector, Matcher {
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
@@ -36,6 +36,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -57,7 +58,13 @@ public final class StreamIntrospector implements ArbitraryIntrospector, Matcher 
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
@@ -12,6 +12,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.TupleLikeElementsProperty;
@@ -27,7 +28,13 @@ public final class TupleLikeElementsIntrospector implements ArbitraryIntrospecto
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+		ContainerProperty containerProperty = property.getContainerProperty();
+		if (containerProperty == null) {
+			throw new IllegalArgumentException(
+				"container property should not null. type : " + property.getObjectProperty().getProperty().getName()
+			);
+		}
+		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -32,11 +32,12 @@ import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.JavaDefaultArbitraryGeneratorBuilder;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
@@ -47,11 +48,14 @@ import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 
+@SuppressWarnings("UnusedReturnValue")
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class GenerateOptionsBuilder {
-	private List<MatcherOperator<ArbitraryPropertyGenerator>> arbitraryPropertyGenerators =
-		new ArrayList<>(GenerateOptions.DEFAULT_ARBITRARY_PROPERTY_GENERATORS);
-	private ArbitraryPropertyGenerator defaultArbitraryPropertyGenerator;
+	private List<MatcherOperator<ObjectPropertyGenerator>> arbitraryObjectPropertyGenerators =
+		new ArrayList<>(GenerateOptions.DEFAULT_OBJECT_PROPERTY_GENERATORS);
+	private List<MatcherOperator<ContainerPropertyGenerator>> containerPropertyGenerators =
+		new ArrayList<>(GenerateOptions.DEFAULT_CONTAINER_PROPERTY_GENERATORS);
+	private ObjectPropertyGenerator defaultObjectPropertyGenerator;
 	private List<MatcherOperator<PropertyNameResolver>> propertyNameResolvers = new ArrayList<>();
 	private PropertyNameResolver defaultPropertyNameResolver;
 	private List<MatcherOperator<NullInjectGenerator>> nullInjectGenerators = new ArrayList<>();
@@ -70,41 +74,76 @@ public final class GenerateOptionsBuilder {
 	GenerateOptionsBuilder() {
 	}
 
-	public GenerateOptionsBuilder arbitraryPropertyGenerators(
-		List<MatcherOperator<ArbitraryPropertyGenerator>> arbitraryPropertyGenerators
+	public GenerateOptionsBuilder arbitraryObjectPropertyGenerators(
+		List<MatcherOperator<ObjectPropertyGenerator>> arbitraryObjectPropertyGenerators
 	) {
-		this.arbitraryPropertyGenerators = arbitraryPropertyGenerators;
+		this.arbitraryObjectPropertyGenerators = arbitraryObjectPropertyGenerators;
 		return this;
 	}
 
-	public GenerateOptionsBuilder insertFirstArbitraryPropertyGenerator(
-		MatcherOperator<ArbitraryPropertyGenerator> arbitraryPropertyGenerator
+	public GenerateOptionsBuilder insertFirstArbitraryObjectPropertyGenerator(
+		MatcherOperator<ObjectPropertyGenerator> arbitraryObjectPropertyGenerator
 	) {
-		List<MatcherOperator<ArbitraryPropertyGenerator>> result =
-			insertFirst(this.arbitraryPropertyGenerators, arbitraryPropertyGenerator);
-		return this.arbitraryPropertyGenerators(result);
+		List<MatcherOperator<ObjectPropertyGenerator>> result =
+			insertFirst(this.arbitraryObjectPropertyGenerators, arbitraryObjectPropertyGenerator);
+		return this.arbitraryObjectPropertyGenerators(result);
 	}
 
-	public GenerateOptionsBuilder insertFirstArbitraryPropertyGenerator(
+	public GenerateOptionsBuilder insertFirstArbitraryObjectPropertyGenerator(
 		Matcher matcher,
-		ArbitraryPropertyGenerator arbitraryPropertyGenerator
+		ObjectPropertyGenerator objectPropertyGenerator
 	) {
-		return this.insertFirstArbitraryPropertyGenerator(new MatcherOperator<>(matcher, arbitraryPropertyGenerator));
-	}
-
-	public GenerateOptionsBuilder insertFirstArbitraryPropertyGenerator(
-		Class<?> type,
-		ArbitraryPropertyGenerator arbitraryPropertyGenerator
-	) {
-		return this.insertFirstArbitraryPropertyGenerator(
-			MatcherOperator.assignableTypeMatchOperator(type, arbitraryPropertyGenerator)
+		return this.insertFirstArbitraryObjectPropertyGenerator(
+			new MatcherOperator<>(matcher, objectPropertyGenerator)
 		);
 	}
 
-	public GenerateOptionsBuilder defaultArbitraryPropertyGenerator(
-		ArbitraryPropertyGenerator defaultArbitraryPropertyGenerator
+	public GenerateOptionsBuilder insertFirstArbitraryObjectPropertyGenerator(
+		Class<?> type,
+		ObjectPropertyGenerator objectPropertyGenerator
 	) {
-		this.defaultArbitraryPropertyGenerator = defaultArbitraryPropertyGenerator;
+		return this.insertFirstArbitraryObjectPropertyGenerator(
+			MatcherOperator.assignableTypeMatchOperator(type, objectPropertyGenerator)
+		);
+	}
+
+	public GenerateOptionsBuilder arbitraryContainerPropertyGenerators(
+		List<MatcherOperator<ContainerPropertyGenerator>> arbitraryContainerPropertyGenerators
+	) {
+		this.containerPropertyGenerators = arbitraryContainerPropertyGenerators;
+		return this;
+	}
+
+	public GenerateOptionsBuilder insertFirstArbitraryContainerPropertyGenerator(
+		MatcherOperator<ContainerPropertyGenerator> arbitraryContainerPropertyGenerator
+	) {
+		List<MatcherOperator<ContainerPropertyGenerator>> result =
+			insertFirst(this.containerPropertyGenerators, arbitraryContainerPropertyGenerator);
+		return this.arbitraryContainerPropertyGenerators(result);
+	}
+
+	public GenerateOptionsBuilder insertFirstArbitraryContainerPropertyGenerator(
+		Matcher matcher,
+		ContainerPropertyGenerator containerPropertyGenerator
+	) {
+		return this.insertFirstArbitraryContainerPropertyGenerator(
+			new MatcherOperator<>(matcher, containerPropertyGenerator)
+		);
+	}
+
+	public GenerateOptionsBuilder insertFirstArbitraryContainerPropertyGenerator(
+		Class<?> type,
+		ContainerPropertyGenerator containerPropertyGenerator
+	) {
+		return this.insertFirstArbitraryContainerPropertyGenerator(
+			MatcherOperator.assignableTypeMatchOperator(type, containerPropertyGenerator)
+		);
+	}
+
+	public GenerateOptionsBuilder defaultObjectPropertyGenerator(
+		ObjectPropertyGenerator defaultObjectPropertyGenerator
+	) {
+		this.defaultObjectPropertyGenerator = defaultObjectPropertyGenerator;
 		return this;
 	}
 
@@ -379,9 +418,9 @@ public final class GenerateOptionsBuilder {
 	}
 
 	public GenerateOptions build() {
-		ArbitraryPropertyGenerator defaultArbitraryPropertyGenerator = defaultIfNull(
-			this.defaultArbitraryPropertyGenerator,
-			() -> GenerateOptions.DEFAULT_ARBITRARY_PROPERTY_GENERATOR
+		ObjectPropertyGenerator defaultObjectPropertyGenerator = defaultIfNull(
+			this.defaultObjectPropertyGenerator,
+			() -> GenerateOptions.DEFAULT_OBJECT_PROPERTY_GENERATOR
 		);
 		PropertyNameResolver defaultPropertyNameResolver = defaultIfNull(
 			this.defaultPropertyNameResolver,
@@ -402,8 +441,9 @@ public final class GenerateOptionsBuilder {
 			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);
 
 		return new GenerateOptions(
-			this.arbitraryPropertyGenerators,
-			defaultArbitraryPropertyGenerator,
+			this.arbitraryObjectPropertyGenerators,
+			defaultObjectPropertyGenerator,
+			this.containerPropertyGenerators,
 			this.propertyNameResolvers,
 			defaultPropertyNameResolver,
 			this.nullInjectGenerators,

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContextTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContextTest.java
@@ -39,11 +39,13 @@ class ArbitraryGeneratorContextTest {
 		};
 		RootProperty rootProperty = new RootProperty(typeReference.getAnnotatedType());
 		ArbitraryProperty arbitraryProperty = new ArbitraryProperty(
-			rootProperty,
-			PropertyNameResolver.IDENTITY,
-			0.0D,
-			null,
-			Collections.emptyList(),
+			new ObjectProperty(
+				rootProperty,
+				PropertyNameResolver.IDENTITY,
+				0.0D,
+				null,
+				Collections.emptyList()
+			),
 			null
 		);
 		ArbitraryGeneratorContext sut = new ArbitraryGeneratorContext(

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
@@ -40,21 +40,20 @@ class ArbitraryPropertyTest {
 		RootProperty rootProperty = new RootProperty(typeReference.getAnnotatedType());
 
 		// when
-		ArbitraryProperty actual = new ArbitraryProperty(
+		ObjectProperty actual = new ObjectProperty(
 			rootProperty,
 			PropertyNameResolver.IDENTITY,
 			0.0D,
 			null,
-			Collections.emptyList(),
-			null
+			Collections.emptyList()
 		);
 
 		then(actual.isRoot()).isTrue();
 		then(actual.getProperty()).isEqualTo(rootProperty);
 		then(actual.getNullInject()).isEqualTo(0.0D);
-		then(actual.getContainerInfo()).isNull();
 	}
 
+	@SuppressWarnings("OptionalGetWithoutIsPresent")
 	@Test
 	void getResolvePropertyName() {
 		// given
@@ -63,13 +62,12 @@ class ArbitraryPropertyTest {
 		Optional<Property> property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "name");
 
 		// when
-		ArbitraryProperty actual = new ArbitraryProperty(
+		ObjectProperty actual = new ObjectProperty(
 			property.get(),
 			prop -> "x_" + prop.getName(),
 			0.0D,
 			null,
-			Collections.emptyList(),
-			null
+			Collections.emptyList()
 		);
 
 		then(actual.getResolvePropertyName()).isEqualTo("x_name");

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
@@ -70,7 +70,7 @@ class ArbitraryPropertyTest {
 			Collections.emptyList()
 		);
 
-		then(actual.getResolvePropertyName()).isEqualTo("x_name");
+		then(actual.getResolvedPropertyName()).isEqualTo("x_name");
 	}
 
 	static class GenericSample<T> {

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/DefaultNullInjectGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/DefaultNullInjectGeneratorTest.java
@@ -32,6 +32,7 @@ import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class DefaultNullInjectGeneratorTest {
 	@Test
 	void generateNullable() {
@@ -40,16 +41,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "nullable").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.2d);
 	}
@@ -61,16 +62,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "nonnull").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -89,16 +90,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "defaultValue").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.2d);
 	}
@@ -117,16 +118,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "defaultValue").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -138,16 +139,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "primitive").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -166,17 +167,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "container").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			true,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
-		ArbitraryContainerInfo containerInfo = new ArbitraryContainerInfo(0, 3);
 
 		// when
-		double actual = sut.generate(context, containerInfo);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -195,17 +195,16 @@ class DefaultNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "container").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			true,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
-		ArbitraryContainerInfo containerInfo = new ArbitraryContainerInfo(0, 3);
 
 		// when
-		double actual = sut.generate(context, containerInfo);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.2d);
 	}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorTest.java
@@ -38,6 +38,7 @@ import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaDefaultArbitraryGeneratorTest {
 	@Test
 	void generateString() {
@@ -50,11 +51,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -83,11 +86,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -116,11 +121,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -149,11 +156,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -182,11 +191,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -215,11 +226,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -248,11 +261,13 @@ class JavaDefaultArbitraryGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -280,35 +295,21 @@ class JavaDefaultArbitraryGeneratorTest {
 		GenerateOptions generateOptions = GenerateOptions.builder()
 			.defaultNullInjectGenerator(
 				new DefaultNullInjectGenerator(
-					0.0d, false, false, false, Collections.emptySet(), Collections.emptySet()
+					0.0d,
+					false,
+					false,
+					false,
+					Collections.emptySet(),
+					Collections.emptySet()
 				)
 			)
 			.build();
 
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -343,6 +344,22 @@ class JavaDefaultArbitraryGeneratorTest {
 		then(result.getBooleans()).isNotNull();
 		then(result.getEnums()).isNotNull();
 		then(result.getUuid()).isNotNull();
+	}
+
+	private ArbitraryProperty getArbitraryProperty(Property property, GenerateOptions generateOptions) {
+		ObjectPropertyGenerator rootGenerator = generateOptions.getObjectPropertyGenerator(property);
+		return new ArbitraryProperty(
+			rootGenerator.generate(
+				new ObjectPropertyGeneratorContext(
+					property,
+					null,
+					null,
+					false,
+					generateOptions
+				)
+			),
+			null
+		);
 	}
 
 	public static class SampleArbitraryGenerator {

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectDelegatorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectDelegatorTest.java
@@ -28,6 +28,7 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorTest.Sample;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
@@ -35,6 +36,7 @@ import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
 class ArbitraryIntrospectDelegatorTest {
+	@SuppressWarnings("OptionalGetWithoutIsPresent")
 	@Test
 	void matchAndIntrospectEmpty() {
 		ArbitraryIntrospectDelegator sut = new ArbitraryIntrospectDelegator(
@@ -47,11 +49,13 @@ class ArbitraryIntrospectDelegatorTest {
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "season").get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorTest.java
@@ -30,11 +30,13 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
 class ArbitraryIntrospectorTest {
 	private final ArbitraryIntrospector sut = new CompositeArbitraryIntrospector(
 		Arrays.asList(
@@ -52,20 +54,7 @@ class ArbitraryIntrospectorTest {
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "season").get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -79,20 +68,7 @@ class ArbitraryIntrospectorTest {
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "bool").get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -106,20 +82,7 @@ class ArbitraryIntrospectorTest {
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "bool").get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -133,20 +96,7 @@ class ArbitraryIntrospectorTest {
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "uuid").get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -154,6 +104,25 @@ class ArbitraryIntrospectorTest {
 		String uuid = actual.getValue().sample().toString();
 		then(uuid).hasSize(36);
 		then(uuid.replaceAll("-", "")).hasSize(32);
+	}
+
+	private ArbitraryGeneratorContext getArbitraryGeneratorContext(Property property) {
+		return new ArbitraryGeneratorContext(
+			new ArbitraryProperty(
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
+				null
+			),
+			Collections.emptyList(),
+			null,
+			(ctx, prop) -> Arbitraries.just(null),
+			Collections.emptyList()
+		);
 	}
 
 	static class Sample {

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospectorTest.java
@@ -29,11 +29,12 @@ import org.junit.jupiter.api.Test;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorTest.Season;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -59,30 +60,11 @@ class BeanArbitraryIntrospectorTest {
 		RootProperty rootProperty = new RootProperty(typeReference.getAnnotatedType());
 
 		GenerateOptions generateOptions = GenerateOptions.DEFAULT_GENERATE_OPTIONS;
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -127,30 +109,11 @@ class BeanArbitraryIntrospectorTest {
 			)
 			.build();
 
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -178,6 +141,22 @@ class BeanArbitraryIntrospectorTest {
 		then(sample.getName()).isNotNull();
 		then(sample.getValue()).isNotNull();
 		then(sample.getSeason()).isNotNull();
+	}
+
+	private ArbitraryProperty getArbitraryProperty(Property property, GenerateOptions generateOptions) {
+		ObjectPropertyGenerator rootGenerator = generateOptions.getObjectPropertyGenerator(property);
+		return new ArbitraryProperty(
+			rootGenerator.generate(
+				new ObjectPropertyGeneratorContext(
+					property,
+					null,
+					null,
+					false,
+					generateOptions
+				)
+			),
+			null
+		);
 	}
 
 	static class BeanSample {

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospectorTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.junit.jupiter.api.Test;
 
 import lombok.Builder;
@@ -32,9 +34,10 @@ import lombok.Getter;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -174,30 +177,11 @@ public class BuilderArbitraryIntrospectorTest {
 		RootProperty rootProperty = new RootProperty(typeReference.getAnnotatedType());
 
 		GenerateOptions generateOptions = GenerateOptions.DEFAULT_GENERATE_OPTIONS;
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, null, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, rootArbitraryProperty, generateOptions))
 			.collect(toList());
 
 		return new ArbitraryGeneratorContext(
@@ -214,6 +198,26 @@ public class BuilderArbitraryIntrospectorTest {
 				)
 			).getValue(),
 			Collections.emptyList()
+		);
+	}
+
+	private ArbitraryProperty getArbitraryProperty(
+		Property property,
+		@Nullable ArbitraryProperty ownerArbitraryProperty,
+		GenerateOptions generateOptions
+	) {
+		ObjectPropertyGenerator rootGenerator = generateOptions.getObjectPropertyGenerator(property);
+		return new ArbitraryProperty(
+			rootGenerator.generate(
+				new ObjectPropertyGeneratorContext(
+					property,
+					null,
+					ownerArbitraryProperty,
+					false,
+					generateOptions
+				)
+			),
+			null
 		);
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospectorTest.java
@@ -28,11 +28,12 @@ import org.junit.jupiter.api.Test;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorTest.Season;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -58,30 +59,11 @@ class FieldReflectionArbitraryIntrospectorTest {
 		RootProperty rootProperty = new RootProperty(typeReference.getAnnotatedType());
 
 		GenerateOptions generateOptions = GenerateOptions.DEFAULT_GENERATE_OPTIONS;
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -128,30 +110,11 @@ class FieldReflectionArbitraryIntrospectorTest {
 			)
 			.build();
 
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -190,5 +153,21 @@ class FieldReflectionArbitraryIntrospectorTest {
 		private Season season;
 		private final String finalValue = "final";
 		private transient String transientValue;
+	}
+
+	private ArbitraryProperty getArbitraryProperty(Property property, GenerateOptions generateOptions) {
+		ObjectPropertyGenerator rootGenerator = generateOptions.getObjectPropertyGenerator(property);
+		return new ArbitraryProperty(
+			rootGenerator.generate(
+				new ObjectPropertyGeneratorContext(
+					property,
+					null,
+					null,
+					false,
+					generateOptions
+				)
+			),
+			null
+		);
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospectorTest.java
@@ -29,10 +29,12 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
 class JavaArbitraryIntrospectorTest {
 	private final JavaArbitraryIntrospector sut = new JavaArbitraryIntrospector();
 
@@ -44,20 +46,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "str";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -73,20 +62,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "str";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -102,20 +78,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "chars";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -131,20 +94,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "chars";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -160,20 +110,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "charWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -189,20 +126,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "charWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -218,20 +142,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "shorts";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -247,20 +158,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "shorts";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -276,20 +174,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "shortWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -305,20 +190,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "shortWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -334,20 +206,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bytes";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -363,20 +222,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bytes";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -392,20 +238,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "byteWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -421,20 +254,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "byteWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -450,20 +270,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "doubles";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -479,20 +286,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "doubles";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -508,20 +302,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "doubleWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -537,20 +318,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "doubleWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -566,20 +334,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "floats";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -595,20 +350,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "floats";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -624,20 +366,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "floatWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -653,20 +382,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "floatWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -682,20 +398,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "ints";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -711,20 +414,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "ints";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -740,20 +430,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "intWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -769,20 +446,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "intWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -798,20 +462,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "longs";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -827,20 +478,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "longs";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -856,20 +494,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "longWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -885,20 +510,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "longWrapper";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -914,20 +526,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bigIntegers";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -943,20 +542,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bigIntegers";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -972,20 +558,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bigDecimals";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -1001,20 +574,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "bigDecimals";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -1030,20 +590,7 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "instant";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -1059,13 +606,26 @@ class JavaArbitraryIntrospectorTest {
 		String propertyName = "instant";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
+
+		// when
+		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
+
+		then(actual).isEqualTo(ArbitraryIntrospectorResult.EMPTY);
+	}
+
+	private ArbitraryGeneratorContext getArbitraryGeneratorContext(
+		com.navercorp.fixturemonkey.api.property.Property property
+	) {
+		return new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -1073,10 +633,5 @@ class JavaArbitraryIntrospectorTest {
 			(ctx, prop) -> Arbitraries.just(null),
 			Collections.emptyList()
 		);
-
-		// when
-		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
-
-		then(actual).isEqualTo(ArbitraryIntrospectorResult.EMPTY);
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospectorTest.java
@@ -42,10 +42,12 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
 class JavaTimeArbitraryIntrospectorTest {
 	private final JavaTimeArbitraryIntrospector sut = new JavaTimeArbitraryIntrospector();
 
@@ -57,20 +59,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "calendar";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -86,20 +75,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "calendar";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -115,20 +91,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "date";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -144,20 +107,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "date";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -173,20 +123,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "instant";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -202,20 +139,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "instant";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -231,20 +155,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localDate";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -260,20 +171,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localDate";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -289,20 +187,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -318,20 +203,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -347,20 +219,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -376,20 +235,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "localTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -405,20 +251,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "zonedDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -434,20 +267,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "zonedDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -463,20 +283,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "monthDay";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -492,20 +299,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "monthDay";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -521,20 +315,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "offsetDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -550,20 +331,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "offsetDateTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -579,20 +347,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "offsetTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -608,20 +363,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "offsetTime";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -637,20 +379,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "period";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -666,20 +395,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "period";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -695,20 +411,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "duration";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -724,20 +427,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "duration";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -753,20 +443,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "year";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -782,20 +459,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "year";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -811,20 +475,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "yearMonth";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -840,20 +491,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "yearMonth";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
@@ -869,20 +507,7 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "zoneOffset";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
-			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
-				null
-			),
-			Collections.emptyList(),
-			null,
-			(ctx, prop) -> Arbitraries.just(null),
-			Collections.emptyList()
-		);
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
 
 		// when
 		boolean actual = this.sut.match(context.getProperty());
@@ -898,13 +523,26 @@ class JavaTimeArbitraryIntrospectorTest {
 		String propertyName = "zoneOffset";
 		com.navercorp.fixturemonkey.api.property.Property property =
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
-		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
+		ArbitraryGeneratorContext context = getArbitraryGeneratorContext(property);
+
+		// when
+		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
+
+		then(actual.getValue().sample()).isInstanceOf(ZoneOffset.class);
+	}
+
+	private ArbitraryGeneratorContext getArbitraryGeneratorContext(
+		com.navercorp.fixturemonkey.api.property.Property property
+	) {
+		return new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -912,10 +550,5 @@ class JavaTimeArbitraryIntrospectorTest {
 			(ctx, prop) -> Arbitraries.just(null),
 			Collections.emptyList()
 		);
-
-		// when
-		ArbitraryIntrospectorResult actual = this.sut.introspect(context);
-
-		then(actual.getValue().sample()).isInstanceOf(ZoneOffset.class);
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGeneratorTests.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeTypeArbitraryGeneratorTests.java
@@ -56,7 +56,7 @@ class JavaTimeTypeArbitraryGeneratorTests {
 		Calendar min = Calendar.getInstance();
 		min.setTimeInMillis(now.minus(366, ChronoUnit.DAYS).toEpochMilli());
 		Calendar max = Calendar.getInstance();
-		max.setTimeInMillis(now.plus(365, ChronoUnit.DAYS).toEpochMilli());
+		max.setTimeInMillis(now.plus(366, ChronoUnit.DAYS).toEpochMilli());
 
 		CalendarArbitrary calendarArbitrary = this.sut.calendars();
 		Calendar actual = calendarArbitrary.sample();

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/AssignableMatcherTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/AssignableMatcherTest.java
@@ -28,11 +28,13 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class AssignableMatcherTest {
 	@Test
 	void match() {
@@ -45,11 +47,13 @@ class AssignableMatcherTest {
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -75,11 +79,13 @@ class AssignableMatcherTest {
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/matcher/ExactMatcherTest.java
@@ -28,11 +28,13 @@ import net.jqwik.api.Arbitraries;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class ExactMatcherTest {
 	@Test
 	void match() {
@@ -45,11 +47,13 @@ class ExactMatcherTest {
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -75,11 +79,13 @@ class ExactMatcherTest {
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
@@ -62,7 +62,7 @@ public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector
 
 		BuilderCombinator<Map<String, Object>> builderCombinator = Builders.withBuilder(HashMap::new);
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-			String resolvePropertyName = arbitraryProperty.getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
 			Arbitrary<?> propertyArbitrary = childrenArbitraries.getOrDefault(
 				resolvePropertyName,
 				Arbitraries.just(null)

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
@@ -62,7 +62,7 @@ public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector
 
 		BuilderCombinator<Map<String, Object>> builderCombinator = Builders.withBuilder(HashMap::new);
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvePropertyName();
+			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvedPropertyName();
 			Arbitrary<?> propertyArbitrary = childrenArbitraries.getOrDefault(
 				resolvePropertyName,
 				Arbitraries.just(null)

--- a/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/introspector/JacksonArbitraryIntrospectorTest.java
+++ b/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/introspector/JacksonArbitraryIntrospectorTest.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
@@ -25,6 +25,7 @@ import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryIntrospecto
 import com.navercorp.fixturemonkey.api.introspector.UuidIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -57,30 +58,11 @@ class JacksonArbitraryIntrospectorTest {
 			)
 			.build();
 
-		ArbitraryPropertyGenerator rootGenerator = generateOptions.getArbitraryPropertyGenerator(rootProperty);
-		ArbitraryProperty rootArbitraryProperty = rootGenerator.generate(
-			new ArbitraryPropertyGeneratorContext(
-				rootProperty,
-				null,
-				null,
-				null,
-				generateOptions
-			)
-		);
+		ArbitraryProperty rootArbitraryProperty = getArbitraryProperty(rootProperty, generateOptions);
 
 		List<ArbitraryProperty> childrenProperties = PropertyCache.getProperties(typeReference.getAnnotatedType())
 			.stream()
-			.map(it -> generateOptions.getArbitraryPropertyGenerator(it)
-				.generate(
-					new ArbitraryPropertyGeneratorContext(
-						it,
-						null,
-						rootArbitraryProperty,
-						null,
-						generateOptions
-					)
-				)
-			)
+			.map(it -> getArbitraryProperty(it, generateOptions))
 			.collect(toList());
 
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
@@ -108,6 +90,22 @@ class JacksonArbitraryIntrospectorTest {
 		then(sample.getName()).isNotNull();
 		then(sample.getValue()).isNotNull();
 		then(sample.getSeason()).isNotNull();
+	}
+
+	private ArbitraryProperty getArbitraryProperty(Property property, GenerateOptions generateOptions) {
+		ObjectPropertyGenerator rootGenerator = generateOptions.getObjectPropertyGenerator(property);
+		return new ArbitraryProperty(
+			rootGenerator.generate(
+				new ObjectPropertyGeneratorContext(
+					property,
+					null,
+					null,
+					false,
+					generateOptions
+				)
+			),
+			null
+		);
 	}
 
 	static class JacksonSample {

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGenerator.java
@@ -28,12 +28,12 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
 	@Override
-	public ArbitraryContainerInfo generate(ArbitraryPropertyGeneratorContext context) {
+	public ArbitraryContainerInfo generate(ContainerPropertyGeneratorContext context) {
 		Integer min = null;
 		Integer max = null;
 		Optional<Size> sizeAnnotation = context.getProperty().getAnnotation(Size.class);

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationNullInjectGenerator.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationNullInjectGenerator.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.toSet;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -32,10 +31,9 @@ import javax.validation.constraints.Null;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
@@ -51,10 +49,7 @@ public final class JavaxValidationNullInjectGenerator implements NullInjectGener
 	}
 
 	@Override
-	public double generate(
-		ArbitraryPropertyGeneratorContext context,
-		@Nullable ArbitraryContainerInfo containerInfo
-	) {
+	public double generate(ObjectPropertyGeneratorContext context) {
 		Set<Class<? extends Annotation>> annotations = context.getProperty().getAnnotations().stream()
 			.map(Annotation::annotationType)
 			.collect(toSet());
@@ -63,7 +58,7 @@ public final class JavaxValidationNullInjectGenerator implements NullInjectGener
 			return 1.0d;
 		}
 
-		double nullInject = this.delegate.generate(context, containerInfo);
+		double nullInject = this.delegate.generate(context);
 		if (nullInject == 0.0d) {
 			return nullInject;
 		}
@@ -78,7 +73,7 @@ public final class JavaxValidationNullInjectGenerator implements NullInjectGener
 			}
 		}
 
-		if (containerInfo != null && annotations.contains(NotEmpty.class)) {
+		if (context.isContainer() && annotations.contains(NotEmpty.class)) {
 			return 0.0d;
 		}
 

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGeneratorTest.java
@@ -26,12 +26,13 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaxValidationArbitraryContainerInfoGeneratorTest {
 	@net.jqwik.api.Property
 	void generateContainer() {
@@ -41,9 +42,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			new TypeReference<SampleWithContainerAnnotation>() {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "container").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -65,9 +65,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "defaultSizeContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -89,9 +88,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "sizeContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -113,9 +111,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "minSizeContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -141,9 +138,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			.defaultArbitraryContainerMaxSize(10)
 			.build();
 
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			generateOptions
@@ -165,9 +161,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "maxSizeContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -189,9 +184,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notEmptyContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
@@ -216,9 +210,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 		GenerateOptions generateOptions = GenerateOptions.builder()
 			.defaultArbitraryContainerMaxSize(10)
 			.build();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			generateOptions
@@ -240,9 +233,8 @@ class JavaxValidationArbitraryContainerInfoGeneratorTest {
 			};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notEmptyAndMaxSizeContainer")
 			.get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ContainerPropertyGeneratorContext context = new ContainerPropertyGeneratorContext(
 			property,
-			null,
 			null,
 			null,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationNullInjectGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationNullInjectGeneratorTest.java
@@ -28,14 +28,14 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaxValidationNullInjectGeneratorTest {
 	@net.jqwik.api.Property
 	void generateNull() {
@@ -44,16 +44,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "nullValue").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(1.0d);
 	}
@@ -74,16 +74,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notNull").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -95,16 +95,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notBlank").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -116,16 +116,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notEmpty").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -146,16 +146,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "defaultValue").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.2d);
 	}
@@ -176,16 +176,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "defaultValue").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			false,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
 
 		// when
-		double actual = sut.generate(context, null);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}
@@ -206,17 +206,16 @@ class JavaxValidationNullInjectGeneratorTest {
 		TypeReference<SampleWithAnnotation> typeReference = new TypeReference<SampleWithAnnotation>() {
 		};
 		Property property = PropertyCache.getProperty(typeReference.getAnnotatedType(), "notEmptyContainer").get();
-		ArbitraryPropertyGeneratorContext context = new ArbitraryPropertyGeneratorContext(
+		ObjectPropertyGeneratorContext context = new ObjectPropertyGeneratorContext(
 			property,
 			null,
 			null,
-			null,
+			true,
 			GenerateOptions.DEFAULT_GENERATE_OPTIONS
 		);
-		ArbitraryContainerInfo containerInfo = new ArbitraryContainerInfo(0, 3);
 
 		// when
-		double actual = sut.generate(context, containerInfo);
+		double actual = sut.generate(context);
 
 		then(actual).isEqualTo(0.0d);
 	}

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationBooleanIntrospectorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationBooleanIntrospectorTest.java
@@ -27,11 +27,13 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "ConstantConditions"})
 class JavaxValidationBooleanIntrospectorTest {
 	private final JavaxValidationBooleanIntrospector sut = new JavaxValidationBooleanIntrospector();
 
@@ -45,11 +47,13 @@ class JavaxValidationBooleanIntrospectorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -76,11 +80,13 @@ class JavaxValidationBooleanIntrospectorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -106,11 +112,13 @@ class JavaxValidationBooleanIntrospectorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGeneratorTest.java
@@ -29,10 +29,12 @@ import net.jqwik.api.Example;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaxValidationConstraintGeneratorTest {
 	private final JavaxValidationConstraintGenerator sut = new JavaxValidationConstraintGenerator();
 
@@ -46,11 +48,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -79,11 +83,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -112,11 +118,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -145,11 +153,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -178,11 +188,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -211,11 +223,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -242,11 +256,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -273,11 +289,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -304,11 +322,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -335,11 +355,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -366,11 +388,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -397,11 +421,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -428,11 +454,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -459,11 +487,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -490,11 +520,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -521,11 +553,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -552,11 +586,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -583,11 +619,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -616,11 +654,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -649,11 +689,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -682,11 +724,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -715,11 +759,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -748,11 +794,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -781,11 +829,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -814,11 +864,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -847,11 +899,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -880,11 +934,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -913,11 +969,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -946,11 +1004,13 @@ class JavaxValidationConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolverTest.java
@@ -42,10 +42,12 @@ import net.jqwik.api.arbitraries.StringArbitrary;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaxValidationJavaArbitraryResolverTest {
 	private final JavaxValidationJavaArbitraryResolver sut = new JavaxValidationJavaArbitraryResolver();
 
@@ -118,6 +120,7 @@ class JavaxValidationJavaArbitraryResolverTest {
 		then(actual.length()).isLessThanOrEqualTo(10);
 	}
 
+	@SuppressWarnings("ResultOfMethodCallIgnored")
 	@Property
 	void stringDigits() {
 		// given
@@ -1830,11 +1833,13 @@ class JavaxValidationJavaArbitraryResolverTest {
 
 		return new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeConstraintGeneratorTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeConstraintGeneratorTest.java
@@ -30,10 +30,12 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 class JavaxValidationTimeConstraintGeneratorTest {
 	private final JavaxValidationTimeConstraintGenerator sut = new JavaxValidationTimeConstraintGenerator();
 
@@ -47,11 +49,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -78,11 +82,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -110,11 +116,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -143,11 +151,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -175,11 +185,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -207,11 +219,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -238,11 +252,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -270,11 +286,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -303,11 +321,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -335,11 +355,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -367,11 +389,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -398,11 +422,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -430,11 +456,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -463,11 +491,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),
@@ -495,11 +525,13 @@ class JavaxValidationTimeConstraintGeneratorTest {
 			PropertyCache.getProperty(typeReference.getAnnotatedType(), propertyName).get();
 		ArbitraryGeneratorContext context = new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeJavaArbitraryResolverTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationTimeJavaArbitraryResolverTest.java
@@ -61,6 +61,7 @@ import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -100,7 +101,7 @@ class JavaxValidationTimeJavaArbitraryResolverTest {
 
 		// then
 		Calendar now = Calendar.getInstance();
-		then(actual.getTimeInMillis()).isLessThan(now.toInstant().toEpochMilli());
+		then(actual.toInstant().toEpochMilli()).isLessThan(now.toInstant().toEpochMilli());
 	}
 
 	@Property
@@ -1218,11 +1219,13 @@ class JavaxValidationTimeJavaArbitraryResolverTest {
 
 		return new ArbitraryGeneratorContext(
 			new ArbitraryProperty(
-				property,
-				PropertyNameResolver.IDENTITY,
-				0.0D,
-				null,
-				Collections.emptyList(),
+				new ObjectProperty(
+					property,
+					PropertyNameResolver.IDENTITY,
+					0.0D,
+					null,
+					Collections.emptyList()
+				),
 				null
 			),
 			Collections.emptyList(),

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -37,10 +37,11 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
-import com.navercorp.fixturemonkey.api.generator.NullArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.NullObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
@@ -93,33 +94,60 @@ public class LabMonkeyBuilder {
 		return this;
 	}
 
-	public LabMonkeyBuilder defaultArbitraryPropertyGenerator(ArbitraryPropertyGenerator arbitraryPropertyGenerator) {
-		generateOptionsBuilder.defaultArbitraryPropertyGenerator(arbitraryPropertyGenerator);
+	public LabMonkeyBuilder defaultObjectPropertyGenerator(
+		ObjectPropertyGenerator objectPropertyGenerator
+	) {
+		generateOptionsBuilder.defaultObjectPropertyGenerator(objectPropertyGenerator);
 		return this;
 	}
 
-	public LabMonkeyBuilder pushAssignableTypeArbitraryPropertyGenerator(
+	public LabMonkeyBuilder pushAssignableTypeObjectPropertyGenerator(
 		Class<?> type,
-		ArbitraryPropertyGenerator arbitraryPropertyGenerator
+		ObjectPropertyGenerator objectPropertyGenerator
 	) {
-		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(type, arbitraryPropertyGenerator);
+		generateOptionsBuilder.insertFirstArbitraryObjectPropertyGenerator(type, objectPropertyGenerator);
 		return this;
 	}
 
-	public LabMonkeyBuilder pushExactTypeArbitraryPropertyGenerator(
+	public LabMonkeyBuilder pushExactTypeObjectPropertyGenerator(
 		Class<?> type,
-		ArbitraryPropertyGenerator arbitraryPropertyGenerator
+		ObjectPropertyGenerator objectPropertyGenerator
 	) {
-		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(
-			MatcherOperator.exactTypeMatchOperator(type, arbitraryPropertyGenerator)
+		generateOptionsBuilder.insertFirstArbitraryObjectPropertyGenerator(
+			MatcherOperator.exactTypeMatchOperator(type, objectPropertyGenerator)
 		);
 		return this;
 	}
 
-	public LabMonkeyBuilder pushArbitraryPropertyGenerator(
-		MatcherOperator<ArbitraryPropertyGenerator> arbitraryPropertyGenerator
+	public LabMonkeyBuilder pushObjectPropertyGenerator(
+		MatcherOperator<ObjectPropertyGenerator> arbitraryObjectPropertyGenerator
 	) {
-		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(arbitraryPropertyGenerator);
+		generateOptionsBuilder.insertFirstArbitraryObjectPropertyGenerator(arbitraryObjectPropertyGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushAssignableTypeContainerPropertyGenerator(
+		Class<?> type,
+		ContainerPropertyGenerator containerPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryContainerPropertyGenerator(type, containerPropertyGenerator);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushExactTypeContainerPropertyGenerator(
+		Class<?> type,
+		ContainerPropertyGenerator containerPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryContainerPropertyGenerator(
+			MatcherOperator.exactTypeMatchOperator(type, containerPropertyGenerator)
+		);
+		return this;
+	}
+
+	public LabMonkeyBuilder pushContainerPropertyGenerator(
+		MatcherOperator<ContainerPropertyGenerator> containerPropertyGenerator
+	) {
+		generateOptionsBuilder.insertFirstArbitraryContainerPropertyGenerator(containerPropertyGenerator);
 		return this;
 	}
 
@@ -258,10 +286,10 @@ public class LabMonkeyBuilder {
 	}
 
 	public LabMonkeyBuilder pushExceptGenerateType(Matcher matcher) {
-		generateOptionsBuilder.insertFirstArbitraryPropertyGenerator(
+		generateOptionsBuilder.insertFirstArbitraryObjectPropertyGenerator(
 			new MatcherOperator<>(
 				matcher,
-				NullArbitraryPropertyGenerator.INSTANCE
+				NullObjectPropertyGenerator.INSTANCE
 			)
 		);
 		return this;
@@ -428,11 +456,11 @@ public class LabMonkeyBuilder {
 
 	public LabMonkeyBuilder addContainerType(
 		Class<?> type,
-		ArbitraryPropertyGenerator containerArbitraryPropertyGenerator,
+		ContainerPropertyGenerator containerObjectPropertyGenerator,
 		ArbitraryIntrospector containerArbitraryIntrospector,
 		DecomposedContainerValueFactory decomposedContainerValueFactory
 	) {
-		this.pushAssignableTypeArbitraryPropertyGenerator(type, containerArbitraryPropertyGenerator);
+		this.pushAssignableTypeContainerPropertyGenerator(type, containerObjectPropertyGenerator);
 		this.pushContainerIntrospector(containerArbitraryIntrospector);
 		decomposableContainerFactoryMap.put(type, decomposedContainerValueFactory);
 		return this;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
@@ -33,6 +33,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.expression.MonkeyExpression;
 import com.navercorp.fixturemonkey.resolver.CompositeNodeResolver;
 import com.navercorp.fixturemonkey.resolver.ContainerElementNodeResolver;
@@ -326,7 +327,8 @@ public final class ArbitraryExpression implements MonkeyExpression, Comparable<A
 		}
 
 		public boolean match(ArbitraryProperty arbitraryProperty) {
-			String resolvePropertyName = arbitraryProperty.getResolvePropertyName();
+			ObjectProperty objectProperty = arbitraryProperty.getObjectProperty();
+			String resolvePropertyName = objectProperty.getResolvePropertyName();
 			boolean samePropertyName;
 			if (resolvePropertyName == null) {
 				samePropertyName = true; // ignore property name equivalence.
@@ -335,8 +337,8 @@ public final class ArbitraryExpression implements MonkeyExpression, Comparable<A
 			}
 
 			boolean sameIndex = true;
-			if (arbitraryProperty.getElementIndex() != null) {
-				sameIndex = indexEquals(arbitraryProperty.getElementIndex()); // notNull
+			if (objectProperty.getElementIndex() != null) {
+				sameIndex = indexEquals(objectProperty.getElementIndex()); // notNull
 			}
 			return samePropertyName && sameIndex;
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitraryExpression.java
@@ -328,7 +328,7 @@ public final class ArbitraryExpression implements MonkeyExpression, Comparable<A
 
 		public boolean match(ArbitraryProperty arbitraryProperty) {
 			ObjectProperty objectProperty = arbitraryProperty.getObjectProperty();
-			String resolvePropertyName = objectProperty.getResolvePropertyName();
+			String resolvePropertyName = objectProperty.getResolvedPropertyName();
 			boolean samePropertyName;
 			if (resolvePropertyName == null) {
 				samePropertyName = true; // ignore property name equivalence.

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/AddMapEntryNodeManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/AddMapEntryNodeManipulator.java
@@ -46,12 +46,13 @@ public final class AddMapEntryNodeManipulator implements NodeManipulator {
 		}
 
 		ArbitraryProperty arbitraryProperty = arbitraryNode.getArbitraryProperty();
-		ArbitraryContainerInfo containerInfo = arbitraryProperty
-			.getContainerInfo().withElementMinSize(1).withElementMaxSize(1);
-		ArbitraryNode entryNode = traverser.traverse(arbitraryProperty.getProperty(), containerInfo)
+		ArbitraryContainerInfo containerInfo = new ArbitraryContainerInfo(1, 1);
+		ArbitraryNode entryNode = traverser.traverse(arbitraryProperty.getObjectProperty().getProperty(), containerInfo)
 			.getChildren().get(0);
 
-		arbitraryProperty.getChildProperties().add(entryNode.getProperty());
+		arbitraryNode.setArbitraryProperty(
+			arbitraryProperty.withContainerProperty(entryNode.getArbitraryProperty().getContainerProperty())
+		);
 		arbitraryNode.getChildren().add(entryNode);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
@@ -65,7 +65,7 @@ final class ArbitraryNode {
 	}
 
 	public Property getProperty() {
-		return this.getArbitraryProperty().getProperty();
+		return this.getArbitraryProperty().getObjectProperty().getProperty();
 	}
 
 	public List<ArbitraryNode> getChildren() {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -114,10 +114,10 @@ final class ArbitraryTree {
 		Arbitrary<?> generated;
 		if (node.getArbitrary() != null) {
 			generated = node.getArbitrary() // fixed
-				.injectNull(node.getArbitraryProperty().getNullInject());
+				.injectNull(node.getArbitraryProperty().getObjectProperty().getNullInject());
 		} else {
 			ArbitraryGeneratorContext childArbitraryGeneratorContext = this.generateContext(node, customizers, ctx);
-			generated = this.generateOptions.getArbitraryGenerator(prop.getProperty())
+			generated = this.generateOptions.getArbitraryGenerator(prop.getObjectProperty().getProperty())
 				.generate(childArbitraryGeneratorContext);
 		}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementNodeResolver.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 
@@ -43,14 +44,15 @@ public final class ContainerElementNodeResolver implements NodeResolver {
 		List<ArbitraryNode> result = new ArrayList<>();
 
 		for (ArbitraryNode node : arbitraryNode.getChildren()) {
-			Property property = node.getArbitraryProperty().getProperty();
+			ArbitraryProperty arbitraryProperty = node.getArbitraryProperty();
+			Property property = arbitraryProperty.getObjectProperty().getProperty();
 			if (!(property instanceof ElementProperty)) {
 				throw new IllegalArgumentException("Resolved node is not element type. : " + property);
 			}
 
 			ElementProperty elementProperty = (ElementProperty)property;
 			if (sequence == NO_OR_ALL_INDEX_INTEGER_VALUE || sequence == elementProperty.getSequence()) {
-				node.setArbitraryProperty(node.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
+				node.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
 				result.add(node);
 			}
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MetadataCollector.java
@@ -46,7 +46,7 @@ final class MetadataCollector {
 	}
 
 	private void collect(ArbitraryNode node) {
-		Property property = node.getArbitraryProperty().getProperty();
+		Property property = node.getArbitraryProperty().getObjectProperty().getProperty();
 
 		List<ArbitraryNode> list = Collections.singletonList(node);
 		nodesByProperty.merge(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyValueResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyValueResolver.java
@@ -26,6 +26,8 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class NodeKeyValueResolver implements NodeResolver {
 	private final boolean key;
@@ -43,7 +45,9 @@ public final class NodeKeyValueResolver implements NodeResolver {
 		} else {
 			child = arbitraryNode.getChildren().get(1);
 		}
-		child.setArbitraryProperty(child.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
+
+		ArbitraryProperty arbitraryProperty = child.getArbitraryProperty();
+		child.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
 		nextNodes.add(child);
 		return nextNodes;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeLastEntryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeLastEntryResolver.java
@@ -26,6 +26,8 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class NodeLastEntryResolver implements NodeResolver {
 
@@ -36,7 +38,8 @@ public final class NodeLastEntryResolver implements NodeResolver {
 	public List<ArbitraryNode> resolve(ArbitraryNode arbitraryNode) {
 		LinkedList<ArbitraryNode> nextNodes = new LinkedList<>();
 		ArbitraryNode child = arbitraryNode.getChildren().get(arbitraryNode.getChildren().size() - 1);
-		child.setArbitraryProperty(child.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
+		ArbitraryProperty arbitraryProperty = child.getArbitraryProperty();
+		child.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
 		nextNodes.add(child);
 		return nextNodes;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeNullityManipulator.java
@@ -21,6 +21,8 @@ package com.navercorp.fixturemonkey.resolver;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.ALWAYS_NULL_INJECT;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.NOT_NULL_INJECT;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+
 public class NodeNullityManipulator implements NodeManipulator {
 	private final boolean toNull;
 
@@ -30,11 +32,9 @@ public class NodeNullityManipulator implements NodeManipulator {
 
 	@Override
 	public void manipulate(ArbitraryNode arbitraryNode) {
+		ArbitraryProperty arbitraryProperty = arbitraryNode.getArbitraryProperty();
 		if (toNull) {
-			arbitraryNode.setArbitraryProperty(
-				arbitraryNode.getArbitraryProperty()
-					.withNullInject(ALWAYS_NULL_INJECT)
-			);
+			arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(ALWAYS_NULL_INJECT));
 		} else {
 			if (arbitraryNode.getArbitrary() != null) {
 				//noinspection ConstantConditions
@@ -42,10 +42,7 @@ public class NodeNullityManipulator implements NodeManipulator {
 					arbitraryNode.setArbitrary(null);
 				}
 			}
-			arbitraryNode.setArbitraryProperty(
-				arbitraryNode.getArbitraryProperty()
-					.withNullInject(NOT_NULL_INJECT)
-			);
+			arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
 		}
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
@@ -30,6 +30,7 @@ import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitraries;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
 
@@ -70,7 +71,8 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 			return;
 		}
 
-		if (arbitraryNode.getArbitraryProperty().isContainer()) {
+		ArbitraryProperty arbitraryProperty = arbitraryNode.getArbitraryProperty();
+		if (arbitraryProperty.getContainerProperty() != null) {
 			DecomposableContainerValue decomposableContainerValue =
 				manipulateOptions.getDecomposedContainerValueFactory().from(value);
 			value = decomposableContainerValue.getContainer();
@@ -84,8 +86,9 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 		}
 
 		List<ArbitraryNode> children = arbitraryNode.getChildren();
-		arbitraryNode.setArbitraryProperty(arbitraryNode.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
-		if (children.isEmpty() && !arbitraryNode.getArbitraryProperty().isContainer()) {
+		arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
+
+		if (children.isEmpty() && arbitraryProperty.getContainerProperty() == null) {
 			arbitraryNode.setArbitrary(Arbitraries.just(value));
 			return;
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSizeManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSizeManipulator.java
@@ -32,20 +32,18 @@ public final class NodeSizeManipulator implements NodeManipulator {
 	@Override
 	public void manipulate(ArbitraryNode arbitraryNode) {
 		ArbitraryProperty arbitraryProperty = arbitraryNode.getArbitraryProperty();
-		if (arbitraryProperty.getContainerInfo() == null) {
+		if (arbitraryProperty.getContainerProperty() == null) {
 			throw new IllegalArgumentException("Only container type supports NodeSizeManipulator.");
 		}
 
-		ArbitraryContainerInfo containerInfo = arbitraryProperty.getContainerInfo()
+		ArbitraryContainerInfo containerInfo = arbitraryProperty.getContainerProperty().getContainerInfo()
 			.withElementMinSize(minSize)
 			.withElementMaxSize(maxSize);
 
 		ArbitraryNode manipulatedNode = traverser.traverse(arbitraryNode.getProperty(), containerInfo);
 		ArbitraryProperty traversedNodeArbitraryProperty = manipulatedNode.getArbitraryProperty();
 		arbitraryNode.setArbitraryProperty(
-			arbitraryProperty
-				.withChildProperties(traversedNodeArbitraryProperty.getChildProperties())
-				.withContainerInfo(traversedNodeArbitraryProperty.getContainerInfo())
+			arbitraryProperty.withContainerProperty(traversedNodeArbitraryProperty.getContainerProperty())
 		);
 		arbitraryNode.setArbitrary(manipulatedNode.getArbitrary());
 		arbitraryNode.setChildren(leftJoin(manipulatedNode, arbitraryNode).getChildren());
@@ -62,7 +60,7 @@ public final class NodeSizeManipulator implements NodeManipulator {
 		leftNode.setArbitrary(rightNode.getArbitrary());
 		leftNode.setArbitraryProperty(
 			leftNode.getArbitraryProperty()
-				.withNullInject(rightNode.getArbitraryProperty().getNullInject())
+				.withNullInject(rightNode.getArbitraryProperty().getObjectProperty().getNullInject())
 		);
 
 		List<ArbitraryNode> leftChildren = leftNode.getChildren();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
@@ -42,7 +42,7 @@ public final class PropertyNameNodeResolver implements NodeResolver {
 		List<ArbitraryNode> result = new ArrayList<>();
 
 		for (ArbitraryNode child : arbitraryNode.getChildren()) {
-			String nodePropertyName = child.getArbitraryProperty().getObjectProperty().getResolvePropertyName();
+			String nodePropertyName = child.getArbitraryProperty().getObjectProperty().getResolvedPropertyName();
 			if (propertyName.equals(ALL_INDEX_STRING) || propertyName.equals(nodePropertyName)) {
 				ArbitraryProperty childArbitraryProperty = child.getArbitraryProperty();
 				child.setArbitraryProperty(childArbitraryProperty.withNullInject(NOT_NULL_INJECT));

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyNameNodeResolver.java
@@ -27,6 +27,8 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class PropertyNameNodeResolver implements NodeResolver {
 	private final String propertyName;
@@ -39,11 +41,12 @@ public final class PropertyNameNodeResolver implements NodeResolver {
 	public List<ArbitraryNode> resolve(ArbitraryNode arbitraryNode) {
 		List<ArbitraryNode> result = new ArrayList<>();
 
-		for (ArbitraryNode node : arbitraryNode.getChildren()) {
-			String nodePropertyName = node.getArbitraryProperty().getResolvePropertyName();
+		for (ArbitraryNode child : arbitraryNode.getChildren()) {
+			String nodePropertyName = child.getArbitraryProperty().getObjectProperty().getResolvePropertyName();
 			if (propertyName.equals(ALL_INDEX_STRING) || propertyName.equals(nodePropertyName)) {
-				node.setArbitraryProperty(node.getArbitraryProperty().withNullInject(NOT_NULL_INJECT));
-				result.add(node);
+				ArbitraryProperty childArbitraryProperty = child.getArbitraryProperty();
+				child.setArbitraryProperty(childArbitraryProperty.withNullInject(NOT_NULL_INJECT));
+				result.add(child);
 			}
 		}
 		return result;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -35,8 +35,9 @@ import com.navercorp.fixturemonkey.LabMonkey;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
@@ -74,9 +75,9 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 		}
 	}
 
-	public static class PairArbitraryPropertyGenerator implements ArbitraryPropertyGenerator {
+	public static class PairContainerPropertyGenerator implements ContainerPropertyGenerator {
 		@Override
-		public ArbitraryProperty generate(ArbitraryPropertyGeneratorContext context) {
+		public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 			com.navercorp.fixturemonkey.api.property.Property property = context.getProperty();
 
 			List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
@@ -88,18 +89,10 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 				);
 			}
 
-			ArbitraryContainerInfo containerInfo = context.getContainerInfo();
-			if (containerInfo == null) {
-				containerInfo = context.getGenerateOptions()
-					.getArbitraryContainerInfoGenerator(property)
-					.generate(context);
-			}
-
-			int size = containerInfo.getRandomSize();
 			AnnotatedType firstElementType = elementTypes.get(0);
 			AnnotatedType secondElementType = elementTypes.get(1);
-			List<com.navercorp.fixturemonkey.api.property.Property> childProperties = new ArrayList<>();
-			childProperties.add(
+			List<com.navercorp.fixturemonkey.api.property.Property> elementProperties = new ArrayList<>();
+			elementProperties.add(
 				new ElementProperty(
 					property,
 					firstElementType,
@@ -107,7 +100,7 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 					0
 				)
 			);
-			childProperties.add(
+			elementProperties.add(
 				new ElementProperty(
 					property,
 					secondElementType,
@@ -116,16 +109,9 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 				)
 			);
 
-			double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
-				.generate(context, containerInfo);
-
-			return new ArbitraryProperty(
-				property,
-				context.getPropertyNameResolver(),
-				nullInject,
-				context.getElementIndex(),
-				childProperties,
-				containerInfo
+			return new ContainerProperty(
+				elementProperties,
+				new ArbitraryContainerInfo(1, 1)
 			);
 		}
 	}
@@ -141,7 +127,7 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 		@Override
 		public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 			ArbitraryProperty property = context.getArbitraryProperty();
-			ArbitraryContainerInfo containerInfo = property.getContainerInfo();
+			ArbitraryContainerInfo containerInfo = property.getContainerProperty().getContainerInfo();
 			if (containerInfo == null) {
 				return ArbitraryIntrospectorResult.EMPTY;
 			}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -48,10 +48,10 @@ import com.navercorp.fixturemonkey.LabMonkey;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ChildArbitraryContext;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
-import com.navercorp.fixturemonkey.api.generator.ObjectArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.DefaultObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
@@ -68,7 +68,7 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpe
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuildMethodInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuilderMethodInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.Pair;
-import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairArbitraryPropertyGenerator;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairIntrospector;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.RegisterGroup;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.SimpleObjectChild;
@@ -115,8 +115,8 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void alterDefaultArbitraryPropertyGenerator() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.defaultArbitraryPropertyGenerator(
-				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+			.defaultObjectPropertyGenerator(
+				(context) -> DefaultObjectPropertyGenerator.INSTANCE.generate(context)
 					.withNullInject(1.0)
 			)
 			.build();
@@ -129,9 +129,9 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void pushAssignableTypeArbitraryPropertyGenerator() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushAssignableTypeArbitraryPropertyGenerator(
+			.pushAssignableTypeObjectPropertyGenerator(
 				SimpleObject.class,
-				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+				(context) -> DefaultObjectPropertyGenerator.INSTANCE.generate(context)
 					.withNullInject(1.0)
 			)
 			.build();
@@ -144,9 +144,9 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void pushExactTypeArbitraryPropertyGenerator() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushExactTypeArbitraryPropertyGenerator(
+			.pushExactTypeObjectPropertyGenerator(
 				SimpleObjectChild.class,
-				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+				(context) -> DefaultObjectPropertyGenerator.INSTANCE.generate(context)
 					.withNullInject(1.0)
 			)
 			.build();
@@ -159,9 +159,9 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void pushExactTypeArbitraryPropertyGeneratorNotAffectsAssignable() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushExactTypeArbitraryPropertyGenerator(
+			.pushExactTypeObjectPropertyGenerator(
 				SimpleObject.class,
-				(context) -> ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+				(context) -> DefaultObjectPropertyGenerator.INSTANCE.generate(context)
 					.withNullInject(1.0)
 			)
 			.build();
@@ -172,12 +172,12 @@ class FixtureMonkeyV04OptionsTest {
 	}
 
 	@Property
-	void pushArbitraryPropertyGenerator() {
-		ArbitraryPropertyGenerator arbitraryPropertyGenerator = (context) ->
-			ObjectArbitraryPropertyGenerator.INSTANCE.generate(context)
+	void pushObjectPropertyGenerator() {
+		ObjectPropertyGenerator arbitraryPropertyGenerator = (context) ->
+			DefaultObjectPropertyGenerator.INSTANCE.generate(context)
 				.withNullInject(1.0);
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushArbitraryPropertyGenerator(
+			.pushObjectPropertyGenerator(
 				MatcherOperator.exactTypeMatchOperator(
 					SimpleObject.class,
 					arbitraryPropertyGenerator
@@ -195,7 +195,7 @@ class FixtureMonkeyV04OptionsTest {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.pushAssignableTypeNullInjectGenerator(
 				SimpleObject.class,
-				(context, containerInfo) -> 1.0d
+				(context) -> 1.0d
 			)
 			.build();
 
@@ -209,7 +209,7 @@ class FixtureMonkeyV04OptionsTest {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.pushExactTypeNullInjectGenerator(
 				SimpleObject.class,
-				(context, containerInfo) -> 1.0d
+				(context) -> 1.0d
 			)
 			.build();
 
@@ -222,7 +222,7 @@ class FixtureMonkeyV04OptionsTest {
 	void pushNullInjectGenerator() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.pushNullInjectGenerator(
-				MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context, containerInfo) -> 1.0d)
+				MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context) -> 1.0d)
 			)
 			.build();
 
@@ -234,7 +234,7 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void defaultNullInjectGenerator() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.defaultNullInjectGenerator((context, containerInfo) -> 1.0d)
+			.defaultNullInjectGenerator((context) -> 1.0d)
 			.build();
 
 		SimpleObject actual = sut.giveMeOne(SimpleObject.class);
@@ -816,7 +816,7 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void generateNewContainer() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushAssignableTypeArbitraryPropertyGenerator(Pair.class, new PairArbitraryPropertyGenerator())
+			.pushAssignableTypeContainerPropertyGenerator(Pair.class, new PairContainerPropertyGenerator())
 			.pushContainerIntrospector(new PairIntrospector())
 			.build();
 
@@ -830,7 +830,7 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void decomposeNewContainer() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushAssignableTypeArbitraryPropertyGenerator(Pair.class, new PairArbitraryPropertyGenerator())
+			.pushAssignableTypeContainerPropertyGenerator(Pair.class, new PairContainerPropertyGenerator())
 			.pushContainerIntrospector(new PairIntrospector())
 			.defaultDecomposedContainerValueFactory(
 				(obj) -> {
@@ -861,7 +861,7 @@ class FixtureMonkeyV04OptionsTest {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.addContainerType(
 				Pair.class,
-				new PairArbitraryPropertyGenerator(),
+				new PairContainerPropertyGenerator(),
 				new PairIntrospector(),
 				(obj) -> {
 					Pair<?, ?> pair = (Pair<?, ?>)obj;
@@ -884,9 +884,7 @@ class FixtureMonkeyV04OptionsTest {
 	@Property
 	void plugin() {
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.plugin((optionsBuilder) -> {
-				optionsBuilder.insertFirstNullInjectGenerators(String.class, (context, containerInfo) -> 1.0d);
-			})
+			.plugin((optionsBuilder) -> optionsBuilder.insertFirstNullInjectGenerators(String.class, (context) -> 1.0d))
 			.build();
 
 		String actual = sut.giveMeBuilder(SimpleObject.class)

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -729,7 +729,7 @@ class FixtureMonkeyV04Test {
 		then(actual).allMatch(Objects::nonNull);
 	}
 
-	@Property(tries = 50)
+	@Property(tries = 10)
 	void sampleAfterMapTwiceReturnsDiff() {
 		ArbitraryBuilder<String> arbitraryBuilder = SUT.giveMeBuilder(ComplexObject.class)
 			.set("str", Arbitraries.strings().ascii().filter(it -> !it.isEmpty()))


### PR DESCRIPTION
`ArbitraryPropertyGenerator`를 `ObjectPropertyGenerator`, `ContainerPropertyGenerator` 로 분리합니다.

`객체 정보 생성`과 `컨테이너 정보 생성`을 분리합니다.
기존에는 `객체 정보 생성` + `컨테이너 정보 생성` 를 한 번에 진행했었습니다. (`ArbitraryPropertyGenerator`)
리팩토링을 통해 `객체 정보 생성`과 `컨테이너 정보 생성` 을 분리합니다.
`객체 정보`와 `컨테이너 정보`는 변경 이유와 주기가 다르므로 분리하였습니다.
`객체 정보 생성` 이후에 `컨테이너 정보 생성`을 진행합니다.

`객체 정보 생성` 후 사용자가 입력한 `size` 연산 적용 여부를 판단합니다.
`size`에 정의한 컨테이너 정보를 `컨테이너 정보 생성` 시점에서 적용합니다.

다음 PR에서는 `표현식과 노드 간의 연간관계 설정`을 진행할 예정입니다.