### PR TITLE
Remove supporting @JsonSubTypes, @JsonTypeInfo

### DIFF
--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
@@ -18,25 +18,19 @@
 
 package com.navercorp.fixturemonkey.jackson.plugin;
 
-import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
-import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
-import com.navercorp.fixturemonkey.jackson.generator.ElementJsonSubTypesObjectPropertyGenerator;
-import com.navercorp.fixturemonkey.jackson.generator.PropertyJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.property.JacksonPropertyNameResolver;
 
@@ -84,18 +78,5 @@ public final class JacksonPlugin implements Plugin {
 				.objectIntrospector(it -> new JacksonArbitraryIntrospector(objectMapper))
 				.defaultPropertyNameResolver(new JacksonPropertyNameResolver());
 		}
-		optionsBuilder
-			.insertFirstArbitraryObjectPropertyGenerator(
-				property -> getJacksonAnnotation(property, JsonSubTypes.class) != null,
-				PropertyJsonSubTypesObjectPropertyGenerator.INSTANCE
-			)
-			.insertFirstArbitraryObjectPropertyGenerator(
-				property -> property instanceof ElementProperty
-					&& getJacksonAnnotation(
-					((ElementProperty)property).getContainerProperty(),
-					JsonSubTypes.class
-				) != null,
-				ElementJsonSubTypesObjectPropertyGenerator.INSTANCE
-			);
 	}
 }

--- a/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04JacksonTest.java
+++ b/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04JacksonTest.java
@@ -9,16 +9,11 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.List;
 
 import net.jqwik.api.Property;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import lombok.Value;
 
@@ -33,31 +28,6 @@ class FixtureMonkeyV04JacksonTest {
 	@Property
 	void jsonFormat() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonFormatSpec.class));
-	}
-
-	@Property
-	void jsonTypeInfo() {
-		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdNameSpec.class));
-	}
-
-	@Property
-	void jsonTypeListInfo() {
-		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListSpec.class));
-	}
-
-	@Property
-	void jsonTypeInfoWithIdClass() {
-		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdClassSpec.class));
-	}
-
-	@Property
-	void jsonTypeWithoutAnnotations() {
-		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsSpec.class));
-	}
-
-	@Property
-	void jsonTypeListWithoutAnnotations() {
-		thenNoException().isThrownBy(() -> SUT.giveMeBuilder(TypeWithAnnotationsListSpec.class));
 	}
 
 	@Value
@@ -85,86 +55,6 @@ class FixtureMonkeyV04JacksonTest {
 
 		@JsonFormat(pattern = "yyyy MM dd HH:mm:ssZ")
 		OffsetDateTime offsetDateTime;
-	}
-
-	@Value
-	public static class JsonTypeInfoIdNameSpec {
-		@JsonTypeInfo(use = Id.NAME)
-		@JsonSubTypes({
-			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
-			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
-		})
-		Type type;
-	}
-
-	@Value
-	public static class JsonTypeInfoIdClassSpec {
-		@JsonTypeInfo(use = Id.CLASS)
-		@JsonSubTypes(
-			{
-				@JsonSubTypes.Type(
-					value = TypeA.class,
-					name = "com.navercorp.fixturemonkey.test.FixtureMonkeyV04Test$TypeA"
-				),
-				@JsonSubTypes.Type(
-					value = TypeB.class,
-					name = "com.navercorp.fixturemonkey.test.FixtureMonkeyV04Test$TypeB"
-				)
-			}
-		)
-		Type type;
-	}
-
-	@Value
-	public static class TypeWithAnnotationsSpec {
-		TypeWithAnnotations type;
-	}
-
-	@Value
-	public static class TypeWithAnnotationsListSpec {
-		List<TypeWithAnnotations> types;
-	}
-
-	@Value
-	public static class JsonTypeInfoListSpec {
-		@JsonTypeInfo(use = Id.NAME)
-		@JsonSubTypes({
-			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
-			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
-		})
-		List<Type> types;
-	}
-
-	public interface Type {
-	}
-
-	@Value
-	public static class TypeA implements Type {
-		String value;
-	}
-
-	@Value
-	@JsonTypeName("typeB")
-	public static class TypeB implements Type {
-		int value;
-	}
-
-	@JsonTypeInfo(use = Id.NAME)
-	@JsonSubTypes({
-		@JsonSubTypes.Type(value = TypeAWithAnnotations.class, name = "TypeAWithAnnotations"),
-		@JsonSubTypes.Type(value = TypeBWithAnnotations.class, name = "TypeBWithAnnotations")
-	})
-	public interface TypeWithAnnotations {
-	}
-
-	@Value
-	public static class TypeAWithAnnotations implements TypeWithAnnotations {
-		String value;
-	}
-
-	@Value
-	public static class TypeBWithAnnotations implements TypeWithAnnotations {
-		int value;
 	}
 
 	public enum JsonEnum {


### PR DESCRIPTION
타입을 생성할 때 하위 타입 중 하나를 jackson이 아닌 introspector로 생성을 할경우 이슈가 생겨 revert 합니다.

0.4.3에서 객체 생성 방식 변경하면서 같이 지원하는 게 좋을 것 같습니다.