### PR TITLE
Fix generating enum set or map

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SetContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SetContainerPropertyGenerator.java
@@ -60,7 +60,7 @@ public final class SetContainerPropertyGenerator implements ContainerPropertyGen
 			if (actualElementType.isEnum()) {
 				int enumSize = EnumSet.allOf((Class<? extends Enum>)actualElementType).size();
 				containerInfo = new ArbitraryContainerInfo(
-					containerInfo.getElementMinSize(),
+					Math.min(containerInfo.getElementMinSize(), enumSize),
 					Math.min(containerInfo.getElementMaxSize(), enumSize),
 					false
 				);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -83,6 +84,7 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.InterfaceImple
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListStringObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.NullableObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.TwoEnum;
 
 class FixtureMonkeyV04OptionsTest {
 	@Property
@@ -1161,5 +1163,41 @@ class FixtureMonkeyV04OptionsTest {
 			.getValues();
 
 		then(actual).hasSize(2);
+	}
+
+	@Property
+	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMaxSize() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultArbitraryContainerMaxSize(5)
+			.build();
+
+		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
+		});
+
+		then(values).hasSizeLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMinSize() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(3, 5, false))
+			.build();
+
+		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
+		});
+
+		then(values).hasSizeLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void sampleEnumSetWithEnumSizeIsLessThanContainerInfoMinSize() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(3, 5, false))
+			.build();
+
+		Set<TwoEnum> values = sut.giveMeOne(new TypeReference<Set<TwoEnum>>() {
+		});
+
+		then(values).hasSizeLessThanOrEqualTo(2);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Property;
+import net.jqwik.api.TooManyFilterMissesException;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.ArbitraryBuilders;
@@ -1473,5 +1474,33 @@ class FixtureMonkeyV04Test {
 			.sample();
 
 		then(actual).hasSize(200);
+	}
+
+	@Property
+	void sampleEnumMap() {
+		Map<TwoEnum, String> values = SUT.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
+		});
+
+		then(values).hasSizeLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void sizeEnumSetGreaterThanEnumSizeThrows() {
+		thenThrownBy(
+			() -> SUT.giveMeBuilder(new TypeReference<Set<TwoEnum>>() {
+				})
+				.size("$", 3)
+				.sample()
+		).isExactlyInstanceOf(TooManyFilterMissesException.class);
+	}
+
+	@Property
+	void sizeEnumMapGreaterThanEnumSizeThrows() {
+		thenThrownBy(
+			() -> SUT.giveMeBuilder(new TypeReference<Map<TwoEnum, String>>() {
+				})
+				.size("$", 3)
+				.sample()
+		).isExactlyInstanceOf(TooManyFilterMissesException.class);
 	}
 }


### PR DESCRIPTION
## Features
EnumMap or EnumSet size which generated by FixtureMonkey  would not exceed enum size if no `size` manipulation


## Issue
https://github.com/naver/fixture-monkey/issues/487