### PR TITLE
Enhance DefaultContainerPropertyGenerator with no generics container

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultContainerPropertyGenerator.java
@@ -27,25 +27,24 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class DefaultContainerPropertyGenerator implements ContainerPropertyGenerator {
 	public static final DefaultContainerPropertyGenerator INSTANCE =
 		new DefaultContainerPropertyGenerator();
+	private static final TypeReference<String> DEFAULT_ELEMENT_TYPE = new TypeReference<String>() {
+	};
 
 	@Override
 	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 
 		List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
-		if (elementTypes.size() != 1) {
-			throw new IllegalArgumentException(
-				"Container elementsTypes must be have 1 generics type for element. "
-					+ "propertyType: " + property.getType()
-					+ ", elementTypes: " + elementTypes
-			);
-		}
+		AnnotatedType elementType = elementTypes.isEmpty()
+			? DEFAULT_ELEMENT_TYPE.getAnnotatedType()
+			: elementTypes.get(0);
 
 		ArbitraryContainerInfo containerInfo = context.getContainerInfo();
 		if (containerInfo == null) {
@@ -55,7 +54,6 @@ public final class DefaultContainerPropertyGenerator implements ContainerPropert
 		}
 
 		int size = containerInfo.getRandomSize();
-		AnnotatedType elementType = elementTypes.get(0);
 		List<Property> childProperties = new ArrayList<>();
 		for (int sequence = 0; sequence < size; sequence++) {
 			Integer elementIndex = sequence;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultSingleContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultSingleContainerPropertyGenerator.java
@@ -27,28 +27,33 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.api.type.Types;
 
-/**
- * Deprecated. use DefaultSingleContainerPropertyGenerator instead.
- */
-@API(since = "0.4.0", status = Status.DEPRECATED)
-public final class DefaultContainerPropertyGenerator implements ContainerPropertyGenerator {
-	public static final DefaultContainerPropertyGenerator INSTANCE =
-		new DefaultContainerPropertyGenerator();
+@API(since = "0.4.3", status = Status.EXPERIMENTAL)
+public final class DefaultSingleContainerPropertyGenerator implements ContainerPropertyGenerator {
+	public static final DefaultSingleContainerPropertyGenerator INSTANCE =
+		new DefaultSingleContainerPropertyGenerator();
+	private static final TypeReference<String> DEFAULT_ELEMENT_TYPE = new TypeReference<String>() {
+	};
 
 	@Override
 	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 
 		List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
-		if (elementTypes.size() != 1) {
+		if (elementTypes.size() > 1) {
 			throw new IllegalArgumentException(
-				"Container elementsTypes must be have 1 generics type for element. "
+				"Container elementsTypes support 1 generics type. "
+					+ "You should be custom ContainerPropertyGenerator for N generics container type. "
 					+ "propertyType: " + property.getType()
 					+ ", elementTypes: " + elementTypes
 			);
 		}
+
+		AnnotatedType elementType = elementTypes.isEmpty()
+			? DEFAULT_ELEMENT_TYPE.getAnnotatedType()
+			: elementTypes.get(0);
 
 		ArbitraryContainerInfo containerInfo = context.getContainerInfo();
 		if (containerInfo == null) {
@@ -58,7 +63,6 @@ public final class DefaultContainerPropertyGenerator implements ContainerPropert
 		}
 
 		int size = containerInfo.getRandomSize();
-		AnnotatedType elementType = elementTypes.get(0);
 		List<Property> childProperties = new ArrayList<>();
 		for (int sequence = 0; sequence < size; sequence++) {
 			Integer elementIndex = sequence;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
@@ -46,8 +46,8 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArrayContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.DefaultContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.DefaultSingleContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.EntryContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.MapContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.MapEntryElementContainerPropertyGenerator;
@@ -285,7 +285,6 @@ public final class GenerateOptions {
 			.arbitraryGenerators(new ArrayList<>(this.arbitraryGenerators))
 			.defaultArbitraryGenerator(this.defaultArbitraryGenerator);
 	}
-	// TODO: equals and hashCode and toString
 
 	private static List<MatcherOperator<ObjectPropertyGenerator>> getDefaultObjectPropertyGenerators(
 	) {
@@ -347,11 +346,11 @@ public final class GenerateOptions {
 			),
 			MatcherOperator.assignableTypeMatchOperator(
 				Iterable.class,
-				DefaultContainerPropertyGenerator.INSTANCE
+				DefaultSingleContainerPropertyGenerator.INSTANCE
 			),
 			MatcherOperator.assignableTypeMatchOperator(
 				Iterator.class,
-				DefaultContainerPropertyGenerator.INSTANCE
+				DefaultSingleContainerPropertyGenerator.INSTANCE
 			),
 			MatcherOperator.assignableTypeMatchOperator(Map.class, MapContainerPropertyGenerator.INSTANCE),
 			MatcherOperator.assignableTypeMatchOperator(Entry.class, EntryContainerPropertyGenerator.INSTANCE),

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -59,6 +59,7 @@ import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.ListIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -74,6 +75,8 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpe
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.RegisterGroup;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.SimpleObjectChild;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ComplexObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.CustomContainer;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.CustomContainerFieldObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.Interface;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.InterfaceFieldObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.InterfaceImplementation;
@@ -1074,5 +1077,28 @@ class FixtureMonkeyV04OptionsTest {
 			.getValues();
 
 		then(values).isNull();
+	}
+
+	@Property
+	void defaultContainerElementDefaultTypeString() {
+		// when
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.pushExactTypeArbitraryIntrospector(
+				CustomContainer.class,
+				context -> new ArbitraryIntrospectorResult(
+					new ListIntrospector().introspect(context).getValue()
+						.map(it -> {
+							CustomContainer result = new CustomContainer();
+							result.addAll((List<String>)it);
+							return result;
+						})
+				)
+			)
+			.build();
+
+		CustomContainerFieldObject actual = sut.giveMeOne(CustomContainerFieldObject.class);
+
+		then(actual).isNotNull();
+		then(actual.getValue()).isNotNull();
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -34,6 +34,7 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
@@ -159,5 +160,13 @@ class FixtureMonkeyV04TestSpecs {
 		ONE,
 		TWO,
 		THREE
+	}
+
+	public static class CustomContainer extends ArrayList<String> {
+	}
+
+	@Data
+	public static class CustomContainerFieldObject {
+		CustomContainer value;
 	}
 }


### PR DESCRIPTION
Generics 가 직접 노출되지 않은 컨테이너 타입의 Property 생성을 디폴트 타입(String)으로 정의되도록 지원합니다.