### PR TITLE
Add global caching

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/RootProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/RootProperty.java
@@ -65,7 +65,7 @@ public final class RootProperty implements Property {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(annotatedType);
+		return Objects.hash(annotatedType.getType());
 	}
 
 	@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
@@ -28,12 +28,12 @@ import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.junit.platform.commons.util.LruCache;
 
 import net.jqwik.api.Arbitrary;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import com.navercorp.fixturemonkey.api.collection.LruCache;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.junit.platform.commons.util.LruCache;
 
 import net.jqwik.api.Arbitrary;
 
@@ -36,6 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.LazyAnnotatedType;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -57,6 +59,7 @@ public class LabMonkey extends FixtureMonkey {
 	private final ArbitraryTraverser traverser;
 	private final ManipulatorOptimizer manipulatorOptimizer;
 	private final ArbitraryValidator validator;
+	private final LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
 
 	@SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
 	public LabMonkey(
@@ -64,7 +67,8 @@ public class LabMonkey extends FixtureMonkey {
 		ManipulateOptionsBuilder manipulateOptionsBuilder,
 		ArbitraryTraverser traverser,
 		ManipulatorOptimizer manipulatorOptimizer,
-		ArbitraryValidator validator
+		ArbitraryValidator validator,
+		LruCache<Property, Arbitrary<?>> arbitrariesByProperty
 	) {
 		super(null, null, null, null, null);
 		this.generateOptions = generateOptions;
@@ -72,6 +76,7 @@ public class LabMonkey extends FixtureMonkey {
 		this.traverser = traverser;
 		this.manipulatorOptimizer = manipulatorOptimizer;
 		this.validator = validator;
+		this.arbitrariesByProperty = arbitrariesByProperty;
 		manipulateOptionsBuilder.propertyNameResolvers(generateOptions.getPropertyNameResolvers());
 		manipulateOptionsBuilder.defaultPropertyNameResolver(generateOptions.getDefaultPropertyNameResolver());
 		manipulateOptionsBuilder.sampleRegisteredArbitraryBuilder(this);
@@ -115,7 +120,8 @@ public class LabMonkey extends FixtureMonkey {
 				traverser,
 				manipulatorOptimizer,
 				generateOptions,
-				manipulateOptions
+				manipulateOptions,
+				arbitrariesByProperty
 			),
 			traverser,
 			this.validator,
@@ -144,7 +150,8 @@ public class LabMonkey extends FixtureMonkey {
 				traverser,
 				manipulatorOptimizer,
 				generateOptions,
-				manipulateOptions
+				manipulateOptions,
+				arbitrariesByProperty
 			),
 			traverser,
 			this.validator,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkey.java
@@ -118,7 +118,7 @@ public class LabMonkey extends FixtureMonkey {
 				manipulatorOptimizer,
 				generateOptions,
 				manipulateOptions,
-				monkeyContext.getArbitrariesByProperty()
+				monkeyContext
 			),
 			traverser,
 			this.validator,
@@ -130,7 +130,7 @@ public class LabMonkey extends FixtureMonkey {
 	public <T> DefaultArbitraryBuilder<T> giveMeBuilder(T value) {
 		ManipulateOptions manipulateOptions = manipulateOptionsBuilder.build();
 		ArbitraryBuilderContext context = new ArbitraryBuilderContext();
-		context.getManipulators().add(
+		context.addManipulator(
 			new ArbitraryManipulator(
 				IdentityNodeResolver.INSTANCE,
 				new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value)
@@ -145,7 +145,7 @@ public class LabMonkey extends FixtureMonkey {
 				manipulatorOptimizer,
 				generateOptions,
 				manipulateOptions,
-				monkeyContext.getArbitrariesByProperty()
+				monkeyContext
 			),
 			traverser,
 			this.validator,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.junit.platform.commons.util.LruCache;
 
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
@@ -396,9 +397,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						| InstantiationException
-						| IllegalAccessException
-						| NoSuchMethodException e) {
+						 | InstantiationException
+						 | IllegalAccessException
+						 | NoSuchMethodException e) {
 					// ignored
 				}
 			}
@@ -523,7 +524,8 @@ public class LabMonkeyBuilder {
 			manipulateOptionsBuilder,
 			traverser,
 			manipulatorOptimizer,
-			this.arbitraryValidator
+			this.arbitraryValidator,
+			new LruCache<>(1000)
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -33,8 +33,8 @@ import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.junit.platform.commons.util.LruCache;
 
+import com.navercorp.fixturemonkey.api.collection.LruCache;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
@@ -397,9 +397,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						 | InstantiationException
-						 | IllegalAccessException
-						 | NoSuchMethodException e) {
+						| InstantiationException
+						| IllegalAccessException
+						| NoSuchMethodException e) {
 					// ignored
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.collection.LruCache;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
@@ -64,6 +63,7 @@ import com.navercorp.fixturemonkey.resolver.DecomposedContainerValueFactory;
 import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
 import com.navercorp.fixturemonkey.resolver.ManipulateOptionsBuilder;
 import com.navercorp.fixturemonkey.resolver.ManipulatorOptimizer;
+import com.navercorp.fixturemonkey.resolver.MonkeyContext;
 import com.navercorp.fixturemonkey.resolver.NoneManipulatorOptimizer;
 import com.navercorp.fixturemonkey.validator.ArbitraryValidator;
 import com.navercorp.fixturemonkey.validator.DefaultArbitraryValidator;
@@ -525,7 +525,7 @@ public class LabMonkeyBuilder {
 			traverser,
 			manipulatorOptimizer,
 			this.arbitraryValidator,
-			new LruCache<>(1000)
+			MonkeyContext.builder().build()
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -135,7 +135,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		} else if (value == null) {
 			this.setNull(expression);
 		} else {
-			this.context.getManipulators().add(
+			this.context.addManipulator(
 				new ArbitraryManipulator(
 					nodeResolver,
 					new ApplyNodeCountManipulator(
@@ -175,8 +175,8 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	public ArbitraryBuilder<T> setLazy(String expression, Supplier<?> supplier, int limit) {
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
 		LazyArbitrary<?> lazyArbitrary = LazyArbitrary.lazy(supplier);
-		this.context.getLazyArbitraries().add(lazyArbitrary);
-		this.context.getManipulators().add(
+		this.context.addLazyArbitrary(lazyArbitrary);
+		this.context.addManipulator(
 			new ArbitraryManipulator(
 				nodeResolver,
 				new ApplyNodeCountManipulator(
@@ -201,13 +201,13 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	public ArbitraryBuilder<T> spec(ExpressionSpec expressionSpec) {
 		List<BuilderManipulator> builderManipulators = expressionSpec.getBuilderManipulators();
 
-		this.context.getContainerInfosByNodeResolver().putAll(
+		this.context.putContainerInfos(
 			builderManipulators.stream()
 				.filter(ContainerSizeManipulator.class::isInstance)
 				.map(builderManipulatorAdapter::convertToContainerInfosByNodeResolverEntry)
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
 		);
-		this.context.getManipulators().addAll(
+		this.context.addManipulators(
 			builderManipulators.stream()
 				.filter(it -> !(it instanceof ContainerSizeManipulator))
 				.map(builderManipulatorAdapter::convertToArbitraryManipulator)
@@ -232,8 +232,8 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		InnerSpec innerSpec = new InnerSpec(traverser, manipulateOptions, nodeResolver);
 		specSpecifier.accept(innerSpec);
 		List<ArbitraryManipulator> mapManipulators = innerSpec.getArbitraryManipulators();
-		this.context.getContainerInfosByNodeResolver().putAll(innerSpec.getContainerInfosByNodeResolver());
-		this.context.getManipulators().addAll(mapManipulators);
+		this.context.putContainerInfos(innerSpec.getContainerInfosByNodeResolver());
+		this.context.addManipulators(mapManipulators);
 		return this;
 	}
 
@@ -275,7 +275,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
 
-		this.context.getContainerInfosByNodeResolver().put(nodeResolver, new ArbitraryContainerInfo(min, max, true));
+		this.context.putContainerInfo(nodeResolver, new ArbitraryContainerInfo(min, max, true));
 		return this;
 	}
 
@@ -293,7 +293,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 			containerInfosByNodeResolverEntries
 		) {
 			int fixedSize = containerInfoByNodeResolver.getValue().getRandomSize();
-			this.context.getContainerInfosByNodeResolver().put(
+			this.context.putContainerInfo(
 				containerInfoByNodeResolver.getKey(),
 				new ArbitraryContainerInfo(
 					fixedSize,
@@ -303,7 +303,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 			);
 		}
 
-		this.context.getManipulators().add(
+		this.context.addManipulator(
 			new ArbitraryManipulator(
 				IdentityNodeResolver.INSTANCE,
 				new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, this.sample())
@@ -327,8 +327,8 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 			}
 		);
 
-		this.context.getLazyArbitraries().add(lazyArbitrary);
-		this.context.getManipulators().add(
+		this.context.addLazyArbitrary(lazyArbitrary);
+		this.context.addManipulator(
 			new ArbitraryManipulator(
 				IdentityNodeResolver.INSTANCE,
 				new NodeSetLazyManipulator<>(
@@ -357,7 +357,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	public ArbitraryBuilder<T> setNull(String expression) {
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
 
-		this.context.getManipulators().add(new ArbitraryManipulator(
+		this.context.addManipulator(new ArbitraryManipulator(
 			nodeResolver,
 			new NodeNullityManipulator(true)
 		));
@@ -373,7 +373,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	public ArbitraryBuilder<T> setNotNull(String expression) {
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
 
-		this.context.getManipulators().add(
+		this.context.addManipulator(
 			new ArbitraryManipulator(
 				nodeResolver,
 				new NodeNullityManipulator(false)
@@ -411,7 +411,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 	) {
 		NodeResolver nodeResolver = monkeyExpressionFactory.from(expression).toNodeResolver();
 
-		this.context.getManipulators().add(
+		this.context.addManipulator(
 			new ArbitraryManipulator(
 				nodeResolver,
 				new ApplyNodeCountManipulator(
@@ -505,7 +505,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 
 	@Override
 	public ArbitraryBuilder<T> customize(MatcherOperator<FixtureCustomizer<T>> fixtureCustomizer) {
-		this.context.getCustomizers().add(fixtureCustomizer);
+		this.context.addCustomizer(fixtureCustomizer);
 		return this;
 	}
 
@@ -566,14 +566,14 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 
 	private <R> DefaultArbitraryBuilder<R> generateArbitraryBuilderLazily(LazyArbitrary<R> lazyArbitrary) {
 		ArbitraryBuilderContext context = new ArbitraryBuilderContext();
-		context.getManipulators().add(
+		context.addManipulator(
 			new ArbitraryManipulator(
 				IdentityNodeResolver.INSTANCE,
 				new NodeSetLazyManipulator<>(traverser, manipulateOptions, lazyArbitrary)
 			)
 		);
-		context.getLazyArbitraries().addAll(this.context.getLazyArbitraries());
-		context.getLazyArbitraries().add(lazyArbitrary);
+		context.addLazyArbitraries(this.context.getLazyArbitraries());
+		context.addLazyArbitrary(lazyArbitrary);
 
 		return new DefaultArbitraryBuilder<>(
 			manipulateOptions,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryBuilderContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryBuilderContext.java
@@ -1,0 +1,99 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class ArbitraryBuilderContext {
+	private final List<ArbitraryManipulator> manipulators;
+	private final Set<LazyArbitrary<?>> lazyArbitraries;
+	@SuppressWarnings("rawtypes")
+	private final List<MatcherOperator<? extends FixtureCustomizer>> customizers;
+	private final Map<NodeResolver, ArbitraryContainerInfo> containerInfosByNodeResolver;
+
+	private boolean validOnly;
+
+	@SuppressWarnings("rawtypes")
+	public ArbitraryBuilderContext(
+		List<ArbitraryManipulator> manipulators,
+		Set<LazyArbitrary<?>> lazyArbitraries,
+		List<MatcherOperator<? extends FixtureCustomizer>> customizers,
+		Map<NodeResolver, ArbitraryContainerInfo> containerInfosByNodeResolver,
+		boolean validOnly
+	) {
+		this.manipulators = manipulators;
+		this.lazyArbitraries = lazyArbitraries;
+		this.customizers = customizers;
+		this.containerInfosByNodeResolver = containerInfosByNodeResolver;
+		this.validOnly = validOnly;
+	}
+
+	public ArbitraryBuilderContext() {
+		this(new ArrayList<>(), new HashSet<>(), new ArrayList<>(), new HashMap<>(), true);
+	}
+
+	public ArbitraryBuilderContext copy() {
+		return new ArbitraryBuilderContext(
+			new ArrayList<>(this.manipulators),
+			new HashSet<>(this.lazyArbitraries),
+			new ArrayList<>(this.customizers),
+			new HashMap<>(this.containerInfosByNodeResolver),
+			this.validOnly
+		);
+	}
+
+	public List<ArbitraryManipulator> getManipulators() {
+		return manipulators;
+	}
+
+	public Set<LazyArbitrary<?>> getLazyArbitraries() {
+		return lazyArbitraries;
+	}
+
+	@SuppressWarnings("rawtypes")
+	public List<MatcherOperator<? extends FixtureCustomizer>> getCustomizers() {
+		return customizers;
+	}
+
+	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver() {
+		return containerInfosByNodeResolver;
+	}
+
+	public void setValidOnly(boolean validOnly) {
+		this.validOnly = validOnly;
+	}
+
+	public boolean isValidOnly() {
+		return validOnly;
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryBuilderContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryBuilderContext.java
@@ -19,6 +19,8 @@
 package com.navercorp.fixturemonkey.resolver;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -72,21 +74,50 @@ public final class ArbitraryBuilderContext {
 		);
 	}
 
+	public void addManipulator(ArbitraryManipulator arbitraryManipulator) {
+		this.manipulators.add(arbitraryManipulator);
+	}
+
+	public void addManipulators(Collection<ArbitraryManipulator> arbitraryManipulators) {
+		this.manipulators.addAll(arbitraryManipulators);
+	}
+
 	public List<ArbitraryManipulator> getManipulators() {
-		return manipulators;
+		return Collections.unmodifiableList(manipulators);
+	}
+
+	public void addLazyArbitrary(LazyArbitrary<?> lazyArbitrary) {
+		this.lazyArbitraries.add(lazyArbitrary);
+	}
+
+	public void addLazyArbitraries(Collection<LazyArbitrary<?>> lazyArbitraries) {
+		this.lazyArbitraries.addAll(lazyArbitraries);
 	}
 
 	public Set<LazyArbitrary<?>> getLazyArbitraries() {
-		return lazyArbitraries;
+		return Collections.unmodifiableSet(lazyArbitraries);
+	}
+
+	@SuppressWarnings("rawtypes")
+	public void addCustomizer(MatcherOperator<? extends FixtureCustomizer> fixtureCustomizer) {
+		this.customizers.add(fixtureCustomizer);
 	}
 
 	@SuppressWarnings("rawtypes")
 	public List<MatcherOperator<? extends FixtureCustomizer>> getCustomizers() {
-		return customizers;
+		return Collections.unmodifiableList(customizers);
+	}
+
+	public void putContainerInfo(NodeResolver nodeResolver, ArbitraryContainerInfo containerInfo) {
+		this.containerInfosByNodeResolver.put(nodeResolver, containerInfo);
+	}
+
+	public void putContainerInfos(Map<NodeResolver, ArbitraryContainerInfo> containerInfosByNodeResolver) {
+		this.containerInfosByNodeResolver.putAll(containerInfosByNodeResolver);
 	}
 
 	public Map<NodeResolver, ArbitraryContainerInfo> getContainerInfosByNodeResolver() {
-		return containerInfosByNodeResolver;
+		return Collections.unmodifiableMap(containerInfosByNodeResolver);
 	}
 
 	public void setValidOnly(boolean validOnly) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -100,11 +100,6 @@ public final class ArbitraryResolver {
 			manipulator.manipulate(arbitraryTree);
 		}
 
-		arbitraryTree.getMetadata().getNodesByProperty().entrySet().stream()
-			.filter(it -> customizers.stream().anyMatch(customizer -> customizer.match(it.getKey())))
-			.flatMap(it -> it.getValue().stream())
-			.forEach(it -> it.setManipulated(true));
-
 		return arbitraryTree.generate();
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -100,6 +100,11 @@ public final class ArbitraryResolver {
 			manipulator.manipulate(arbitraryTree);
 		}
 
+		arbitraryTree.getMetadata().getNodesByProperty().entrySet().stream()
+			.filter(it -> customizers.stream().anyMatch(customizer -> customizer.match(it.getKey())))
+			.flatMap(it -> it.getValue().stream())
+			.forEach(it -> it.setManipulated(true));
+
 		return arbitraryTree.generate();
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -32,7 +32,6 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
-import com.navercorp.fixturemonkey.api.collection.LruCache;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
@@ -48,20 +47,20 @@ public final class ArbitraryResolver {
 
 	private final GenerateOptions generateOptions;
 	private final ManipulateOptions manipulateOptions;
-	private final LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
+	private final MonkeyContext monkeyContext;
 
 	public ArbitraryResolver(
 		ArbitraryTraverser traverser,
 		ManipulatorOptimizer manipulatorOptimizer,
 		GenerateOptions generateOptions,
 		ManipulateOptions manipulateOptions,
-		LruCache<Property, Arbitrary<?>> arbitrariesByProperty
+		MonkeyContext monkeyContext
 	) {
 		this.traverser = traverser;
 		this.manipulatorOptimizer = manipulatorOptimizer;
 		this.generateOptions = generateOptions;
 		this.manipulateOptions = manipulateOptions;
-		this.arbitrariesByProperty = arbitrariesByProperty;
+		this.monkeyContext = monkeyContext;
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -74,8 +73,8 @@ public final class ArbitraryResolver {
 		ArbitraryTree arbitraryTree = new ArbitraryTree(
 			this.traverser.traverse(rootProperty, containerInfosByNodeResolver),
 			generateOptions,
+			monkeyContext,
 			customizers,
-			arbitrariesByProperty,
 			generateOptions.getUniqueProperties()
 		);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -128,7 +128,10 @@ final class ArbitraryTree {
 
 			Arbitrary<?> cached = arbitrariesByProperty.get(node.getProperty());
 
-			if (node.isNotManipulated() && cached != null) {
+			boolean notCustomized = ctx.getArbitraryCustomizers().stream()
+				.noneMatch(it -> it.match(node.getProperty()));
+
+			if (node.isNotManipulated() && notCustomized && cached != null) {
 				generated = cached;
 			} else {
 				generated = this.generateOptions.getArbitraryGenerator(prop.getObjectProperty().getProperty())
@@ -144,7 +147,7 @@ final class ArbitraryTree {
 					generated = generated.injectDuplicates(0d);
 				}
 
-				if (node.isNotManipulated()) {
+				if (node.isNotManipulated() && notCustomized) {
 					arbitrariesByProperty.put(
 						node.getProperty(),
 						generated

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContext.java
@@ -1,0 +1,44 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.collection.LruCache;
+import com.navercorp.fixturemonkey.api.property.Property;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class MonkeyContext {
+	private final LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
+
+	MonkeyContext(LruCache<Property, Arbitrary<?>> arbitrariesByProperty) {
+		this.arbitrariesByProperty = arbitrariesByProperty;
+	}
+
+	public static MonkeyContextBuilder builder() {
+		return new MonkeyContextBuilder();
+	}
+
+	public LruCache<Property, Arbitrary<?>> getArbitrariesByProperty() {
+		return arbitrariesByProperty;
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContext.java
@@ -38,7 +38,11 @@ public final class MonkeyContext {
 		return new MonkeyContextBuilder();
 	}
 
-	public LruCache<Property, Arbitrary<?>> getArbitrariesByProperty() {
-		return arbitrariesByProperty;
+	public Arbitrary<?> getCachedArbitrary(Property property) {
+		return arbitrariesByProperty.get(property);
+	}
+
+	public void putCachedArbitrary(Property property, Arbitrary<?> arbitrary) {
+		arbitrariesByProperty.put(property, arbitrary);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContextBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/MonkeyContextBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.resolver;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.collection.LruCache;
+import com.navercorp.fixturemonkey.api.property.Property;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class MonkeyContextBuilder {
+	private LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
+	private int cacheSize = 1000;
+
+	public MonkeyContextBuilder arbitrariesByProperty(LruCache<Property, Arbitrary<?>> arbitrariesByProperty) {
+		this.arbitrariesByProperty = arbitrariesByProperty;
+		return this;
+	}
+
+	public MonkeyContextBuilder cacheSize(int cacheSize) {
+		this.cacheSize = cacheSize;
+		return this;
+	}
+
+	public MonkeyContext build() {
+		if (arbitrariesByProperty == null) {
+			arbitrariesByProperty = new LruCache<>(cacheSize);
+		}
+
+		return new MonkeyContext(arbitrariesByProperty);
+	}
+}


### PR DESCRIPTION
동일한 LabMonkey에서 생성한 경우 캐싱이 적용이 됩니다.
캐싱은 Property의 타입과 어노테이션을 기준으로 적용합니다.
연산을 적용한 경우 캐싱을 적용하지 않습니다.