### PR TITLE
Remove uniqueProperties

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
@@ -62,9 +62,7 @@ import com.navercorp.fixturemonkey.api.generator.StreamContainerPropertyGenerato
 import com.navercorp.fixturemonkey.api.generator.TupleLikeElementsPropertyGenerator;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.matcher.Matchers;
-import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
-import com.navercorp.fixturemonkey.api.property.MapKeyElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.TupleLikeElementsProperty;
@@ -78,7 +76,6 @@ public final class GenerateOptions {
 		getDefaultObjectPropertyGenerators();
 	public static final List<MatcherOperator<ContainerPropertyGenerator>> DEFAULT_CONTAINER_PROPERTY_GENERATORS =
 		getDefaultContainerPropertyGenerators();
-	public static final List<MatcherOperator<Boolean>> DEFAULT_UNIQUE_PROPERTIES = getDefaultUniqueProperties();
 	public static final ObjectPropertyGenerator DEFAULT_OBJECT_PROPERTY_GENERATOR =
 		DefaultObjectPropertyGenerator.INSTANCE;
 	public static final PropertyNameResolver DEFAULT_PROPERTY_NAME_RESOLVER = PropertyNameResolver.IDENTITY;
@@ -112,7 +109,6 @@ public final class GenerateOptions {
 
 	@SuppressWarnings("rawtypes")
 	private final List<MatcherOperator<FixtureCustomizer>> arbitraryCustomizers;
-	private final List<MatcherOperator<Boolean>> uniqueProperties;
 
 	@SuppressWarnings("rawtypes")
 	public GenerateOptions(
@@ -128,8 +124,7 @@ public final class GenerateOptions {
 		int defaultArbitraryContainerSize, ArbitraryContainerInfo defaultArbitraryContainerInfo,
 		List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators,
 		ArbitraryGenerator defaultArbitraryGenerator,
-		List<MatcherOperator<FixtureCustomizer>> arbitraryCustomizers,
-		List<MatcherOperator<Boolean>> uniqueProperties
+		List<MatcherOperator<FixtureCustomizer>> arbitraryCustomizers
 	) {
 		this.defaultPropertyGenerator = defaultPropertyGenerator;
 		this.objectPropertyGenerators = objectPropertyGenerators;
@@ -145,7 +140,6 @@ public final class GenerateOptions {
 		this.arbitraryGenerators = arbitraryGenerators;
 		this.defaultArbitraryGenerator = defaultArbitraryGenerator;
 		this.arbitraryCustomizers = arbitraryCustomizers;
-		this.uniqueProperties = uniqueProperties;
 	}
 
 	public static GenerateOptionsBuilder builder() {
@@ -258,10 +252,6 @@ public final class GenerateOptions {
 		return arbitraryCustomizers;
 	}
 
-	public List<MatcherOperator<Boolean>> getUniqueProperties() {
-		return uniqueProperties;
-	}
-
 	public GenerateOptionsBuilder toBuilder() {
 		return builder()
 			.defaultPropertyGenerator(defaultPropertyGenerator)
@@ -276,8 +266,7 @@ public final class GenerateOptions {
 			.defaultArbitraryContainerMaxSize(this.defaultArbitraryContainerSize)
 			.defaultArbitraryContainerInfo(this.defaultArbitraryContainerInfo)
 			.arbitraryGenerators(new ArrayList<>(this.arbitraryGenerators))
-			.defaultArbitraryGenerator(this.defaultArbitraryGenerator)
-			.uniqueProperties(new ArrayList<>(this.uniqueProperties));
+			.defaultArbitraryGenerator(this.defaultArbitraryGenerator);
 	}
 	// TODO: equals and hashCode and toString
 
@@ -360,23 +349,6 @@ public final class GenerateOptions {
 			new MatcherOperator<>(
 				property -> property.getClass() == TupleLikeElementsProperty.class,
 				TupleLikeElementsPropertyGenerator.INSTANCE
-			)
-		);
-	}
-
-	private static List<MatcherOperator<Boolean>> getDefaultUniqueProperties() {
-		return Arrays.asList(
-			new MatcherOperator<>(
-				property -> property.getClass() == MapKeyElementProperty.class,
-				true
-			),
-			new MatcherOperator<>(
-				property -> property.getClass() == ElementProperty.class
-					&&
-					Set.class.isAssignableFrom(
-						Types.getActualType(((ElementProperty)property).getContainerProperty().getType())
-					),
-				true
 			)
 		);
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -18,8 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.option;
 
-import static com.navercorp.fixturemonkey.api.option.GenerateOptions.DEFAULT_UNIQUE_PROPERTIES;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -75,8 +73,6 @@ public final class GenerateOptionsBuilder {
 	private List<MatcherOperator<FixtureCustomizer>> arbitraryCustomizers = new ArrayList<>();
 	private final JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
 		DefaultArbitraryGenerator.javaBuilder();
-
-	private List<MatcherOperator<Boolean>> uniqueProperties = new ArrayList<>(DEFAULT_UNIQUE_PROPERTIES);
 
 	GenerateOptionsBuilder() {
 	}
@@ -436,16 +432,6 @@ public final class GenerateOptionsBuilder {
 		);
 	}
 
-	public GenerateOptionsBuilder uniqueProperties(List<MatcherOperator<Boolean>> uniqueProperties) {
-		this.uniqueProperties = uniqueProperties;
-		return this;
-	}
-
-	public GenerateOptionsBuilder insertFirstUniqueProperty(MatcherOperator<Boolean> uniqueProperty) {
-		this.uniqueProperties.add(uniqueProperty);
-		return this;
-	}
-
 	public GenerateOptions build() {
 		ObjectPropertyGenerator defaultObjectPropertyGenerator = defaultIfNull(
 			this.defaultObjectPropertyGenerator,
@@ -483,8 +469,7 @@ public final class GenerateOptionsBuilder {
 			defaultArbitraryContainerInfo,
 			this.arbitraryGenerators,
 			defaultArbitraryGenerator,
-			this.arbitraryCustomizers,
-			this.uniqueProperties
+			this.arbitraryCustomizers
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -398,9 +398,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						| InstantiationException
-						| IllegalAccessException
-						| NoSuchMethodException e) {
+						 | InstantiationException
+						 | IllegalAccessException
+						 | NoSuchMethodException e) {
 					// ignored
 				}
 			}
@@ -465,21 +465,6 @@ public class LabMonkeyBuilder {
 		this.pushAssignableTypeContainerPropertyGenerator(type, containerObjectPropertyGenerator);
 		this.pushContainerIntrospector(containerArbitraryIntrospector);
 		decomposableContainerFactoryMap.put(type, decomposedContainerValueFactory);
-		return this;
-	}
-
-	public LabMonkeyBuilder pushUniqueProperty(MatcherOperator<Boolean> uniqueProperty) {
-		this.generateOptionsBuilder.insertFirstUniqueProperty(uniqueProperty);
-		return this;
-	}
-
-	public LabMonkeyBuilder pushExactTypeUniqueProperty(Class<?> type) {
-		this.generateOptionsBuilder.insertFirstUniqueProperty(MatcherOperator.exactTypeMatchOperator(type, true));
-		return this;
-	}
-
-	public LabMonkeyBuilder pushAssignableTypeUniqueProperty(Class<?> type) {
-		this.generateOptionsBuilder.insertFirstUniqueProperty(MatcherOperator.assignableTypeMatchOperator(type, true));
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -398,9 +398,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						 | InstantiationException
-						 | IllegalAccessException
-						 | NoSuchMethodException e) {
+						| InstantiationException
+						| IllegalAccessException
+						| NoSuchMethodException e) {
 					// ignored
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -73,8 +73,7 @@ public final class ArbitraryResolver {
 			this.traverser.traverse(rootProperty, containerInfoManipulators),
 			generateOptions,
 			monkeyContext,
-			customizers,
-			generateOptions.getUniqueProperties()
+			customizers
 		);
 
 		containerInfoManipulators.stream()

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTree.java
@@ -46,21 +46,18 @@ final class ArbitraryTree {
 	private final MonkeyContext monkeyContext;
 	@SuppressWarnings("rawtypes")
 	private final List<MatcherOperator<? extends FixtureCustomizer>> customizers;
-	private final List<MatcherOperator<Boolean>> uniqueProperties;
 
 	@SuppressWarnings("rawtypes")
 	ArbitraryTree(
 		ArbitraryNode rootNode,
 		GenerateOptions generateOptions,
 		MonkeyContext monkeyContext,
-		List<MatcherOperator<? extends FixtureCustomizer>> customizers,
-		List<MatcherOperator<Boolean>> uniqueProperties
+		List<MatcherOperator<? extends FixtureCustomizer>> customizers
 	) {
 		this.rootNode = rootNode;
 		this.generateOptions = generateOptions;
 		this.monkeyContext = monkeyContext;
 		this.customizers = customizers;
-		this.uniqueProperties = uniqueProperties;
 		MetadataCollector metadataCollector = new MetadataCollector(rootNode);
 		this.metadata = metadataCollector.collect();
 	}
@@ -134,16 +131,6 @@ final class ArbitraryTree {
 			} else {
 				generated = this.generateOptions.getArbitraryGenerator(prop.getObjectProperty().getProperty())
 					.generate(childArbitraryGeneratorContext);
-
-				boolean unique = uniqueProperties.stream()
-					.filter(it -> it.match(node.getProperty()))
-					.findAny()
-					.map(MatcherOperator::getOperator)
-					.orElse(false);
-
-				if (unique) {
-					generated = generated.injectDuplicates(0d);
-				}
 
 				if (node.isNotManipulated() && notCustomized) {
 					monkeyContext.putCachedArbitrary(

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -77,7 +77,6 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpe
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListStringObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
-import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.TwoEnum;
 
 class FixtureMonkeyV04OptionsTest {
 	@Property
@@ -1019,20 +1018,6 @@ class FixtureMonkeyV04OptionsTest {
 			.getStrList();
 
 		then(actual).hasSize(10);
-	}
-
-	@Property
-	void uniqueProperty() {
-		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.pushExactTypeUniqueProperty(TwoEnum.class)
-			.build();
-
-		List<TwoEnum> twoEnums = sut.giveMeBuilder(new TypeReference<List<TwoEnum>>() {
-			})
-			.size("$", 2)
-			.sample();
-
-		then(twoEnums).hasSize(2);
 	}
 
 	@Property


### PR DESCRIPTION
jqwik의 `injectDuplicate`가 unique함을 보장하지 않아서 unique 연산을 제거합니다.
0.4.0 배포 이후에 Arbitrary에 의존하지 않고 Unique한 값을 만들어 내는 구조를 고민해볼 예정입니다.