### PR TITLE
Add support for KPropertyProperty

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -134,6 +135,14 @@ public class Types {
 			}
 
 			return Arrays.asList(rawTypes);
+		}
+
+		if (ParameterizedType.class.isAssignableFrom(type.getClass())) {
+			Type[] actualTypeArguments = ((ParameterizedType)type).getActualTypeArguments();
+
+			return Arrays.stream(actualTypeArguments)
+				.map(Types::generateAnnotatedTypeWithoutAnnotation)
+				.collect(Collectors.toList());
 		}
 
 		throw new UnsupportedOperationException(
@@ -405,14 +414,20 @@ public class Types {
 	}
 
 	public static AnnotatedType getArrayComponentAnnotatedType(AnnotatedType annotatedType) {
-		if (!(annotatedType instanceof AnnotatedArrayType)) {
-			throw new IllegalArgumentException(
-				"given type is not Array type, annotatedType: " + annotatedType
-			);
-		}
-		AnnotatedArrayType annotatedArrayType = (AnnotatedArrayType)annotatedType;
+		if ((annotatedType instanceof AnnotatedArrayType)) {
+			AnnotatedArrayType annotatedArrayType = (AnnotatedArrayType)annotatedType;
 
-		return annotatedArrayType.getAnnotatedGenericComponentType();
+			return annotatedArrayType.getAnnotatedGenericComponentType();
+		}
+
+		Class<?> type = Types.getActualType(annotatedType.getType());
+		if (type.isArray()) {
+			return generateAnnotatedTypeWithoutAnnotation(type.getComponentType());
+		}
+
+		throw new IllegalArgumentException(
+			"given type is not Array type, annotatedType: " + annotatedType
+		);
 	}
 
 	public static Class<?> getArrayComponentType(AnnotatedType annotatedType) {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
@@ -23,6 +23,8 @@ import org.apiguardian.api.API
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Type
 import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
 
 @API(since = "0.4.0", status = API.Status.EXPERIMENTAL)
 data class KPropertyProperty(
@@ -38,7 +40,14 @@ data class KPropertyProperty(
 
     override fun getAnnotations(): List<Annotation> = this.annotatedType.annotations.toList()
 
-    override fun getValue(obj: Any): Any? = this.kProperty.getter.call(obj)
+    override fun getValue(obj: Any): Any? =
+        if (this.kProperty.isAccessible) {
+            this.kProperty.getter.call(obj)
+        } else {
+            val javaField = this.kProperty.javaField!!
+            javaField.isAccessible = true
+            javaField.get(obj)
+        }
 
     override fun isNullable(): Boolean = this.kProperty.returnType.isMarkedNullable
 }

--- a/fixture-monkey-kotlin/src/test/java/com/navercorp/fixturemonkey/kotlin/spec/JavaObject.java
+++ b/fixture-monkey-kotlin/src/test/java/com/navercorp/fixturemonkey/kotlin/spec/JavaObject.java
@@ -18,17 +18,28 @@
 
 package com.navercorp.fixturemonkey.kotlin.spec;
 
+import java.util.Map;
+
 public class JavaObject {
 	private String value;
+	private Map<String, String> map;
 
 	public JavaObject() {
+	}
+
+	public String getValue() {
+		return value;
 	}
 
 	public void setValue(String value) {
 		this.value = value;
 	}
 
-	public String getValue() {
-		return value;
+	public Map<String, String> getMap() {
+		return map;
+	}
+
+	public void setMap(Map<String, String> map) {
+		this.map = map;
 	}
 }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyV04JavaTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyV04JavaTest.kt
@@ -1,0 +1,33 @@
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.LabMonkey
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
+import com.navercorp.fixturemonkey.kotlin.spec.JavaObject
+import net.jqwik.api.Property
+import org.assertj.core.api.BDDAssertions.then
+import org.assertj.core.api.BDDAssertions.thenNoException
+
+class FixtureMonkeyV04JavaTest {
+    private val sut: LabMonkey = LabMonkey.labMonkeyBuilder()
+        .plugin(KotlinPlugin())
+        .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+        .build()
+
+    @Property
+    fun sampleJavaObject() {
+        // when
+        val actual = sut.giveMeOne<JavaObject>()
+
+        then(actual).isNotNull
+    }
+
+    @Property
+    fun fixedJavaObject() {
+        thenNoException()
+            .isThrownBy {
+                sut.giveMeBuilder<JavaObject>()
+                    .fixed()
+                    .sample()
+            }
+    }
+}

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTest.kt
@@ -20,10 +20,8 @@ package com.navercorp.fixturemonkey.kotlin.test
 
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.LabMonkey
-import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
-import com.navercorp.fixturemonkey.kotlin.spec.JavaObject
 import net.jqwik.api.Property
 import org.assertj.core.api.BDDAssertions.then
 import org.assertj.core.api.BDDAssertions.thenNoException
@@ -80,17 +78,5 @@ class PrimaryConstructorArbitraryIntrospectorTest {
         val actual = sut.giveMeOne<InterfaceClass>()
 
         then(actual).isNull()
-    }
-
-    @Property
-    fun sampleJavaObject() {
-        val sut: LabMonkey = FixtureMonkey.labMonkeyBuilder()
-            .plugin(KotlinPlugin())
-            .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
-            .build()
-        // when
-        val actual = sut.giveMeOne<JavaObject>()
-
-        then(actual).isNotNull
     }
 }


### PR DESCRIPTION
java와 kotlin 혼용 시 kotlin plugin을 활성화하면 java 객체를 생성 못하는 이슈를 해결합니다.
