### PR TITLE
Fix set when fixed as null

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeSetDecomposedValueManipulator.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
+import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.ALWAYS_NULL_INJECT;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.NOT_NULL_INJECT;
 import static com.navercorp.fixturemonkey.api.type.Types.isAssignable;
 
@@ -77,7 +78,7 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 		arbitraryNode.setManipulated(true);
 		arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(NOT_NULL_INJECT));
 		if (value == null) {
-			arbitraryNode.setArbitrary(Arbitraries.just(null));
+			arbitraryNode.setArbitraryProperty(arbitraryProperty.withNullInject(ALWAYS_NULL_INJECT));
 			return;
 		}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -1402,4 +1402,20 @@ class FixtureMonkeyV04Test {
 
 		then(actual).hasSizeLessThanOrEqualTo(2);
 	}
+
+	@Property
+	void setNullFixed() {
+		String expected = "test";
+
+		String actual = SUT.giveMeBuilder(ComplexObject.class)
+			.setNull("object")
+			.fixed()
+			.set("object.str", expected)
+			.sample()
+			.getObject()
+			.getStr();
+
+		then(actual).isEqualTo(expected);
+
+	}
 }


### PR DESCRIPTION
필드를 null로 Fixed 되는 경우에 필드의 하위 필드를 설정할 수 없는 문제를 해결합니다.