### PR TITLE
Fix not resolved properly

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
@@ -235,8 +235,8 @@ public class OldArbitraryBuilderImpl<T> implements ArbitraryBuilder<T> {
 				buildTree,
 				false,
 				(PropertyNameResolver)property ->
-					this.generatorMap.getOrDefault(
-							tree.getClazz(),
+					buildArbitraryBuilder.generatorMap.getOrDefault(
+							Types.getActualType(property.getType()),
 							buildArbitraryBuilder.generator
 						)
 						.resolveFieldName(((FieldProperty)property).getField())


### PR DESCRIPTION
0.3 Fixture Monkey 인스턴스를 통해 생성하는 경우 `putGenerator`를 통해 ArbitraryGenerator를 변경하면 ArbitraryGenerator에 해당하는 propertyNameResolver가 적용안되는 문제를 해결합니다. 