### PR TITLE
Fix Kotlin properties with parent private property

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositeProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositeProperty.java
@@ -89,6 +89,12 @@ public final class CompositeProperty implements Property {
 	}
 
 	@Override
+	@Nullable
+	public Boolean isNullable() {
+		return this.primaryProperty.isNullable();
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/KotlinPropertyGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/KotlinPropertyGenerator.kt
@@ -34,11 +34,11 @@ import java.lang.reflect.AnnotatedType
 
 @API(since = "0.4.0", status = API.Status.EXPERIMENTAL)
 class KotlinPropertyGenerator : PropertyGenerator {
-    private val OBJECT_CHILD_PROPERTIES_CACHE = LruCache<Class<*>, List<Property>> (2000)
+    private val objectChildPropertiesCache = LruCache<Class<*>, List<Property>> (2000)
     override fun generateRootProperty(annotatedType: AnnotatedType): Property = RootProperty(annotatedType)
 
     override fun generateObjectChildProperties(annotatedType: AnnotatedType): List<Property> =
-        OBJECT_CHILD_PROPERTIES_CACHE.computeIfAbsent(Types.getActualType(annotatedType.type)) {
+        objectChildPropertiesCache.computeIfAbsent(Types.getActualType(annotatedType.type)) {
             val javaProperties = PropertyCache.getProperties(annotatedType)
                 .filter { it.name != null }
                 .associateBy { it.name!! }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensionsTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensionsTest.kt
@@ -258,9 +258,9 @@ class FixtureMonkeyExtensionsTest {
 
         then(actual).isNotNull
     }
-
-    data class IntegerStringWrapperClass(
-        val intValue: Int,
-        val stringValue: String,
-    )
 }
+
+data class IntegerStringWrapperClass(
+    val intValue: Int,
+    val stringValue: String,
+)

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyV04KotlinJacksonTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyV04KotlinJacksonTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.LabMonkey
+import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin
+import net.jqwik.api.Example
+import org.assertj.core.api.BDDAssertions.then
+import java.util.UUID
+
+class FixtureMonkeyV04Test {
+    private val sut: LabMonkey = LabMonkey.labMonkeyBuilder()
+        .plugin(KotlinPlugin())
+        .plugin(JacksonPlugin())
+        .build()
+
+    @Example
+    fun setParentPrivateValue() {
+        val actual = this.sut.giveMeBuilder<SampleKotlin>()
+            .set("id", "id")
+            .sample()
+
+        then(actual.getId()).isEqualTo("id")
+    }
+}
+
+data class SampleKotlin(
+    val intValue: Int,
+    val stringValue: String,
+) : Parent()
+
+abstract class Parent {
+    private var id: String = UUID.randomUUID().toString()
+
+    fun getId(): String {
+        return id
+    }
+}


### PR DESCRIPTION
Kotlin reflection 의 memberProperties 는 상위 부모의 private 속성 값을 property 로 가져오지 못합니다.
KotlinPlugin 상위 부모의 private 속성값이 누락되어 값 제어가 되지 않습니다.
이에 따라 KotlinPlugin 의 properties 를 구할 때 java properties 와 조합한 결과를 반환합니다.