### PR TITLE
Replace junit logger to slf4j logger

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -27,9 +27,9 @@ import java.util.Map;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Builders;
@@ -76,9 +76,7 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 							writeMethod.invoke(b, v);
 						}
 					} catch (IllegalAccessException | InvocationTargetException e) {
-						log.warn(e,
-							() -> "set bean property is failed. name: " + writeMethod.getName() + " value: " + v
-						);
+						log.warn("set bean property is failed. name: {} value: {}", writeMethod.getName(), v, e);
 					}
 					return b;
 				});

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -24,9 +24,9 @@ import java.util.Map;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Builders;
@@ -72,9 +72,7 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 						field.set(object, value);
 					}
 				} catch (IllegalAccessException e) {
-					log.warn(e,
-						() -> "set field by reflection is failed. field: " + resolvePropertyName + " value: " + value
-					);
+					log.warn("set field by reflection is failed. field: {} value: {}", resolvePropertyName, value, e);
 				}
 				return object;
 			});

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BeanArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/BeanArbitraryGenerator.java
@@ -28,9 +28,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -87,9 +87,7 @@ public final class BeanArbitraryGenerator extends AbstractArbitraryGenerator
 							writeMethod.invoke(b, v);
 						}
 					} catch (IllegalAccessException | InvocationTargetException e) {
-						log.warn(e,
-							() -> "set bean property is failed. field: " + fieldName + " value: " + v
-						);
+						log.warn("set bean property is failed. field: {} value: {}", fieldName, v, e);
 					}
 					return b;
 				});
@@ -121,7 +119,7 @@ public final class BeanArbitraryGenerator extends AbstractArbitraryGenerator
 				result.put(descriptor.getName(), descriptor);
 			}
 		} catch (IntrospectionException e) {
-			log.warn(e, () -> "Introspect bean property is failed. type: " + clazz);
+			log.warn("Introspect bean property is failed. type: {}", clazz, e);
 		}
 
 		return result;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/FieldReflectionArbitraryGenerator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/generator/FieldReflectionArbitraryGenerator.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -98,9 +98,7 @@ public final class FieldReflectionArbitraryGenerator extends AbstractArbitraryGe
 						field.set(object, value);
 					}
 				} catch (IllegalAccessException e) {
-					log.warn(e,
-						() -> "set field by reflection is failed. field: " + fieldName + " value: " + value
-					);
+					log.warn("set field by reflection is failed. field: {} value: {}", fieldName, value, e);
 				}
 				return object;
 			});


### PR DESCRIPTION
## Summary

Related to #35

Remove usage of `org.junit.platform.commons.logging.Logger`