### PR TITLE
Upgrade jackson version

### DIFF
--- a/fixture-monkey-jackson/build.gradle
+++ b/fixture-monkey-jackson/build.gradle
@@ -9,9 +9,9 @@ plugins {
 
 dependencies {
     api(project(":fixture-monkey"))
-    api("com.fasterxml.jackson.core:jackson-databind:2.13.3")
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.3")
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3")
+    api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2')
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4")
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")


### PR DESCRIPTION
0.4.2 배포하려다가 취약점 있던 게 기억나서 배포를 잠시 미루고 내일 하려고합니다.
큰 이슈는 없겠지만 호환성 문제가 있을 수 있어 테스트를 진행하고 배포하려고 합니다.

0.4.2에서 사용하던 jackson 2.13.3이 DoS에 취약하다고 합니다.
https://security.snyk.io/package/maven/com.fasterxml.jackson.core:jackson-databind/2.13.3

