### PR TITLE
Fix innerSpec manipulations not generate entry

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -161,12 +161,6 @@ public final class InnerSpec {
 		consumer.accept(innerSpec);
 		arbitraryManipulators.addAll(innerSpec.arbitraryManipulators);
 		containerInfoManipulators.addAll(innerSpec.containerInfoManipulators);
-		this.containerInfoManipulators.add(
-			new ContainerInfoManipulator(
-				this.treePathResolver,
-				new ArbitraryContainerInfo(this.entrySize + this.min, this.entrySize + this.max, true)
-			)
-		);
 		return this;
 	}
 
@@ -216,12 +210,6 @@ public final class InnerSpec {
 	public InnerSpec entry(Consumer<InnerSpec> consumer, @Nullable Object value) {
 		entrySize++;
 
-		this.containerInfoManipulators.add(
-			new ContainerInfoManipulator(
-				this.treePathResolver,
-				new ArbitraryContainerInfo(this.entrySize + this.min, this.entrySize + this.max, true)
-			)
-		);
 		arbitraryManipulators.add(
 			new ArbitraryManipulator(
 				new CompositeNodeResolver(

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -168,7 +168,9 @@ class InnerSpecTest {
 	void sizeInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m -> m.value(v -> v.size(10)))
+			.setInner("listValueMap", m -> m
+				.size(1)
+				.value(v -> v.size(10)))
 			.sample();
 
 		List<Integer> sizeList = actual.getListValueMap().values().stream()
@@ -180,8 +182,9 @@ class InnerSpecTest {
 	void listElementInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m ->
-				m.value(v -> {
+			.setInner("listValueMap", m -> m
+				.size(1)
+				.value(v -> {
 					v.size(1);
 					v.listElement(0, "test");
 				})
@@ -197,8 +200,9 @@ class InnerSpecTest {
 	void propertyInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("objectValueMap", m ->
-				m.value(v -> v.property("str", "test"))
+			.setInner("objectValueMap", m -> m
+				.size(1)
+				.value(v -> v.property("str", "test"))
 			)
 			.sample();
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -168,8 +168,7 @@ class InnerSpecTest {
 	void sizeInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m -> m
-				.size(1)
+			.setInner("listValueMap", m -> m.size(1)
 				.value(v -> v.size(10)))
 			.sample();
 
@@ -182,8 +181,7 @@ class InnerSpecTest {
 	void listElementInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m -> m
-				.size(1)
+			.setInner("listValueMap", m -> m.size(1)
 				.value(v -> {
 					v.size(1);
 					v.listElement(0, "test");
@@ -200,8 +198,7 @@ class InnerSpecTest {
 	void propertyInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("objectValueMap", m -> m
-				.size(1)
+			.setInner("objectValueMap", m -> m.size(1)
 				.value(v -> v.property("str", "test"))
 			)
 			.sample();
@@ -257,8 +254,8 @@ class InnerSpecTest {
 	void entryValueSetNull() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m ->
-				m.entry("key", null)
+			.setInner("strMap", m -> m.size(1)
+				.entry("key", null)
 			)
 			.sample();
 


### PR DESCRIPTION
## Summary
InnerSpec의 연산들이 entry를 생성하지 않도록 수정합니다.

##  Description
InnerSpec에서 다른 연산과 다르게 다음 연산들은 entry를 만들고 있습니다.
`InnerSpec value(Consumer<InnerSpec> consumer) `,
`InnerSpec entry(Consumer<InnerSpec> consumer, @Nullable Object value)`

다른 연산들과 일관성을 맞춰 entry를 생성하지 않도록 수정합니다.
