### PR TITLE
Remove checkStyle, spotBugs report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,19 +23,6 @@ jobs:
         with:
           arguments: check -x test
 
-      - name: Publish SpotBugs report
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
-        if: always()
-        with:
-          name: SpotBugs Report
-          path: '**/build/reports/spotbugs/main.xml'
-
-      - name: Publish Checkstyle report
-        uses: jwgmeligmeyling/checkstyle-github-action@v1.2
-        if: always()
-        with:
-          name: Checkstyle Report
-          path: '**/build/reports/checkstyle/*.xml'
   test:
     name: Testing on JDK ${{ matrix.java }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
외부 contributor는 action을 정상적으로 실행할 수 없으므로 제거합니다.

report만 action에서 확인할 수 없고 검증은 `Execute check without tests` 에서 실행합니다.