### PR TITLE
Add a simple option for generating concrete class with interface

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/InterfaceObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/InterfaceObjectPropertyGenerator.java
@@ -1,0 +1,92 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import static com.navercorp.fixturemonkey.api.type.Types.generateAnnotatedTypeWithoutAnnotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.random.Randoms;
+
+@API(since = "0.4.7", status = Status.EXPERIMENTAL)
+public final class InterfaceObjectPropertyGenerator<T> implements ObjectPropertyGenerator {
+	private final List<Class<? extends T>> implementations;
+
+	public InterfaceObjectPropertyGenerator(List<Class<? extends T>> implementations) {
+		this.implementations = implementations;
+	}
+
+	@Override
+	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
+		Property interfaceProperty = context.getProperty();
+		Class<?> implementation = implementations.get(Randoms.nextInt(implementations.size()));
+
+		Property property = new Property() {
+			@Override
+			public Type getType() {
+				return implementation;
+			}
+
+			@Override
+			public AnnotatedType getAnnotatedType() {
+				return generateAnnotatedTypeWithoutAnnotation(implementation);
+			}
+
+			@Nullable
+			@Override
+			public String getName() {
+				return interfaceProperty.getName();
+			}
+
+			@Override
+			public List<Annotation> getAnnotations() {
+				return interfaceProperty.getAnnotations();
+			}
+
+			@Nullable
+			@Override
+			public Object getValue(Object obj) {
+				return interfaceProperty.getValue(obj);
+			}
+		};
+
+		double nullInject = context.getGenerateOptions().getNullInjectGenerator(property)
+			.generate(context);
+
+		List<Property> childProperties = context.getGenerateOptions().getPropertyGenerator(property)
+			.generateObjectChildProperties(property.getAnnotatedType());
+
+		return new ObjectProperty(
+			property,
+			context.getPropertyNameResolver(),
+			nullInject,
+			context.getElementIndex(),
+			childProperties
+		);
+	}
+}

