### PR TITLE
Split static analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,41 +1,13 @@
-name: Gradle check
+name: Run build and test
 
 on:
-  push:
-    branches: [ main, '[0-9]*.[0-9]*.x' ]
-  pull_request:
-    branches: [ main, '[0-9]*.[0-9]*.x' ]
-  workflow_dispatch:
+  on:
+    workflow_run:
+      workflows: [ "Run Static analysis" ]
+      types:
+        - completed
 
 jobs:
-  static-analysis:
-    name: Static analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 8
-      - name: Execute check without tests
-        uses: gradle/gradle-build-action@v2.2.1
-        with:
-          arguments: check -x test
-
-      - name: Publish SpotBugs report
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
-        if: always()
-        with:
-          name: SpotBugs Report
-          path: '**/build/reports/spotbugs/main.xml'
-
-      - name: Publish Checkstyle report
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
-        if: always()
-        with:
-          name: Checkstyle Report
-          path: '**/build/reports/checkstyle/*.xml'
   test:
     name: Testing on JDK ${{ matrix.java }}
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,37 @@
+name: Run Static analysis
+
+on:
+  push:
+    branches: [ main, '[0-9]*.[0-9]*.x' ]
+  pull_request_target:
+    branches: [ main, '[0-9]*.[0-9]*.x' ]
+
+jobs:
+  static-analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Execute check without tests
+        uses: gradle/gradle-build-action@v2.2.1
+        with:
+          arguments: check -x test
+
+      - name: Publish SpotBugs report
+        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        if: always()
+        with:
+          name: SpotBugs Report
+          path: '**/build/reports/spotbugs/main.xml'
+
+      - name: Publish Checkstyle report
+        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+        if: always()
+        with:
+          name: Checkstyle Report
+          path: '**/build/reports/checkstyle/*.xml'


### PR DESCRIPTION
## Summary
정적 분석을 별도 깃헙 액션으로 분리합니다.

## Description
fork한 경우 정적 분석을 했을 때 권한으로 인해 다음과 같은 문제가 생깁니다.

`pull_request_target`로 변경해서 메인 브랜치에서 정적 분석을 하도록 수정합니다.
보안 이슈가 있을 수 있으므로 별도 깃헙 액션으로 분리합니다.
https://github.com/naver/fixture-monkey/actions/runs/3504428117/jobs/5876093774
