### PR TITLE
Refactor how container ObjectProperty generating

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -51,11 +51,16 @@ public final class ArbitraryTraverser {
 		Property property,
 		Map<NodeResolver, ArbitraryContainerInfo> arbitraryContainerInfosByNodeResolver
 	) {
-		ObjectPropertyGenerator objectPropertyGenerator =
-			this.generateOptions.getObjectPropertyGenerator(property);
 		ContainerPropertyGenerator containerPropertyGenerator =
 			this.generateOptions.getContainerPropertyGenerator(property);
 		boolean container = containerPropertyGenerator != null;
+
+		ObjectPropertyGenerator objectPropertyGenerator;
+		if (container) {
+			objectPropertyGenerator = SingleValueObjectPropertyGenerator.INSTANCE;
+		} else {
+			objectPropertyGenerator = this.generateOptions.getObjectPropertyGenerator(property);
+		}
 
 		ObjectProperty objectProperty = objectPropertyGenerator.generate(
 			new ObjectPropertyGeneratorContext(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -34,6 +34,7 @@ import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorConte
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.SingleValueObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -128,11 +129,16 @@ public final class ArbitraryTraverser {
 		for (int sequence = 0; sequence < properties.size(); sequence++) {
 			Property childProperty = properties.get(sequence);
 
-			ObjectPropertyGenerator objectPropertyGenerator =
-				this.generateOptions.getObjectPropertyGenerator(childProperty);
 			ContainerPropertyGenerator containerPropertyGenerator =
 				this.generateOptions.getContainerPropertyGenerator(childProperty);
 			boolean childContainer = containerPropertyGenerator != null;
+
+			ObjectPropertyGenerator objectPropertyGenerator;
+			if (childContainer) {
+				objectPropertyGenerator = SingleValueObjectPropertyGenerator.INSTANCE;
+			} else {
+				objectPropertyGenerator = this.generateOptions.getObjectPropertyGenerator(childProperty);
+			}
 
 			int index = sequence;
 			if (parentArbitraryProperty.getObjectProperty().getProperty() instanceof MapEntryElementProperty) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -72,10 +72,10 @@ public final class ArbitraryTraverser {
 			)
 		);
 
-		ArbitraryContainerInfo containerInfo = arbitraryContainerInfosByNodeResolver.get(IdentityNodeResolver.INSTANCE);
-
 		ContainerProperty containerProperty = null;
 		if (container) {
+			ArbitraryContainerInfo containerInfo =
+				arbitraryContainerInfosByNodeResolver.get(IdentityNodeResolver.INSTANCE);
 			containerProperty = containerPropertyGenerator.generate(
 				new ContainerPropertyGeneratorContext(
 					property,


### PR DESCRIPTION
컨테이너인 경우 필드는 존재하지 않으므로 항상 `SingleValueObjectPropertyGenerator`를 사용하도록 수정합니다.