--- a/fixture-monkey-mockito/src/test/java/com/navercorp/fixturemonkey/mockito/plugin/MockitoPluginTest.java
+++ b/fixture-monkey-mockito/src/test/java/com/navercorp/fixturemonkey/mockito/plugin/MockitoPluginTest.java
@@ -21,24 +21,33 @@ package com.navercorp.fixturemonkey.mockito.plugin;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Example;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.mockito.plugin.MockitoPluginTestSpecs.AbstractSample;
+import com.navercorp.fixturemonkey.mockito.plugin.MockitoPluginTestSpecs.AbstractSampleImpl;
+import com.navercorp.fixturemonkey.mockito.plugin.MockitoPluginTestSpecs.InterfaceSample;
+import com.navercorp.fixturemonkey.mockito.plugin.MockitoPluginTestSpecs.InterfaceSampleImpl;
 import com.navercorp.fixturemonkey.mockito.plugin.MockitoPluginTestSpecs.Sample;
 
 class MockitoPluginTest {
-	private final LabMonkey sut = FixtureMonkey.labMonkeyBuilder()
-		.plugin(new MockitoPlugin())
-		.defaultNullInjectGenerator(context -> 0)
-		.build();
-
 	@Example
 	void mockitoAbstractInterface() {
-		Sample actual = this.sut.giveMeOne(Sample.class);
-		then(actual.getAbstractSample()).isNotNull();
+		// given
+		LabMonkey sut = FixtureMonkey.labMonkeyBuilder()
+			.plugin(new MockitoPlugin())
+			.defaultNullInjectGenerator(context -> 0)
+			.build();
 
+		// when
+		Sample actual = sut.giveMeOne(Sample.class);
+
+		// then
+		then(actual.getAbstractSample()).isNotNull();
 		String mockStringValue = Arbitraries.strings().sample();
 		when(actual.getAbstractSample().getValue()).thenReturn(mockStringValue);
 		then(actual.getAbstractSample().getValue()).isEqualTo(mockStringValue);
@@ -46,7 +55,32 @@ class MockitoPluginTest {
 		then(actual.getInterfaceSample()).isNotNull();
 
 		int mockIntValue = Arbitraries.integers().sample();
-		when(actual.getInterfaceSample().getInt()).thenReturn(mockIntValue);
-		then(actual.getInterfaceSample().getInt()).isEqualTo(mockIntValue);
+		when(actual.getInterfaceSample().getValue()).thenReturn(mockIntValue);
+		then(actual.getInterfaceSample().getValue()).isEqualTo(mockIntValue);
+	}
+
+	@Example
+	void interfaceImplementsAndMockitoInterface() {
+		LabMonkey sut = FixtureMonkey.labMonkeyBuilder()
+			.plugin(new MockitoPlugin())
+			.interfaceImplements(InterfaceSample.class, Collections.singletonList(InterfaceSampleImpl.class))
+			.build();
+
+		int actual = sut.giveMeOne(Sample.class).getInterfaceSample().getValue();
+
+		then(actual).isNotNull();
+	}
+
+	@Example
+	void interfaceImplementsAndMockitoAbstract() {
+		LabMonkey sut = FixtureMonkey.labMonkeyBuilder()
+			.plugin(new MockitoPlugin())
+			.defaultNullInjectGenerator(context -> 0)
+			.interfaceImplements(AbstractSample.class, Collections.singletonList(AbstractSampleImpl.class))
+			.build();
+
+		String actual = sut.giveMeOne(Sample.class).getAbstractSample().getValue();
+
+		then(actual).isNotNull();
 	}
 }

--- a/fixture-monkey-mockito/src/test/java/com/navercorp/fixturemonkey/mockito/plugin/MockitoPluginTestSpecs.java
+++ b/fixture-monkey-mockito/src/test/java/com/navercorp/fixturemonkey/mockito/plugin/MockitoPluginTestSpecs.java
@@ -27,15 +27,32 @@ class MockitoPluginTestSpecs {
 		private InterfaceSample interfaceSample;
 	}
 
-	abstract static class AbstractSample {
+	public abstract static class AbstractSample {
 		private String value;
 
 		public String getValue() {
 			return this.value;
 		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	static class AbstractSampleImpl extends AbstractSample {
 	}
 
 	interface InterfaceSample {
-		int getInt();
+		int getValue();
+	}
+
+	@Data
+	public static class InterfaceSampleImpl implements InterfaceSample {
+		private int value;
+
+		@Override
+		public int getValue() {
+			return this.value;
+		}
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -400,9 +400,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						 | InstantiationException
-						 | IllegalAccessException
-						 | NoSuchMethodException e) {
+						| InstantiationException
+						| IllegalAccessException
+						| NoSuchMethodException e) {
 					// ignored
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -400,9 +400,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						| InstantiationException
-						| IllegalAccessException
-						| NoSuchMethodException e) {
+						 | InstantiationException
+						 | IllegalAccessException
+						 | NoSuchMethodException e) {
 					// ignored
 				}
 			}
@@ -490,9 +490,9 @@ public class LabMonkeyBuilder {
 		return this;
 	}
 
-	public LabMonkeyBuilder interfaceImplements(
-		Class<?> interfaceClass,
-		Class<?>... implementations
+	public <T> LabMonkeyBuilder interfaceImplements(
+		Class<T> interfaceClass,
+		List<Class<? extends T>> implementations
 	) {
 		this.pushObjectPropertyGenerator(
 			new MatcherOperator<>(
@@ -540,10 +540,10 @@ public class LabMonkeyBuilder {
 		return this;
 	}
 
-	private ObjectPropertyGenerator getImplementationObjectProperty(Class<?>[] implementations) {
+	private <T> ObjectPropertyGenerator getImplementationObjectProperty(List<Class<? extends T>> implementations) {
 		return context -> {
 			Property interfaceProperty = context.getProperty();
-			Class<?> implementation = implementations[Randoms.nextInt(implementations.length)];
+			Class<?> implementation = implementations.get(Randoms.nextInt(implementations.size()));
 
 			Property property = new Property() {
 				@Override

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -503,7 +503,44 @@ public class LabMonkeyBuilder {
 		return this;
 	}
 
-	private static ObjectPropertyGenerator getImplementationObjectProperty(Class<?>[] implementations) {
+	public LabMonkey build() {
+		manipulateOptionsBuilder.additionalDecomposedContainerValueFactory(
+			obj -> {
+				Class<?> actualType = obj.getClass();
+				for (
+					Entry<Class<?>, DecomposedContainerValueFactory> entry :
+					this.decomposableContainerFactoryMap.entrySet()
+				) {
+					Class<?> type = entry.getKey();
+					DecomposableContainerValue decomposedValue = entry.getValue().from(obj);
+
+					if (actualType.isAssignableFrom(type)) {
+						return decomposedValue;
+					}
+				}
+				return this.defaultDecomposedContainerValueFactory.from(obj);
+			}
+		);
+
+		GenerateOptions generateOptions = generateOptionsBuilder.build();
+		ArbitraryTraverser traverser = new ArbitraryTraverser(generateOptions);
+
+		return new LabMonkey(
+			generateOptions,
+			manipulateOptionsBuilder,
+			traverser,
+			manipulatorOptimizer,
+			this.arbitraryValidator,
+			MonkeyContext.builder().build()
+		);
+	}
+
+	public LabMonkeyBuilder useExpressionStrictMode() {
+		this.manipulateOptionsBuilder.expressionStrictMode(true);
+		return this;
+	}
+
+	private ObjectPropertyGenerator getImplementationObjectProperty(Class<?>[] implementations) {
 		return context -> {
 			Property interfaceProperty = context.getProperty();
 			Class<?> implementation = implementations[Randoms.nextInt(implementations.length)];
@@ -548,42 +585,5 @@ public class LabMonkeyBuilder {
 				Collections.emptyList()
 			);
 		};
-	}
-
-	public LabMonkey build() {
-		manipulateOptionsBuilder.additionalDecomposedContainerValueFactory(
-			obj -> {
-				Class<?> actualType = obj.getClass();
-				for (
-					Entry<Class<?>, DecomposedContainerValueFactory> entry :
-					this.decomposableContainerFactoryMap.entrySet()
-				) {
-					Class<?> type = entry.getKey();
-					DecomposableContainerValue decomposedValue = entry.getValue().from(obj);
-
-					if (actualType.isAssignableFrom(type)) {
-						return decomposedValue;
-					}
-				}
-				return this.defaultDecomposedContainerValueFactory.from(obj);
-			}
-		);
-
-		GenerateOptions generateOptions = generateOptionsBuilder.build();
-		ArbitraryTraverser traverser = new ArbitraryTraverser(generateOptions);
-
-		return new LabMonkey(
-			generateOptions,
-			manipulateOptionsBuilder,
-			traverser,
-			manipulatorOptimizer,
-			this.arbitraryValidator,
-			MonkeyContext.builder().build()
-		);
-	}
-
-	public LabMonkeyBuilder useExpressionStrictMode() {
-		this.manipulateOptionsBuilder.expressionStrictMode(true);
-		return this;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -401,9 +401,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						 | InstantiationException
-						 | IllegalAccessException
-						 | NoSuchMethodException e) {
+						| InstantiationException
+						| IllegalAccessException
+						| NoSuchMethodException e) {
 					// ignored
 				}
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/LabMonkeyBuilder.java
@@ -55,6 +55,7 @@ import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.GenerateOptions;
@@ -400,9 +401,9 @@ public class LabMonkeyBuilder {
 					};
 					this.register(actualType, registerArbitraryBuilder);
 				} catch (InvocationTargetException
-						| InstantiationException
-						| IllegalAccessException
-						| NoSuchMethodException e) {
+						 | InstantiationException
+						 | IllegalAccessException
+						 | NoSuchMethodException e) {
 					// ignored
 				}
 			}
@@ -491,16 +492,29 @@ public class LabMonkeyBuilder {
 	}
 
 	public <T> LabMonkeyBuilder interfaceImplements(
-		Class<T> interfaceClass,
+		Matcher matcher,
 		List<Class<? extends T>> implementations
 	) {
 		this.pushObjectPropertyGenerator(
 			new MatcherOperator<>(
-				new AssignableTypeMatcher(interfaceClass),
+				matcher,
 				getImplementationObjectProperty(implementations)
 			)
 		);
 		return this;
+	}
+
+	public <T> LabMonkeyBuilder interfaceImplements(
+		Class<T> interfaceClass,
+		List<Class<? extends T>> implementations
+	) {
+		if (!interfaceClass.isInterface()) {
+			throw new IllegalArgumentException(
+				"interfaceImplements option first parameter should be interface. " + interfaceClass.getTypeName()
+			);
+		}
+
+		return this.interfaceImplements(new ExactTypeMatcher(interfaceClass), implementations);
 	}
 
 	public LabMonkey build() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -201,4 +201,9 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 			return "fixed";
 		}
 	}
+
+	@Data
+	public static class GenericGetFixedValue<T extends GetFixedValue>{
+		T value;
+	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -202,8 +202,19 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 		}
 	}
 
+	public interface GetFixedValueChild extends GetFixedValue {
+	}
+
+	public static class GetIntegerFixedValueChild implements GetFixedValueChild {
+
+		@Override
+		public Object get() {
+			return 2;
+		}
+	}
+
 	@Data
-	public static class GenericGetFixedValue<T extends GetFixedValue>{
+	public static class GenericGetFixedValue<T extends GetFixedValue> {
 		T value;
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsAdditionalTestSpecs.java
@@ -183,4 +183,22 @@ class FixtureMonkeyV04OptionsAdditionalTestSpecs {
 			}
 		}
 	}
+
+	public interface GetFixedValue {
+		Object get();
+	}
+
+	public static class GetIntegerFixedValue implements GetFixedValue {
+		@Override
+		public Object get() {
+			return 1;
+		}
+	}
+
+	public static class GetStringFixedValue implements GetFixedValue {
+		@Override
+		public Object get() {
+			return "fixed";
+		}
+	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -70,6 +70,7 @@ import com.navercorp.fixturemonkey.resolver.IdentityNodeResolver;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.BuilderInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuildMethodInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuilderMethodInteger;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GenericGetFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetIntegerFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetStringFixedValue;
@@ -1206,12 +1207,55 @@ class FixtureMonkeyV04OptionsTest {
 
 	@Property
 	void interfaceImplements() {
+		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
+		implementations.add(GetIntegerFixedValue.class);
+		implementations.add(GetStringFixedValue.class);
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
-			.interfaceImplements(GetFixedValue.class, GetIntegerFixedValue.class, GetStringFixedValue.class)
+			.interfaceImplements(GetFixedValue.class, implementations)
 			.build();
 
 		Object actual = sut.giveMeOne(GetFixedValue.class).get();
 
 		then(actual).isIn(1, "fixed");
+	}
+
+	@Property
+	void sampleGenericInterface() {
+		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
+		implementations.add(GetIntegerFixedValue.class);
+		implementations.add(GetStringFixedValue.class);
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.interfaceImplements(GetFixedValue.class, implementations)
+			.build();
+
+		Object actual = sut.giveMeBuilder(new TypeReference<GenericGetFixedValue<GetFixedValue>>() {
+			})
+			.setNotNull("value")
+			.sample()
+			.getValue()
+			.get();
+
+		then(actual).isIn(1, "fixed");
+	}
+
+	@Property
+	void sampleGenericInterfaceReturnsDiff() {
+		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
+		implementations.add(GetIntegerFixedValue.class);
+		implementations.add(GetStringFixedValue.class);
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.interfaceImplements(GetFixedValue.class, implementations)
+			.build();
+
+		Set<Class<? extends GetFixedValue>> actual = sut.giveMeBuilder(
+				new TypeReference<GenericGetFixedValue<GetFixedValue>>() {
+				})
+			.setNotNull("value")
+			.sampleList(100)
+			.stream()
+			.map(it -> it.getValue().getClass())
+			.collect(Collectors.toSet());
+
+		then(actual).hasSize(2);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -72,7 +72,9 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpe
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuilderMethodInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GenericGetFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetFixedValue;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetFixedValueChild;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetIntegerFixedValue;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetIntegerFixedValueChild;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetStringFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.Pair;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairContainerPropertyGenerator;
@@ -1207,13 +1209,16 @@ class FixtureMonkeyV04OptionsTest {
 
 	@Property
 	void interfaceImplements() {
+		// given
 		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
 		implementations.add(GetIntegerFixedValue.class);
 		implementations.add(GetStringFixedValue.class);
+
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.interfaceImplements(GetFixedValue.class, implementations)
 			.build();
 
+		// when
 		Object actual = sut.giveMeOne(GetFixedValue.class).get();
 
 		then(actual).isIn(1, "fixed");
@@ -1221,13 +1226,16 @@ class FixtureMonkeyV04OptionsTest {
 
 	@Property
 	void sampleGenericInterface() {
+		// given
 		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
 		implementations.add(GetIntegerFixedValue.class);
 		implementations.add(GetStringFixedValue.class);
+
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.interfaceImplements(GetFixedValue.class, implementations)
 			.build();
 
+		// when
 		Object actual = sut.giveMeBuilder(new TypeReference<GenericGetFixedValue<GetFixedValue>>() {
 			})
 			.setNotNull("value")
@@ -1240,13 +1248,16 @@ class FixtureMonkeyV04OptionsTest {
 
 	@Property
 	void sampleGenericInterfaceReturnsDiff() {
+		// given
 		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
 		implementations.add(GetIntegerFixedValue.class);
 		implementations.add(GetStringFixedValue.class);
+
 		LabMonkey sut = LabMonkey.labMonkeyBuilder()
 			.interfaceImplements(GetFixedValue.class, implementations)
 			.build();
 
+		// when
 		Set<Class<? extends GetFixedValue>> actual = sut.giveMeBuilder(
 				new TypeReference<GenericGetFixedValue<GetFixedValue>>() {
 				})
@@ -1257,5 +1268,28 @@ class FixtureMonkeyV04OptionsTest {
 			.collect(Collectors.toSet());
 
 		then(actual).hasSize(2);
+	}
+
+	@Property
+	void sampleInterfaceChildWhenOptionHasHierarchy() {
+		// given
+		List<Class<? extends GetFixedValue>> implementations = new ArrayList<>();
+		implementations.add(GetIntegerFixedValue.class);
+		implementations.add(GetStringFixedValue.class);
+
+		List<Class<? extends GetFixedValueChild>> childImplementations = new ArrayList<>();
+		childImplementations.add(GetIntegerFixedValueChild.class);
+
+		// when
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.interfaceImplements(GetFixedValueChild.class, childImplementations)
+			.interfaceImplements(GetFixedValue.class, implementations)
+			.build();
+
+		Object actual = sut.giveMeOne(new TypeReference<GetFixedValueChild>() {
+			})
+			.get();
+
+		then(actual).isEqualTo(2);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04OptionsTest.java
@@ -70,6 +70,9 @@ import com.navercorp.fixturemonkey.resolver.IdentityNodeResolver;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.BuilderInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuildMethodInteger;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.CustomBuilderMethodInteger;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetFixedValue;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetIntegerFixedValue;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.GetStringFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.Pair;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04OptionsAdditionalTestSpecs.PairIntrospector;
@@ -1199,5 +1202,16 @@ class FixtureMonkeyV04OptionsTest {
 		});
 
 		then(values).hasSizeLessThanOrEqualTo(2);
+	}
+
+	@Property
+	void interfaceImplements() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.interfaceImplements(GetFixedValue.class, GetIntegerFixedValue.class, GetStringFixedValue.class)
+			.build();
+
+		Object actual = sut.giveMeOne(GetFixedValue.class).get();
+
+		then(actual).isIn(1, "fixed");
 	}
 }


### PR DESCRIPTION
## Summary
인터페이스가 반환할 구현체를 명시하는 옵션을 추가합니다.

## How Has This Been Tested?
`interfaceImplements`

resolves #348 