### PR TITLE
Add spec for DefaultArbitraryBuilder 

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySet.java
@@ -59,6 +59,11 @@ public final class ArbitrarySet<T> extends AbstractArbitrarySet<T> {
 		return value;
 	}
 
+	public long getLimit() {
+		return limit;
+	}
+
+
 	@Override
 	public ArbitrarySet<T> copy() {
 		return new ArbitrarySet<>(this.getArbitraryExpression(), this.value, this.limit);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySet.java
@@ -63,7 +63,6 @@ public final class ArbitrarySet<T> extends AbstractArbitrarySet<T> {
 		return limit;
 	}
 
-
 	@Override
 	public ArbitrarySet<T> copy() {
 		return new ArbitrarySet<>(this.getArbitraryExpression(), this.value, this.limit);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetArbitrary.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetArbitrary.java
@@ -55,6 +55,10 @@ public final class ArbitrarySetArbitrary<T> extends AbstractArbitrarySet<T> {
 		return value;
 	}
 
+	public long getLimit() {
+		return limit;
+	}
+
 	@Override
 	public boolean isApplicable() {
 		return limit > 0;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetLazyValue.java
@@ -80,6 +80,10 @@ public final class ArbitrarySetLazyValue<T> extends AbstractArbitrarySet<T> {
 		return supplier.get();
 	}
 
+	public long getLimit() {
+		return limit;
+	}
+
 	@Override
 	public ArbitrarySetLazyValue<T> copy() {
 		return this;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetPostCondition.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetPostCondition.java
@@ -53,6 +53,10 @@ public final class ArbitrarySetPostCondition<T> extends AbstractArbitraryExpress
 		return filter;
 	}
 
+	public long getLimit() {
+		return limit;
+	}
+
 	@Override
 	public Arbitrary<T> apply(Arbitrary<T> from) {
 		if (this.limit > 0) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetPostCondition.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/arbitrary/ArbitrarySetPostCondition.java
@@ -49,6 +49,10 @@ public final class ArbitrarySetPostCondition<T> extends AbstractArbitraryExpress
 		return clazz;
 	}
 
+	public Predicate<T> getFilter() {
+		return filter;
+	}
+
 	@Override
 	public Arbitrary<T> apply(Arbitrary<T> from) {
 		if (this.limit > 0) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -40,6 +41,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import com.navercorp.fixturemonkey.api.random.Randoms;
+import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -199,6 +202,23 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	@Override
 	public ArbitraryBuilder<T> setLazy(String expression, Supplier<?> supplier) {
 		return this.setLazy(expression, supplier, MAX_MANIPULATION_COUNT);
+	}
+
+	@Override
+	public ArbitraryBuilder<T> spec(ExpressionSpec expressionSpec) {
+		this.containerInfosByNodeResolver.putAll(expressionSpec.getContainerInfosByNodeResolver(traverser, manipulateOptions));
+		this.manipulators.addAll(expressionSpec.getArbitraryManipulators(traverser, manipulateOptions));
+		return this;
+	}
+
+	@Override
+	public ArbitraryBuilder<T> specAny(ExpressionSpec... specs) {
+		if (specs == null || specs.length == 0) {
+			return this;
+		}
+
+		ExpressionSpec spec = Arrays.asList(specs).get(Randoms.nextInt(specs.length));
+		return this.spec(spec);
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -24,13 +24,13 @@ import static com.navercorp.fixturemonkey.Constants.MAX_MANIPULATION_COUNT;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -41,8 +41,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import com.navercorp.fixturemonkey.api.random.Randoms;
-import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -61,9 +59,11 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.random.Randoms;
 import com.navercorp.fixturemonkey.api.type.LazyAnnotatedType;
 import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizer;
+import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.expression.MonkeyExpressionFactory;
 import com.navercorp.fixturemonkey.resolver.ApplyNodeCountManipulator;
@@ -206,7 +206,9 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 
 	@Override
 	public ArbitraryBuilder<T> spec(ExpressionSpec expressionSpec) {
-		this.containerInfosByNodeResolver.putAll(expressionSpec.getContainerInfosByNodeResolver(traverser, manipulateOptions));
+		this.containerInfosByNodeResolver.putAll(
+			expressionSpec.getContainerInfosByNodeResolver(traverser, manipulateOptions)
+		);
 		this.manipulators.addAll(expressionSpec.getArbitraryManipulators(traverser, manipulateOptions));
 		return this;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import com.navercorp.fixturemonkey.resolver.*;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -67,6 +66,18 @@ import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizer;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.expression.MonkeyExpressionFactory;
+import com.navercorp.fixturemonkey.resolver.ApplyNodeCountManipulator;
+import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
+import com.navercorp.fixturemonkey.resolver.ArbitraryResolver;
+import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
+import com.navercorp.fixturemonkey.resolver.BuilderManipulatorAdapter;
+import com.navercorp.fixturemonkey.resolver.IdentityNodeResolver;
+import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
+import com.navercorp.fixturemonkey.resolver.NodeFilterManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeNullityManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeResolver;
+import com.navercorp.fixturemonkey.resolver.NodeSetDecomposedValueManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeSetLazyManipulator;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 
 // TODO: remove extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> inheritance in 1.0.0

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -214,22 +214,18 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	public ArbitraryBuilder<T> spec(ExpressionSpec expressionSpec) {
 		List<BuilderManipulator> builderManipulators = expressionSpec.getBuilderManipulators();
 
-		List<ArbitraryManipulator> convertedArbitraryManipulators =
-			builderManipulators.stream()
-				.filter(it -> !(it instanceof ContainerSizeManipulator))
-				.map(builderManipulatorAdapter::convertToArbitraryManipulator)
-				.collect(toList());
-
-		Map<NodeResolver, ArbitraryContainerInfo> convertedContainerInfosByNodeResolver =
+		this.containerInfosByNodeResolver.putAll(
 			builderManipulators.stream()
 				.filter(ContainerSizeManipulator.class::isInstance)
 				.map(builderManipulatorAdapter::convertToContainerInfosByNodeResolverEntry)
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-		this.containerInfosByNodeResolver.putAll(
-			convertedContainerInfosByNodeResolver
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
 		);
-		this.manipulators.addAll(convertedArbitraryManipulators);
+		this.manipulators.addAll(
+			builderManipulators.stream()
+				.filter(it -> !(it instanceof ContainerSizeManipulator))
+				.map(builderManipulatorAdapter::convertToArbitraryManipulator)
+				.collect(toList())
+		);
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import com.navercorp.fixturemonkey.resolver.*;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -66,17 +67,6 @@ import com.navercorp.fixturemonkey.customizer.ArbitraryCustomizer;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
 import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.expression.MonkeyExpressionFactory;
-import com.navercorp.fixturemonkey.resolver.ApplyNodeCountManipulator;
-import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
-import com.navercorp.fixturemonkey.resolver.ArbitraryResolver;
-import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
-import com.navercorp.fixturemonkey.resolver.IdentityNodeResolver;
-import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
-import com.navercorp.fixturemonkey.resolver.NodeFilterManipulator;
-import com.navercorp.fixturemonkey.resolver.NodeNullityManipulator;
-import com.navercorp.fixturemonkey.resolver.NodeResolver;
-import com.navercorp.fixturemonkey.resolver.NodeSetDecomposedValueManipulator;
-import com.navercorp.fixturemonkey.resolver.NodeSetLazyManipulator;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 
 // TODO: remove extends com.navercorp.fixturemonkey.ArbitraryBuilder<T> inheritance in 1.0.0
@@ -94,6 +84,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	@SuppressWarnings("rawtypes")
 	private final List<MatcherOperator<? extends FixtureCustomizer>> customizers;
 	private final Map<NodeResolver, ArbitraryContainerInfo> containerInfosByNodeResolver;
+	private final BuilderManipulatorAdapter builderManipulatorAdapter;
 	private boolean validOnly = true;
 
 	@SuppressWarnings("rawtypes")
@@ -119,6 +110,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		this.customizers = customizers;
 		this.containerInfosByNodeResolver = containerInfosByNodeResolver;
 		this.monkeyExpressionFactory = manipulateOptions.getDefaultMonkeyExpressionFactory();
+		this.builderManipulatorAdapter = new BuilderManipulatorAdapter(traverser, manipulateOptions);
 	}
 
 	@Override
@@ -207,9 +199,9 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	@Override
 	public ArbitraryBuilder<T> spec(ExpressionSpec expressionSpec) {
 		this.containerInfosByNodeResolver.putAll(
-			expressionSpec.getContainerInfosByNodeResolver(traverser, manipulateOptions)
+			expressionSpec.getContainerInfosByNodeResolver(builderManipulatorAdapter)
 		);
-		this.manipulators.addAll(expressionSpec.getArbitraryManipulators(traverser, manipulateOptions));
+		this.manipulators.addAll(expressionSpec.getArbitraryManipulators(builderManipulatorAdapter));
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -19,17 +19,17 @@
 package com.navercorp.fixturemonkey.customizer;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.resolver.*;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -335,6 +335,20 @@ public final class ExpressionSpec {
 
 	public List<BuilderManipulator> getBuilderManipulators() {
 		return builderManipulators;
+	}
+
+	public List<ArbitraryManipulator> getArbitraryManipulators(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+		return this.builderManipulators.stream()
+			.filter(it -> !(it instanceof ContainerSizeManipulator))
+			.map(new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToArbitraryManipulator)
+			.collect(toList());
+	}
+
+	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+		return this.builderManipulators.stream()
+			.filter(ContainerSizeManipulator.class::isInstance)
+			.map(new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToContainerInfosByNodeResolverEntry)
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -19,17 +19,19 @@
 package com.navercorp.fixturemonkey.customizer;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
-import com.navercorp.fixturemonkey.resolver.*;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -39,6 +41,7 @@ import net.jqwik.api.Combinators;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitraryExpressionManipulator;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpression;
@@ -51,6 +54,11 @@ import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
+import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
+import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
+import com.navercorp.fixturemonkey.resolver.BuilderManipulatorAdapter;
+import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
+import com.navercorp.fixturemonkey.resolver.NodeResolver;
 
 public final class ExpressionSpec {
 	private final List<BuilderManipulator> builderManipulators;
@@ -337,17 +345,25 @@ public final class ExpressionSpec {
 		return builderManipulators;
 	}
 
-	public List<ArbitraryManipulator> getArbitraryManipulators(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+	public List<ArbitraryManipulator> getArbitraryManipulators(
+		ArbitraryTraverser traverser,
+		ManipulateOptions manipulateOptions
+	) {
 		return this.builderManipulators.stream()
 			.filter(it -> !(it instanceof ContainerSizeManipulator))
 			.map(new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToArbitraryManipulator)
 			.collect(toList());
 	}
 
-	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver(
+		ArbitraryTraverser traverser,
+		ManipulateOptions manipulateOptions
+	) {
 		return this.builderManipulators.stream()
 			.filter(ContainerSizeManipulator.class::isInstance)
-			.map(new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToContainerInfosByNodeResolverEntry)
+			.map(
+				new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToContainerInfosByNodeResolverEntry
+			)
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -55,9 +55,7 @@ import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
-import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.resolver.BuilderManipulatorAdapter;
-import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
 import com.navercorp.fixturemonkey.resolver.NodeResolver;
 
 public final class ExpressionSpec {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -23,12 +23,10 @@ import static java.util.stream.Collectors.toList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -41,7 +39,6 @@ import net.jqwik.api.Combinators;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitraryExpressionManipulator;
 import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
 import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpression;
@@ -54,9 +51,6 @@ import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
 import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
 import com.navercorp.fixturemonkey.arbitrary.MetadataManipulator;
 import com.navercorp.fixturemonkey.arbitrary.PostArbitraryManipulator;
-import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
-import com.navercorp.fixturemonkey.resolver.BuilderManipulatorAdapter;
-import com.navercorp.fixturemonkey.resolver.NodeResolver;
 
 public final class ExpressionSpec {
 	private final List<BuilderManipulator> builderManipulators;
@@ -341,24 +335,6 @@ public final class ExpressionSpec {
 
 	public List<BuilderManipulator> getBuilderManipulators() {
 		return builderManipulators;
-	}
-
-	public List<ArbitraryManipulator> getArbitraryManipulators(
-		BuilderManipulatorAdapter builderManipulatorAdapter
-	) {
-		return this.builderManipulators.stream()
-			.filter(it -> !(it instanceof ContainerSizeManipulator))
-			.map(builderManipulatorAdapter::convertToArbitraryManipulator)
-			.collect(toList());
-	}
-
-	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver(
-		BuilderManipulatorAdapter builderManipulatorAdapter
-	) {
-		return this.builderManipulators.stream()
-			.filter(ContainerSizeManipulator.class::isInstance)
-			.map(builderManipulatorAdapter::convertToContainerInfosByNodeResolverEntry)
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/ExpressionSpec.java
@@ -346,24 +346,20 @@ public final class ExpressionSpec {
 	}
 
 	public List<ArbitraryManipulator> getArbitraryManipulators(
-		ArbitraryTraverser traverser,
-		ManipulateOptions manipulateOptions
+		BuilderManipulatorAdapter builderManipulatorAdapter
 	) {
 		return this.builderManipulators.stream()
 			.filter(it -> !(it instanceof ContainerSizeManipulator))
-			.map(new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToArbitraryManipulator)
+			.map(builderManipulatorAdapter::convertToArbitraryManipulator)
 			.collect(toList());
 	}
 
 	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver(
-		ArbitraryTraverser traverser,
-		ManipulateOptions manipulateOptions
+		BuilderManipulatorAdapter builderManipulatorAdapter
 	) {
 		return this.builderManipulators.stream()
 			.filter(ContainerSizeManipulator.class::isInstance)
-			.map(
-				new BuilderManipulatorAdapter(traverser, manipulateOptions)::convertToContainerInfosByNodeResolverEntry
-			)
+			.map(builderManipulatorAdapter::convertToContainerInfosByNodeResolverEntry)
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
@@ -18,15 +18,97 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.arbitrary.AbstractArbitrarySet;
+import com.navercorp.fixturemonkey.arbitrary.ArbitraryExpressionManipulator;
+import com.navercorp.fixturemonkey.arbitrary.ArbitraryNullity;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySet;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetArbitrary;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetLazyValue;
+import com.navercorp.fixturemonkey.arbitrary.ArbitrarySetPostCondition;
 import com.navercorp.fixturemonkey.arbitrary.BuilderManipulator;
+import com.navercorp.fixturemonkey.arbitrary.ContainerSizeManipulator;
+
+import java.util.AbstractMap;
+import java.util.Map;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class BuilderManipulatorAdapter {
-	public ArbitraryManipulator convert(BuilderManipulator builderManipulator) {
-		// TODO: builderManipulator converts to ArbitraryManipulator
-		return null;
+	private final ArbitraryTraverser traverser;
+	private final ManipulateOptions manipulateOptions;
+
+	public BuilderManipulatorAdapter(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+		this.traverser = traverser;
+		this.manipulateOptions = manipulateOptions;
+	}
+
+	public ArbitraryManipulator convertToArbitraryManipulator(BuilderManipulator builderManipulator) {
+		NodeResolver nodeResolver;
+		if (builderManipulator instanceof ArbitraryExpressionManipulator) {
+			nodeResolver = ((ArbitraryExpressionManipulator) builderManipulator).getArbitraryExpression()
+				.toNodeResolver();
+		} else {
+			nodeResolver = IdentityNodeResolver.INSTANCE;
+		}
+
+		NodeManipulator nodeManipulator = null;
+		if (builderManipulator instanceof ArbitrarySet) {
+			ArbitrarySet<?> manipulator = (ArbitrarySet<?>) builderManipulator;
+			nodeManipulator = new NodeSetDecomposedValueManipulator<>(
+				traverser,
+				manipulateOptions,
+				manipulator.getApplicableValue()
+			);
+		} else if (builderManipulator instanceof ArbitrarySetArbitrary) {
+			ArbitrarySetArbitrary<?> manipulator = (ArbitrarySetArbitrary<?>) builderManipulator;
+			nodeManipulator = new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				LazyArbitrary.lazy(manipulator::getApplicableValue)
+			);
+		} else if (builderManipulator instanceof ArbitrarySetLazyValue) {
+			ArbitrarySetLazyValue<?> manipulator = (ArbitrarySetLazyValue<?>) builderManipulator;
+			nodeManipulator = new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				LazyArbitrary.lazy(manipulator::getApplicableValue)
+			);
+		} else if (builderManipulator instanceof ArbitrarySetPostCondition) {
+			ArbitrarySetPostCondition<?> manipulator = (ArbitrarySetPostCondition<?>) builderManipulator;
+			nodeManipulator = new NodeFilterManipulator(
+				manipulator.getClazz(),
+				manipulator.getFilter()
+			);
+		} else if (builderManipulator instanceof ArbitraryNullity) {
+			ArbitraryNullity manipulator = (ArbitraryNullity) builderManipulator;
+			nodeManipulator = new NodeNullityManipulator(manipulator.toNull());
+		} else {
+			throw new IllegalArgumentException(
+				"No convertable NodeManipulator exists : " + builderManipulator.getClass().getTypeName()
+			);
+		}
+
+		return new ArbitraryManipulator(
+			nodeResolver,
+			nodeManipulator
+		);
+	}
+
+	public Map.Entry<NodeResolver, ArbitraryContainerInfo> convertToContainerInfosByNodeResolverEntry(BuilderManipulator builderManipulator) {
+		NodeResolver nodeResolver;
+		if (builderManipulator instanceof ArbitraryExpressionManipulator) {
+			nodeResolver = ((ArbitraryExpressionManipulator) builderManipulator).getArbitraryExpression()
+				.toNodeResolver();
+		} else {
+			nodeResolver = IdentityNodeResolver.INSTANCE;
+		}
+
+		ContainerSizeManipulator manipulator = (ContainerSizeManipulator) builderManipulator;
+
+		return new AbstractMap.SimpleEntry<>(nodeResolver, new ArbitraryContainerInfo(manipulator.getMin(), manipulator.getMax(), true));
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
@@ -19,6 +19,7 @@
 package com.navercorp.fixturemonkey.resolver;
 
 import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
+import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 
 import java.util.AbstractMap;
 import java.util.Map;
@@ -79,7 +80,7 @@ public final class BuilderManipulatorAdapter {
 	private NodeManipulator getNodeManipulator(BuilderManipulator builderManipulator) {
 		if (builderManipulator instanceof ArbitrarySet) {
 			ArbitrarySet<?> manipulator = (ArbitrarySet<?>)builderManipulator;
-			int limit = safeCastLongToInt(manipulator.getLimit());
+			int limit = safeCast(manipulator.getLimit());
 			return new ApplyNodeCountManipulator(
 				new NodeSetDecomposedValueManipulator<>(
 					traverser,
@@ -90,7 +91,7 @@ public final class BuilderManipulatorAdapter {
 			);
 		} else if (builderManipulator instanceof ArbitrarySetArbitrary) {
 			ArbitrarySetArbitrary<?> manipulator = (ArbitrarySetArbitrary<?>)builderManipulator;
-			int limit = safeCastLongToInt(manipulator.getLimit());
+			int limit = safeCast(manipulator.getLimit());
 			return new ApplyNodeCountManipulator(
 				new NodeSetLazyManipulator<>(
 					traverser,
@@ -101,7 +102,7 @@ public final class BuilderManipulatorAdapter {
 			);
 		} else if (builderManipulator instanceof ArbitrarySetLazyValue) {
 			ArbitrarySetLazyValue<?> manipulator = (ArbitrarySetLazyValue<?>)builderManipulator;
-			int limit = safeCastLongToInt(manipulator.getLimit());
+			int limit = safeCast(manipulator.getLimit());
 			return new ApplyNodeCountManipulator(
 				new NodeSetLazyManipulator<>(
 					traverser,
@@ -112,7 +113,7 @@ public final class BuilderManipulatorAdapter {
 			);
 		} else if (builderManipulator instanceof ArbitrarySetPostCondition) {
 			ArbitrarySetPostCondition<?> manipulator = (ArbitrarySetPostCondition<?>)builderManipulator;
-			int limit = safeCastLongToInt(manipulator.getLimit());
+			int limit = safeCast(manipulator.getLimit());
 			return new ApplyNodeCountManipulator(
 				new NodeFilterManipulator(
 					manipulator.getClazz(),
@@ -137,7 +138,7 @@ public final class BuilderManipulatorAdapter {
 			Integer max = manipulator.getMax();
 
 			if (min == null && max != null) {
-				min = Math.max(0, manipulator.getMax() - DEFAULT_ELEMENT_MAX_SIZE);
+				min = Math.max(DEFAULT_ELEMENT_MIN_SIZE, manipulator.getMax() - DEFAULT_ELEMENT_MAX_SIZE);
 			} else if (min != null && max == null) {
 				max = manipulator.getMin() + DEFAULT_ELEMENT_MAX_SIZE;
 			}
@@ -150,7 +151,7 @@ public final class BuilderManipulatorAdapter {
 		}
 	}
 
-	private int safeCastLongToInt(long value) {
+	private int safeCast(long value) {
 		if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException(
 				"Limit should be within the range of int type. limit : " + value

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/BuilderManipulatorAdapter.java
@@ -19,7 +19,6 @@
 package com.navercorp.fixturemonkey.resolver;
 
 import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MAX_SIZE;
-import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 
 import java.util.AbstractMap;
 import java.util.Map;
@@ -151,12 +150,12 @@ public final class BuilderManipulatorAdapter {
 		}
 	}
 
-	private int safeCastLongToInt(long l) {
-		if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
+	private int safeCastLongToInt(long value) {
+		if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException(
-				"Limit should be within the range of int type. limit : " + l
+				"Limit should be within the range of int type. limit : " + value
 			);
 		}
-		return (int)l;
+		return (int)value;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
@@ -132,5 +132,4 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 			setValue(child, childProperty.getValue(value));
 		}
 	}
-
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -1,0 +1,549 @@
+package com.navercorp.fixturemonkey.test;
+
+import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Property;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.SUT;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+
+public class SpecTest {
+	@Property
+	void giveMeSpecSet() {
+		// when
+		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+			.spec(new ExpressionSpec().set("value", -1))
+			.sample();
+
+		then(actual.getValue()).isEqualTo(-1);
+	}
+
+	@Property
+	void giveMeSpecSetArbitrary() {
+		// when
+		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+			.spec(new ExpressionSpec().set("value", Arbitraries.just(1)))
+			.sample();
+
+		then(actual.getValue()).isEqualTo(1);
+	}
+
+	@Property
+	void giveMeListSize() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().size("values", 1, 1))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+	}
+
+	@Property
+	void giveMeSetNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().setNull("values"))
+			.sample();
+
+		then(actual.getValues()).isNull();
+	}
+
+	@Property
+	void giveMeSizeAfterSetNullReturnsNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.setNull("values")
+				.size("values", 1, 1)
+			)
+			.sample();
+
+		then(actual.getValues()).isNull();
+	}
+
+	@Property
+	void giveMeSetAfterSetNullReturnsNotNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.setNull("values")
+				.size("values", 1, 1)
+				.set("values[0]", 0)
+			)
+			.sample();
+
+		then(actual.getValues()).isNotNull();
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).isEqualTo(0);
+	}
+
+	@Property
+	void giveMeSetNotNullAfterSetNullReturnsNotNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.setNull("values")
+				.setNotNull("values")
+			)
+			.sample();
+
+		then(actual.getValues()).isNotNull();
+	}
+
+	@Property
+	void giveMeSetNullAfterSetNotNullReturnsNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.setNotNull("values")
+				.setNull("values")
+			)
+			.sample();
+
+		then(actual.getValues()).isNull();
+	}
+
+	@Property
+	void giveMeSetNullAfterSetReturnsNull() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.size("values", 1, 1)
+				.set("values[0]", 0)
+				.setNull("values")
+			)
+			.sample();
+
+		then(actual.getValues()).isNull();
+	}
+
+	@Property
+	void giveMeSpecPostCondition() {
+		// when
+		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+			.spec(new ExpressionSpec().setPostCondition(
+				"value",
+				int.class,
+				value -> value >= 0 && value <= 100
+			))
+			.sample();
+
+		then(actual.getValue()).isBetween(0, 100);
+	}
+
+	@Property
+	void giveMeSpecPostConditionType() {
+		// when
+		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+			.spec(new ExpressionSpec().setPostCondition(
+				"value",
+				int.class,
+				value -> value >= 0 && value <= 100
+			))
+			.sample();
+
+		then(actual.getValue()).isBetween(0, 100);
+	}
+
+	@Property
+	void giveMePostConditionIndex() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec()
+				.setPostCondition("values[0]", int.class, value -> value >= 0 && value <= 100)
+				.size("values", 1, 1))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).isBetween(0, 100);
+	}
+
+	@Property
+	void giveMeObjectToBuilderSetIndex() {
+		// given
+		SpecTestSpecs.IntegerList expected = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().size("values", 2, 2))
+			.sample();
+
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(expected)
+			.set("values[1]", 1)
+			.sample();
+
+		then(actual.getValues().get(1)).isEqualTo(1);
+	}
+
+	@Property
+	void giveMeListSpecMaxSize() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values",
+					it -> it.ofMaxSize(2)
+				)
+			)
+			.sample();
+
+		then(actual.getValues().size()).isLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void giveMeListSpecSizeBetween() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values",
+					it -> it.ofSizeBetween(1, 3)
+				)
+			)
+			.sample();
+
+		then(actual.getValues().size()).isBetween(1, 3);
+	}
+
+	@Property
+	void giveMeSetRightOrder() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values",
+					it -> it.ofSize(3)
+						.setElement(0, "field1")
+						.setElement(1, "field2")
+						.setElement(2, "field3")
+				)
+			)
+			.sample();
+
+		// then
+		List<String> values = actual.getValues();
+		then(values.size()).isEqualTo(3);
+		then(values.get(0)).isEqualTo("field1");
+		then(values.get(1)).isEqualTo("field2");
+		then(values.get(2)).isEqualTo("field3");
+	}
+
+	@Property
+	void giveMePostConditionRightOrder() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values",
+					(it) -> it.ofSize(2)
+						.setElementPostCondition(0, String.class, s -> s.length() > 5)
+						.setElementPostCondition(1, String.class, s -> s.length() > 10)
+				))
+			.sample();
+
+		// then
+		List<String> values = actual.getValues();
+		then(values.size()).isEqualTo(2);
+		then(values.get(0).length()).isGreaterThan(5);
+		then(values.get(1).length()).isGreaterThan(10);
+	}
+
+	@Property
+	void giveMeListSpecMinSize() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.list("values",
+					it -> it.ofMinSize(1)
+				)
+			)
+			.sample();
+
+		then(actual.getValues().size()).isGreaterThanOrEqualTo(1);
+	}
+
+	@Property
+	void giveMeSpecAny() {
+		// given
+		ExpressionSpec specOne = new ExpressionSpec()
+			.list("values", it -> it
+				.ofSize(1)
+				.setElement(0, 1)
+			);
+		ExpressionSpec specTwo = new ExpressionSpec()
+			.list("values", it -> it
+				.ofSize(2)
+				.setElement(0, 1)
+				.setElement(1, 2)
+			);
+
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.specAny(specOne, specTwo)
+			.sample();
+
+		// then
+		SpecTestSpecs.IntegerList expectedOne = new SpecTestSpecs.IntegerList();
+		expectedOne.setValues(new ArrayList<>());
+		expectedOne.getValues().add(1);
+
+		SpecTestSpecs.IntegerList expectedTwo = new SpecTestSpecs.IntegerList();
+		expectedTwo.setValues(new ArrayList<>());
+		expectedTwo.getValues().add(1);
+		expectedTwo.getValues().add(2);
+
+		then(actual).isIn(expectedOne, expectedTwo);
+	}
+
+	@Property
+	void giveMeSpecAnyWithEmpty() {
+		thenNoException().isThrownBy(
+			() -> SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+				.specAny()
+				.sample()
+		);
+	}
+
+	@Property
+	void giveMeSpecAnyWithNull() {
+		thenNoException().isThrownBy(
+			() -> SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+				.specAny((ExpressionSpec[])null)
+				.sample()
+		);
+	}
+
+	@Property(tries = 2)
+	void giveMeSpecAnyReturnsDiff() {
+		// given
+		Arbitrary<SpecTestSpecs.StringValue> complex = SpecTestSpecs.SUT.giveMeBuilder(
+				SpecTestSpecs.StringValue.class)
+			.specAny(
+				new ExpressionSpec().set("value", "test1"),
+				new ExpressionSpec().set("value", "test2"),
+				new ExpressionSpec().set("value", "test3"),
+				new ExpressionSpec().set("value", "test4"),
+				new ExpressionSpec().set("value", "test5"),
+				new ExpressionSpec().set("value", "test6"),
+				new ExpressionSpec().set("value", "test7"),
+				new ExpressionSpec().set("value", "test8"),
+				new ExpressionSpec().set("value", "test9"),
+				new ExpressionSpec().set("value", "test10")
+			)
+			.build();
+
+		// when
+		List<SpecTestSpecs.StringValue> sampled = complex.list().ofSize(100).sample();
+
+		// then
+		List<SpecTestSpecs.StringValue> distinct = sampled.stream().distinct().collect(toList());
+		then(distinct.size()).isNotEqualTo(sampled.size());
+	}
+
+	@Property
+	void giveMeSpecAnyFirstWithMetadataManipulatorReturnsGivenOrder() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.specAny(new ExpressionSpec().size("values", 2))
+			.size("values", 1)
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+	}
+
+	@Property
+	void giveMeSpecAnyLastWithMetadataManipulatorReturnsGivenOrder() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.size("values", 1)
+			.specAny(new ExpressionSpec().size("values", 2))
+			.sample();
+
+		then(actual.getValues()).hasSize(2);
+	}
+
+	@Property
+	void giveMeSpecListSetSize() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().list("values", it -> it.ofSize(1)))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+	}
+
+	@Property
+	void giveMeSpecListSetElement() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(1);
+				it.setElement(0, 1);
+			}))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).isEqualTo(1);
+	}
+
+	@Property
+	void giveMeSpecListAnySet() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(3);
+				it.any(1);
+			}))
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it == 1);
+	}
+
+	@Property
+	void giveMeSpecListAnyWithoutSize() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec().list("values", it -> it.any("set")))
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecListAnyWithoutMaxSize() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofMinSize(5);
+				it.any("set");
+			}))
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecListAnyWithoutMinSize() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofMaxSize(2);
+				it.any("set");
+			}))
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecListAllSet() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(3);
+				it.all(1);
+			}))
+			.sample();
+
+		then(actual.getValues()).allMatch(it -> it == 1);
+	}
+
+	@Property
+	void giveMeSpecListPostConditionElement() {
+		// when
+		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(1);
+				it.setElementPostCondition(0, int.class, postConditioned -> postConditioned > 1);
+			}))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).isGreaterThan(1);
+	}
+
+	@Property
+	void giveMeSpecListPostConditionElementField() {
+		// when
+		SpecTestSpecs.NestedStringValueList actual = SUT.giveMeBuilder(SpecTestSpecs.NestedStringValueList.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(1);
+				it.setElementFieldPostCondition(0, "value", String.class,
+					postConditioned -> postConditioned.length() > 5);
+			}))
+			.sample();
+
+		then(actual.getValues()).allMatch(it -> it.getValue().length() > 5);
+	}
+
+	@Property
+	void giveMeSpecListListElementSet() {
+		// when
+		SpecTestSpecs.ListListString actual = SUT.giveMeBuilder(SpecTestSpecs.ListListString.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(1);
+				it.listElement(0, nestedIt -> {
+					nestedIt.ofSize(1);
+					nestedIt.setElement(0, "set");
+				});
+			}))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).hasSize(1);
+		then(actual.getValues().get(0).get(0)).isEqualTo("set");
+	}
+
+	@Property
+	void giveMeSpecListListElementPostCondition() {
+		// when
+		SpecTestSpecs.ListListString actual = SUT.giveMeBuilder(SpecTestSpecs.ListListString.class)
+			.spec(new ExpressionSpec().list("values", it -> {
+				it.ofSize(1);
+				it.listElement(0, nestedIt -> {
+					nestedIt.ofSize(1);
+					nestedIt.setElementPostCondition(0, String.class, postConditioned -> postConditioned.length() > 5);
+				});
+			}))
+			.sample();
+
+		then(actual.getValues()).hasSize(1);
+		then(actual.getValues().get(0)).hasSize(1);
+		then(actual.getValues().get(0).get(0).length()).isGreaterThan(5);
+	}
+
+	@Property
+	void giveMeSpecSetWithLimit() {
+		// when
+		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+			.spec(new ExpressionSpec()
+				.set("value", 1, 0))
+			.sample();
+
+		then(actual.getValue()).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+	}
+
+	@Property
+	void giveMeSpecSetIndexWithLimitReturns() {
+		// when
+		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			.spec(new ExpressionSpec()
+				.size("values", 2, 2)
+				.set("values[*]", "set", 1))
+			.sample();
+
+		then(actual.getValues()).anyMatch(it -> !it.equals("set"));
+	}
+
+	@Property
+	void giveMeSpecSetArbitraryBuilder() {
+		// when
+		SpecTestSpecs.StringAndInt actual = SUT.giveMeBuilder(SpecTestSpecs.StringAndInt.class)
+			.spec(new ExpressionSpec().set("value2",
+				SUT.giveMeBuilder(SpecTestSpecs.IntValue.class).set("value", 1))
+			)
+			.sample();
+
+		then(actual.getValue2().getValue()).isEqualTo(1);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -18,7 +18,9 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import com.navercorp.fixturemonkey.LabMonkey;
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
+
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Property;
@@ -26,7 +28,6 @@ import net.jqwik.api.Property;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.SUT;
 import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntegerList;
 import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntValue;
 import static com.navercorp.fixturemonkey.test.SpecTestSpecs.ListListString;
@@ -40,8 +41,10 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
 public class SpecTest {
+	public static final LabMonkey SUT = LabMonkey.create();
+
 	@Property
-	void giveMeSpecSet() {
+	void specSet() {
 		// when
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().set("value", -1))
@@ -51,7 +54,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecSetArbitrary() {
+	void specSetArbitrary() {
 		// when
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().set("value", Arbitraries.just(1)))
@@ -61,7 +64,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeListSize() {
+	void specSize() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().size("values", 1, 1))
@@ -71,7 +74,29 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetNull() {
+	void specMinSize() {
+		// when
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
+			.spec(new ExpressionSpec().minSize("values", 10))
+			.sample();
+
+		then(actual.getValues()).hasSizeGreaterThanOrEqualTo(10);
+	}
+
+
+	@Property
+	void specMaxSize() {
+		// when
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
+			.spec(new ExpressionSpec().maxSize("values", 10))
+			.sample();
+
+		then(actual.getValues()).hasSizeLessThanOrEqualTo(10);
+	}
+
+
+	@Property
+	void specSetNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().setNull("values"))
@@ -81,7 +106,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSizeAfterSetNullReturnsNull() {
+	void specSizeAfterSetNullReturnsNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -94,7 +119,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetAfterSetNullReturnsNotNull() {
+	void specSetAfterSetNullReturnsNotNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -110,7 +135,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetNotNullAfterSetNullReturnsNotNull() {
+	void specSetNotNullAfterSetNullReturnsNotNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -123,7 +148,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetNullAfterSetNotNullReturnsNull() {
+	void specSetNullAfterSetNotNullReturnsNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -136,7 +161,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetNullAfterSetReturnsNull() {
+	void specSetNullAfterSetReturnsNull() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -150,7 +175,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecPostCondition() {
+	void specPostCondition() {
 		// when
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().setPostCondition(
@@ -164,7 +189,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecPostConditionType() {
+	void specPostConditionType() {
 		// when
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().setPostCondition(
@@ -178,7 +203,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMePostConditionIndex() {
+	void specPostConditionIndex() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
@@ -191,7 +216,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeObjectToBuilderSetIndex() {
+	void specObjectToBuilderSetIndex() {
 		// given
 		IntegerList expected = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().size("values", 2, 2))
@@ -206,7 +231,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeListSpecMaxSize() {
+	void specListMaxSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -220,7 +245,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeListSpecSizeBetween() {
+	void specListSizeBetween() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -234,7 +259,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSetRightOrder() {
+	void specSetRightOrder() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -256,7 +281,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMePostConditionRightOrder() {
+	void specPostConditionRightOrder() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -275,7 +300,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeListSpecMinSize() {
+	void specListMinSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -289,7 +314,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecAny() {
+	void specAny() {
 		// given
 		ExpressionSpec specOne = new ExpressionSpec()
 			.list("values", it -> it
@@ -322,7 +347,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecAnyWithEmpty() {
+	void specAnyWithEmpty() {
 		thenNoException().isThrownBy(
 			() -> SUT.giveMeBuilder(StringList.class)
 				.specAny()
@@ -331,7 +356,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecAnyWithNull() {
+	void specAnyWithNull() {
 		thenNoException().isThrownBy(
 			() -> SUT.giveMeBuilder(StringList.class)
 				.specAny((ExpressionSpec[])null)
@@ -340,7 +365,7 @@ public class SpecTest {
 	}
 
 	@Property(tries = 2)
-	void giveMeSpecAnyReturnsDiff() {
+	void specAnyReturnsDiff() {
 		// given
 		Arbitrary<StringValue> complex = SUT.giveMeBuilder(
 				StringValue.class)
@@ -367,7 +392,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecAnyFirstWithMetadataManipulatorReturnsGivenOrder() {
+	void specAnyFirstWithMetadataManipulatorReturnsGivenOrder() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.specAny(new ExpressionSpec().size("values", 2))
@@ -378,7 +403,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecAnyLastWithMetadataManipulatorReturnsGivenOrder() {
+	void specAnyLastWithMetadataManipulatorReturnsGivenOrder() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.size("values", 1)
@@ -389,7 +414,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListSetSize() {
+	void specListSetSize() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> it.ofSize(1)))
@@ -399,7 +424,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListSetElement() {
+	void specListSetElement() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -413,7 +438,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListAnySet() {
+	void specListAnySet() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -426,7 +451,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListAnyWithoutSize() {
+	void specListAnyWithoutSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> it.any("set")))
@@ -436,7 +461,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListAnyWithoutMaxSize() {
+	void specListAnyWithoutMaxSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -449,7 +474,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListAnyWithoutMinSize() {
+	void specListAnyWithoutMinSize() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -462,7 +487,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListAllSet() {
+	void specListAllSet() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -475,7 +500,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListPostConditionElement() {
+	void specListPostConditionElement() {
 		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -489,7 +514,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListPostConditionElementField() {
+	void specListPostConditionElementField() {
 		// when
 		NestedStringValueList actual = SUT.giveMeBuilder(NestedStringValueList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -503,7 +528,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListListElementSet() {
+	void specListListElementSet() {
 		// when
 		ListListString actual = SUT.giveMeBuilder(ListListString.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -521,7 +546,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecListListElementPostCondition() {
+	void specListListElementPostCondition() {
 		// when
 		ListListString actual = SUT.giveMeBuilder(ListListString.class)
 			.spec(new ExpressionSpec().list("values", it -> {
@@ -539,7 +564,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecSetWithLimit() {
+	void specSetWithLimit() {
 		// when
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec()
@@ -550,7 +575,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecSetIndexWithLimitReturns() {
+	void specSetIndexWithLimitReturns() {
 		// when
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
@@ -562,7 +587,7 @@ public class SpecTest {
 	}
 
 	@Property
-	void giveMeSpecSetArbitraryBuilder() {
+	void specSetArbitraryBuilder() {
 		// when
 		StringAndInt actual = SUT.giveMeBuilder(StringAndInt.class)
 			.spec(new ExpressionSpec().set("value2",

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.test;
 
 import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
@@ -9,6 +27,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.navercorp.fixturemonkey.test.SpecTestSpecs.SUT;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntegerList;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntValue;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.ListListString;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.NestedStringValueList;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringAndInt;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringList;
+import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringValue;
+
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
@@ -17,7 +43,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecSet() {
 		// when
-		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().set("value", -1))
 			.sample();
 
@@ -27,7 +53,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecSetArbitrary() {
 		// when
-		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().set("value", Arbitraries.just(1)))
 			.sample();
 
@@ -37,7 +63,7 @@ public class SpecTest {
 	@Property
 	void giveMeListSize() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().size("values", 1, 1))
 			.sample();
 
@@ -47,7 +73,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().setNull("values"))
 			.sample();
 
@@ -57,7 +83,7 @@ public class SpecTest {
 	@Property
 	void giveMeSizeAfterSetNullReturnsNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
 				.setNull("values")
 				.size("values", 1, 1)
@@ -70,7 +96,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetAfterSetNullReturnsNotNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
 				.setNull("values")
 				.size("values", 1, 1)
@@ -86,7 +112,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetNotNullAfterSetNullReturnsNotNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
 				.setNull("values")
 				.setNotNull("values")
@@ -99,7 +125,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetNullAfterSetNotNullReturnsNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
 				.setNotNull("values")
 				.setNull("values")
@@ -112,7 +138,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetNullAfterSetReturnsNull() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
 				.size("values", 1, 1)
 				.set("values[0]", 0)
@@ -126,7 +152,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecPostCondition() {
 		// when
-		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().setPostCondition(
 				"value",
 				int.class,
@@ -140,7 +166,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecPostConditionType() {
 		// when
-		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec().setPostCondition(
 				"value",
 				int.class,
@@ -154,9 +180,9 @@ public class SpecTest {
 	@Property
 	void giveMePostConditionIndex() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec()
-				.setPostCondition("values[0]", int.class, value -> value >= 0 && value <= 100)
+				.setPostCondition("values[0]", Integer.class, value -> value >= 0 && value <= 100)
 				.size("values", 1, 1))
 			.sample();
 
@@ -167,12 +193,12 @@ public class SpecTest {
 	@Property
 	void giveMeObjectToBuilderSetIndex() {
 		// given
-		SpecTestSpecs.IntegerList expected = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList expected = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().size("values", 2, 2))
 			.sample();
 
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(expected)
+		IntegerList actual = SUT.giveMeBuilder(expected)
 			.set("values[1]", 1)
 			.sample();
 
@@ -182,7 +208,7 @@ public class SpecTest {
 	@Property
 	void giveMeListSpecMaxSize() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.list("values",
 					it -> it.ofMaxSize(2)
@@ -196,7 +222,7 @@ public class SpecTest {
 	@Property
 	void giveMeListSpecSizeBetween() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.list("values",
 					it -> it.ofSizeBetween(1, 3)
@@ -210,7 +236,7 @@ public class SpecTest {
 	@Property
 	void giveMeSetRightOrder() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.list("values",
 					it -> it.ofSize(3)
@@ -232,7 +258,7 @@ public class SpecTest {
 	@Property
 	void giveMePostConditionRightOrder() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.list("values",
 					(it) -> it.ofSize(2)
@@ -251,7 +277,7 @@ public class SpecTest {
 	@Property
 	void giveMeListSpecMinSize() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.list("values",
 					it -> it.ofMinSize(1)
@@ -278,16 +304,16 @@ public class SpecTest {
 			);
 
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.specAny(specOne, specTwo)
 			.sample();
 
 		// then
-		SpecTestSpecs.IntegerList expectedOne = new SpecTestSpecs.IntegerList();
+		IntegerList expectedOne = new IntegerList();
 		expectedOne.setValues(new ArrayList<>());
 		expectedOne.getValues().add(1);
 
-		SpecTestSpecs.IntegerList expectedTwo = new SpecTestSpecs.IntegerList();
+		IntegerList expectedTwo = new IntegerList();
 		expectedTwo.setValues(new ArrayList<>());
 		expectedTwo.getValues().add(1);
 		expectedTwo.getValues().add(2);
@@ -298,7 +324,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecAnyWithEmpty() {
 		thenNoException().isThrownBy(
-			() -> SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			() -> SUT.giveMeBuilder(StringList.class)
 				.specAny()
 				.sample()
 		);
@@ -307,7 +333,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecAnyWithNull() {
 		thenNoException().isThrownBy(
-			() -> SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+			() -> SUT.giveMeBuilder(StringList.class)
 				.specAny((ExpressionSpec[])null)
 				.sample()
 		);
@@ -316,8 +342,8 @@ public class SpecTest {
 	@Property(tries = 2)
 	void giveMeSpecAnyReturnsDiff() {
 		// given
-		Arbitrary<SpecTestSpecs.StringValue> complex = SpecTestSpecs.SUT.giveMeBuilder(
-				SpecTestSpecs.StringValue.class)
+		Arbitrary<StringValue> complex = SUT.giveMeBuilder(
+				StringValue.class)
 			.specAny(
 				new ExpressionSpec().set("value", "test1"),
 				new ExpressionSpec().set("value", "test2"),
@@ -333,17 +359,17 @@ public class SpecTest {
 			.build();
 
 		// when
-		List<SpecTestSpecs.StringValue> sampled = complex.list().ofSize(100).sample();
+		List<StringValue> sampled = complex.list().ofSize(100).sample();
 
 		// then
-		List<SpecTestSpecs.StringValue> distinct = sampled.stream().distinct().collect(toList());
+		List<StringValue> distinct = sampled.stream().distinct().collect(toList());
 		then(distinct.size()).isNotEqualTo(sampled.size());
 	}
 
 	@Property
 	void giveMeSpecAnyFirstWithMetadataManipulatorReturnsGivenOrder() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.specAny(new ExpressionSpec().size("values", 2))
 			.size("values", 1)
 			.sample();
@@ -354,7 +380,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecAnyLastWithMetadataManipulatorReturnsGivenOrder() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.size("values", 1)
 			.specAny(new ExpressionSpec().size("values", 2))
 			.sample();
@@ -365,7 +391,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListSetSize() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> it.ofSize(1)))
 			.sample();
 
@@ -375,7 +401,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListSetElement() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(1);
 				it.setElement(0, 1);
@@ -389,7 +415,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListAnySet() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(3);
 				it.any(1);
@@ -402,7 +428,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListAnyWithoutSize() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> it.any("set")))
 			.sample();
 
@@ -412,7 +438,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListAnyWithoutMaxSize() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofMinSize(5);
 				it.any("set");
@@ -425,7 +451,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListAnyWithoutMinSize() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofMaxSize(2);
 				it.any("set");
@@ -438,7 +464,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListAllSet() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(3);
 				it.all(1);
@@ -451,10 +477,10 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListPostConditionElement() {
 		// when
-		SpecTestSpecs.IntegerList actual = SUT.giveMeBuilder(SpecTestSpecs.IntegerList.class)
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(1);
-				it.setElementPostCondition(0, int.class, postConditioned -> postConditioned > 1);
+				it.setElementPostCondition(0, Integer.class, postConditioned -> postConditioned > 1);
 			}))
 			.sample();
 
@@ -465,7 +491,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListPostConditionElementField() {
 		// when
-		SpecTestSpecs.NestedStringValueList actual = SUT.giveMeBuilder(SpecTestSpecs.NestedStringValueList.class)
+		NestedStringValueList actual = SUT.giveMeBuilder(NestedStringValueList.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(1);
 				it.setElementFieldPostCondition(0, "value", String.class,
@@ -479,7 +505,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListListElementSet() {
 		// when
-		SpecTestSpecs.ListListString actual = SUT.giveMeBuilder(SpecTestSpecs.ListListString.class)
+		ListListString actual = SUT.giveMeBuilder(ListListString.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(1);
 				it.listElement(0, nestedIt -> {
@@ -497,7 +523,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecListListElementPostCondition() {
 		// when
-		SpecTestSpecs.ListListString actual = SUT.giveMeBuilder(SpecTestSpecs.ListListString.class)
+		ListListString actual = SUT.giveMeBuilder(ListListString.class)
 			.spec(new ExpressionSpec().list("values", it -> {
 				it.ofSize(1);
 				it.listElement(0, nestedIt -> {
@@ -515,7 +541,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecSetWithLimit() {
 		// when
-		SpecTestSpecs.IntValue actual = SUT.giveMeBuilder(SpecTestSpecs.IntValue.class)
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
 			.spec(new ExpressionSpec()
 				.set("value", 1, 0))
 			.sample();
@@ -526,7 +552,7 @@ public class SpecTest {
 	@Property
 	void giveMeSpecSetIndexWithLimitReturns() {
 		// when
-		SpecTestSpecs.StringList actual = SUT.giveMeBuilder(SpecTestSpecs.StringList.class)
+		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.spec(new ExpressionSpec()
 				.size("values", 2, 2)
 				.set("values[*]", "set", 1))
@@ -538,9 +564,9 @@ public class SpecTest {
 	@Property
 	void giveMeSpecSetArbitraryBuilder() {
 		// when
-		SpecTestSpecs.StringAndInt actual = SUT.giveMeBuilder(SpecTestSpecs.StringAndInt.class)
+		StringAndInt actual = SUT.giveMeBuilder(StringAndInt.class)
 			.spec(new ExpressionSpec().set("value2",
-				SUT.giveMeBuilder(SpecTestSpecs.IntValue.class).set("value", 1))
+				SUT.giveMeBuilder(IntValue.class).set("value", 1))
 			)
 			.sample();
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -18,27 +18,26 @@
 
 package com.navercorp.fixturemonkey.test;
 
-import com.navercorp.fixturemonkey.LabMonkey;
-import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Property;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntegerList;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.IntValue;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.ListListString;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.NestedStringValueList;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringAndInt;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringList;
-import static com.navercorp.fixturemonkey.test.SpecTestSpecs.StringValue;
-
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenNoException;
+import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.customizer.ExpressionSpec;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.IntValue;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.IntegerList;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.ListListString;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.NestedStringValueList;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringAndInt;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringList;
+import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringValue;
 
 public class SpecTest {
 	public static final LabMonkey SUT = LabMonkey.create();
@@ -83,7 +82,6 @@ public class SpecTest {
 		then(actual.getValues()).hasSizeGreaterThanOrEqualTo(10);
 	}
 
-
 	@Property
 	void specMaxSize() {
 		// when
@@ -93,7 +91,6 @@ public class SpecTest {
 
 		then(actual.getValues()).hasSizeLessThanOrEqualTo(10);
 	}
-
 
 	@Property
 	void specSetNull() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -39,7 +39,7 @@ import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringAndInt;
 import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringList;
 import com.navercorp.fixturemonkey.test.SpecTestSpecs.StringValue;
 
-public class SpecTest {
+class SpecTest {
 	public static final LabMonkey SUT = LabMonkey.create();
 
 	@Property

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTest.java
@@ -44,9 +44,11 @@ class SpecTest {
 
 	@Property
 	void specSet() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.set("value", -1);
+
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
-			.spec(new ExpressionSpec().set("value", -1))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValue()).isEqualTo(-1);
@@ -54,9 +56,11 @@ class SpecTest {
 
 	@Property
 	void specSetArbitrary() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.set("value", Arbitraries.just(1));
+
 		IntValue actual = SUT.giveMeBuilder(IntValue.class)
-			.spec(new ExpressionSpec().set("value", Arbitraries.just(1)))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValue()).isEqualTo(1);
@@ -64,9 +68,11 @@ class SpecTest {
 
 	@Property
 	void specSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 1, 1);
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().size("values", 1, 1))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -74,9 +80,11 @@ class SpecTest {
 
 	@Property
 	void specMinSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.minSize("values", 10);
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().minSize("values", 10))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSizeGreaterThanOrEqualTo(10);
@@ -84,9 +92,10 @@ class SpecTest {
 
 	@Property
 	void specMaxSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.maxSize("values", 10);
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().maxSize("values", 10))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSizeLessThanOrEqualTo(10);
@@ -94,9 +103,11 @@ class SpecTest {
 
 	@Property
 	void specSetNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setNull("values");
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().setNull("values"))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNull();
@@ -104,12 +115,12 @@ class SpecTest {
 
 	@Property
 	void specSizeAfterSetNullReturnsNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setNull("values")
+			.size("values", 1, 1);
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.setNull("values")
-				.size("values", 1, 1)
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNull();
@@ -117,13 +128,13 @@ class SpecTest {
 
 	@Property
 	void specSetAfterSetNullReturnsNotNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setNull("values")
+			.size("values", 1, 1)
+			.set("values[0]", 0);
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.setNull("values")
-				.size("values", 1, 1)
-				.set("values[0]", 0)
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNotNull();
@@ -133,12 +144,12 @@ class SpecTest {
 
 	@Property
 	void specSetNotNullAfterSetNullReturnsNotNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setNull("values")
+			.setNotNull("values");
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.setNull("values")
-				.setNotNull("values")
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNotNull();
@@ -146,12 +157,12 @@ class SpecTest {
 
 	@Property
 	void specSetNullAfterSetNotNullReturnsNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setNotNull("values")
+			.setNull("values");
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.setNotNull("values")
-				.setNull("values")
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNull();
@@ -159,13 +170,13 @@ class SpecTest {
 
 	@Property
 	void specSetNullAfterSetReturnsNull() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 1, 1)
+			.set("values[0]", 0)
+			.setNull("values");
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.size("values", 1, 1)
-				.set("values[0]", 0)
-				.setNull("values")
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).isNull();
@@ -173,13 +184,15 @@ class SpecTest {
 
 	@Property
 	void specPostCondition() {
-		// when
-		IntValue actual = SUT.giveMeBuilder(IntValue.class)
-			.spec(new ExpressionSpec().setPostCondition(
+		ExpressionSpec spec = new ExpressionSpec()
+			.setPostCondition(
 				"value",
 				int.class,
 				value -> value >= 0 && value <= 100
-			))
+			);
+
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValue()).isBetween(0, 100);
@@ -187,13 +200,15 @@ class SpecTest {
 
 	@Property
 	void specPostConditionType() {
-		// when
-		IntValue actual = SUT.giveMeBuilder(IntValue.class)
-			.spec(new ExpressionSpec().setPostCondition(
+		ExpressionSpec spec = new ExpressionSpec()
+			.setPostCondition(
 				"value",
 				int.class,
 				value -> value >= 0 && value <= 100
-			))
+			);
+
+		IntValue actual = SUT.giveMeBuilder(IntValue.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValue()).isBetween(0, 100);
@@ -201,11 +216,12 @@ class SpecTest {
 
 	@Property
 	void specPostConditionIndex() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.setPostCondition("values[0]", Integer.class, value -> value >= 0 && value <= 100)
+			.size("values", 1, 1);
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec()
-				.setPostCondition("values[0]", Integer.class, value -> value >= 0 && value <= 100)
-				.size("values", 1, 1))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -214,12 +230,12 @@ class SpecTest {
 
 	@Property
 	void specObjectToBuilderSetIndex() {
-		// given
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 2, 2);
 		IntegerList expected = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().size("values", 2, 2))
+			.spec(spec)
 			.sample();
 
-		// when
 		IntegerList actual = SUT.giveMeBuilder(expected)
 			.set("values[1]", 1)
 			.sample();
@@ -229,13 +245,13 @@ class SpecTest {
 
 	@Property
 	void specListMaxSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values",
+				it -> it.ofMaxSize(2)
+			);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values",
-					it -> it.ofMaxSize(2)
-				)
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues().size()).isLessThanOrEqualTo(2);
@@ -243,13 +259,13 @@ class SpecTest {
 
 	@Property
 	void specListSizeBetween() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values",
+				it -> it.ofSizeBetween(1, 3)
+			);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values",
-					it -> it.ofSizeBetween(1, 3)
-				)
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues().size()).isBetween(1, 3);
@@ -257,16 +273,16 @@ class SpecTest {
 
 	@Property
 	void specSetRightOrder() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values",
+				it -> it.ofSize(3)
+					.setElement(0, "field1")
+					.setElement(1, "field2")
+					.setElement(2, "field3")
+			);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values",
-					it -> it.ofSize(3)
-						.setElement(0, "field1")
-						.setElement(1, "field2")
-						.setElement(2, "field3")
-				)
-			)
+			.spec(spec)
 			.sample();
 
 		// then
@@ -279,14 +295,15 @@ class SpecTest {
 
 	@Property
 	void specPostConditionRightOrder() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values",
+				(it) -> it.ofSize(2)
+					.setElementPostCondition(0, String.class, s -> s.length() > 5)
+					.setElementPostCondition(1, String.class, s -> s.length() > 10)
+			);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values",
-					(it) -> it.ofSize(2)
-						.setElementPostCondition(0, String.class, s -> s.length() > 5)
-						.setElementPostCondition(1, String.class, s -> s.length() > 10)
-				))
+			.spec(spec)
 			.sample();
 
 		// then
@@ -298,13 +315,13 @@ class SpecTest {
 
 	@Property
 	void specListMinSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values",
+				it -> it.ofMinSize(1)
+			);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.list("values",
-					it -> it.ofMinSize(1)
-				)
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues().size()).isGreaterThanOrEqualTo(1);
@@ -325,7 +342,6 @@ class SpecTest {
 				.setElement(1, 2)
 			);
 
-		// when
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
 			.specAny(specOne, specTwo)
 			.sample();
@@ -363,7 +379,6 @@ class SpecTest {
 
 	@Property(tries = 2)
 	void specAnyReturnsDiff() {
-		// given
 		Arbitrary<StringValue> complex = SUT.giveMeBuilder(
 				StringValue.class)
 			.specAny(
@@ -380,19 +395,19 @@ class SpecTest {
 			)
 			.build();
 
-		// when
 		List<StringValue> sampled = complex.list().ofSize(100).sample();
 
-		// then
 		List<StringValue> distinct = sampled.stream().distinct().collect(toList());
 		then(distinct.size()).isNotEqualTo(sampled.size());
 	}
 
 	@Property
 	void specAnyFirstWithMetadataManipulatorReturnsGivenOrder() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 2);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.specAny(new ExpressionSpec().size("values", 2))
+			.specAny(spec)
 			.size("values", 1)
 			.sample();
 
@@ -401,10 +416,12 @@ class SpecTest {
 
 	@Property
 	void specAnyLastWithMetadataManipulatorReturnsGivenOrder() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 2);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
 			.size("values", 1)
-			.specAny(new ExpressionSpec().size("values", 2))
+			.specAny(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(2);
@@ -412,9 +429,11 @@ class SpecTest {
 
 	@Property
 	void specListSetSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> it.ofSize(1));
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().list("values", it -> it.ofSize(1)))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -422,12 +441,13 @@ class SpecTest {
 
 	@Property
 	void specListSetElement() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec().list("values", it -> {
+			it.ofSize(1);
+			it.setElement(0, 1);
+		});
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
-				it.ofSize(1);
-				it.setElement(0, 1);
-			}))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -436,12 +456,13 @@ class SpecTest {
 
 	@Property
 	void specListAnySet() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec().list("values", it -> {
+			it.ofSize(3);
+			it.any(1);
+		});
+
 		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
-				it.ofSize(3);
-				it.any(1);
-			}))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it == 1);
@@ -449,9 +470,11 @@ class SpecTest {
 
 	@Property
 	void specListAnyWithoutSize() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> it.any("set"));
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec().list("values", it -> it.any("set")))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));
@@ -459,12 +482,14 @@ class SpecTest {
 
 	@Property
 	void specListAnyWithoutMaxSize() {
-		// when
-		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofMinSize(5);
 				it.any("set");
-			}))
+			});
+
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));
@@ -472,12 +497,14 @@ class SpecTest {
 
 	@Property
 	void specListAnyWithoutMinSize() {
-		// when
-		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofMaxSize(2);
 				it.any("set");
-			}))
+			});
+
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> it.equals("set"));
@@ -485,12 +512,14 @@ class SpecTest {
 
 	@Property
 	void specListAllSet() {
-		// when
-		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofSize(3);
 				it.all(1);
-			}))
+			});
+
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).allMatch(it -> it == 1);
@@ -498,12 +527,14 @@ class SpecTest {
 
 	@Property
 	void specListPostConditionElement() {
-		// when
-		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofSize(1);
 				it.setElementPostCondition(0, Integer.class, postConditioned -> postConditioned > 1);
-			}))
+			});
+
+		IntegerList actual = SUT.giveMeBuilder(IntegerList.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -512,13 +543,15 @@ class SpecTest {
 
 	@Property
 	void specListPostConditionElementField() {
-		// when
-		NestedStringValueList actual = SUT.giveMeBuilder(NestedStringValueList.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofSize(1);
 				it.setElementFieldPostCondition(0, "value", String.class,
 					postConditioned -> postConditioned.length() > 5);
-			}))
+			});
+
+		NestedStringValueList actual = SUT.giveMeBuilder(NestedStringValueList.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).allMatch(it -> it.getValue().length() > 5);
@@ -526,15 +559,17 @@ class SpecTest {
 
 	@Property
 	void specListListElementSet() {
-		// when
-		ListListString actual = SUT.giveMeBuilder(ListListString.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofSize(1);
 				it.listElement(0, nestedIt -> {
 					nestedIt.ofSize(1);
 					nestedIt.setElement(0, "set");
 				});
-			}))
+			});
+
+		ListListString actual = SUT.giveMeBuilder(ListListString.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -544,15 +579,17 @@ class SpecTest {
 
 	@Property
 	void specListListElementPostCondition() {
-		// when
-		ListListString actual = SUT.giveMeBuilder(ListListString.class)
-			.spec(new ExpressionSpec().list("values", it -> {
+		ExpressionSpec spec = new ExpressionSpec()
+			.list("values", it -> {
 				it.ofSize(1);
 				it.listElement(0, nestedIt -> {
 					nestedIt.ofSize(1);
 					nestedIt.setElementPostCondition(0, String.class, postConditioned -> postConditioned.length() > 5);
 				});
-			}))
+			});
+
+		ListListString actual = SUT.giveMeBuilder(ListListString.class)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).hasSize(1);
@@ -561,23 +598,25 @@ class SpecTest {
 	}
 
 	@Property
-	void specSetWithLimit() {
-		// when
-		IntValue actual = SUT.giveMeBuilder(IntValue.class)
-			.spec(new ExpressionSpec()
-				.set("value", 1, 0))
+	void specSetWithLimitZeroAffectsNothing() {
+		ExpressionSpec spec = new ExpressionSpec()
+			.set("values[*]", "set", 0);
+
+		StringList actual = SUT.giveMeBuilder(StringList.class)
+			.spec(spec)
 			.sample();
 
-		then(actual.getValue()).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+		then(actual.getValues()).allMatch(it -> !it.equals("set"));
 	}
 
 	@Property
 	void specSetIndexWithLimitReturns() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.size("values", 2, 2)
+			.set("values[*]", "set", 1);
+
 		StringList actual = SUT.giveMeBuilder(StringList.class)
-			.spec(new ExpressionSpec()
-				.size("values", 2, 2)
-				.set("values[*]", "set", 1))
+			.spec(spec)
 			.sample();
 
 		then(actual.getValues()).anyMatch(it -> !it.equals("set"));
@@ -585,11 +624,11 @@ class SpecTest {
 
 	@Property
 	void specSetArbitraryBuilder() {
-		// when
+		ExpressionSpec spec = new ExpressionSpec()
+			.set("value2", SUT.giveMeBuilder(IntValue.class).set("value", 1));
+
 		StringAndInt actual = SUT.giveMeBuilder(StringAndInt.class)
-			.spec(new ExpressionSpec().set("value2",
-				SUT.giveMeBuilder(IntValue.class).set("value", 1))
-			)
+			.spec(spec)
 			.sample();
 
 		then(actual.getValue2().getValue()).isEqualTo(1);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 public class SpecTestSpecs {
-	public static final LabMonkey SUT = LabMonkey.create();
-
 	@Data
 	public static class IntValue {
 		private int value;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -1,10 +1,26 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.test;
 
-import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.LabMonkey;
+
 import lombok.Data;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Provide;
 
 import java.util.List;
 import java.util.Map;
@@ -17,19 +33,9 @@ public class SpecTestSpecs {
 		private int value;
 	}
 
-	@Provide
-	Arbitrary<SpecTestSpecs.IntValue> intValue() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.IntValue.class);
-	}
-
 	@Data
 	public static class IntegerList {
 		private List<Integer> values;
-	}
-
-	@Provide
-	Arbitrary<SpecTestSpecs.IntegerList> integerList() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.IntegerList.class);
 	}
 
 	@Data
@@ -37,19 +43,9 @@ public class SpecTestSpecs {
 		private String value;
 	}
 
-	@Provide
-	Arbitrary<SpecTestSpecs.StringValue> stringValue() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.StringValue.class);
-	}
-
 	@Data
 	public static class StringList {
 		private List<String> values;
-	}
-
-	@Provide
-	Arbitrary<SpecTestSpecs.StringList> stringList() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.StringList.class);
 	}
 
 	@Data
@@ -58,19 +54,9 @@ public class SpecTestSpecs {
 		private String value2;
 	}
 
-	@Provide
-	Arbitrary<SpecTestSpecs.TwoString> twoString() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.TwoString.class);
-	}
-
 	@Data
 	public static class MapKeyIntegerValueInteger {
 		private Map<Integer, Integer> values;
-	}
-
-	@Provide
-	Arbitrary<SpecTestSpecs.MapKeyIntegerValueInteger> mapKeyIntegerValueInteger() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.MapKeyIntegerValueInteger.class);
 	}
 
 	@Data
@@ -78,29 +64,14 @@ public class SpecTestSpecs {
 		private List<SpecTestSpecs.StringValue> values;
 	}
 
-	@Provide
-	Arbitrary<SpecTestSpecs.NestedStringValueList> nestedStringValueList() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.NestedStringValueList.class);
-	}
-
 	@Data
 	public static class ListListString {
 		private List<List<String>> values;
-	}
-
-	@Provide
-	Arbitrary<SpecTestSpecs.ListListString> listListString() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.ListListString.class);
 	}
 
 	@Data
 	public static class StringAndInt {
 		private SpecTestSpecs.StringValue value1;
 		private SpecTestSpecs.IntValue value2;
-	}
-
-	@Provide
-	Arbitrary<SpecTestSpecs.StringAndInt> stringAndInt() {
-		return SUT.giveMeArbitrary(SpecTestSpecs.StringAndInt.class);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -1,0 +1,106 @@
+package com.navercorp.fixturemonkey.test;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.LabMonkey;
+import lombok.Data;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Provide;
+
+import java.util.List;
+import java.util.Map;
+
+public class SpecTestSpecs {
+	public static final LabMonkey SUT = LabMonkey.create();
+
+	@Data
+	public static class IntValue {
+		private int value;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.IntValue> intValue() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.IntValue.class);
+	}
+
+	@Data
+	public static class IntegerList {
+		private List<Integer> values;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.IntegerList> integerList() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.IntegerList.class);
+	}
+
+	@Data
+	public static class StringValue {
+		private String value;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.StringValue> stringValue() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.StringValue.class);
+	}
+
+	@Data
+	public static class StringList {
+		private List<String> values;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.StringList> stringList() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.StringList.class);
+	}
+
+	@Data
+	public static class TwoString {
+		private String value1;
+		private String value2;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.TwoString> twoString() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.TwoString.class);
+	}
+
+	@Data
+	public static class MapKeyIntegerValueInteger {
+		private Map<Integer, Integer> values;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.MapKeyIntegerValueInteger> mapKeyIntegerValueInteger() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.MapKeyIntegerValueInteger.class);
+	}
+
+	@Data
+	public static class NestedStringValueList {
+		private List<SpecTestSpecs.StringValue> values;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.NestedStringValueList> nestedStringValueList() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.NestedStringValueList.class);
+	}
+
+	@Data
+	public static class ListListString {
+		private List<List<String>> values;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.ListListString> listListString() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.ListListString.class);
+	}
+
+	@Data
+	public static class StringAndInt {
+		private SpecTestSpecs.StringValue value1;
+		private SpecTestSpecs.IntValue value2;
+	}
+
+	@Provide
+	Arbitrary<SpecTestSpecs.StringAndInt> stringAndInt() {
+		return SUT.giveMeArbitrary(SpecTestSpecs.StringAndInt.class);
+	}
+}

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -57,7 +57,7 @@ class SpecTestSpecs {
 
 	@Data
 	public static class NestedStringValueList {
-		private List<SpecTestSpecs.StringValue> values;
+		private List<StringValue> values;
 	}
 
 	@Data
@@ -67,7 +67,7 @@ class SpecTestSpecs {
 
 	@Data
 	public static class StringAndInt {
-		private SpecTestSpecs.StringValue value1;
-		private SpecTestSpecs.IntValue value2;
+		private StringValue value1;
+		private IntValue value2;
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -18,12 +18,10 @@
 
 package com.navercorp.fixturemonkey.test;
 
-import com.navercorp.fixturemonkey.LabMonkey;
-
-import lombok.Data;
-
 import java.util.List;
 import java.util.Map;
+
+import lombok.Data;
 
 public class SpecTestSpecs {
 	@Data

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/SpecTestSpecs.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import lombok.Data;
 
-public class SpecTestSpecs {
+class SpecTestSpecs {
 	@Data
 	public static class IntValue {
 		private int value;


### PR DESCRIPTION
0.4.0 버젼에서 ExpressionSpec을 사용한 .spec(), .specAny() 연산을 쓸 수 있도록 기능을 추가합니다.

- BuilderManipulatorAdapter를 사용해 ExpressionSpec의 BuilderManipulator들을 0.4.0 버젼에서 사용할 수 있는 연산의 형태로 변환합니다.