### PR TITLE
Add generating a circular-reference object

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -95,6 +95,7 @@ public final class ArbitraryTraverser {
 		return this.traverse(
 			arbitraryProperty,
 			new TraverseContext(
+				arbitraryProperty,
 				new ArrayList<>(),
 				containerInfoManipulators
 			)
@@ -134,6 +135,10 @@ public final class ArbitraryTraverser {
 
 		for (int sequence = 0; sequence < properties.size(); sequence++) {
 			Property childProperty = properties.get(sequence);
+
+			if (context.isTraversed(childProperty)) {
+				continue;
+			}
 
 			ContainerPropertyGenerator containerPropertyGenerator =
 				this.generateOptions.getContainerPropertyGenerator(childProperty);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/TraverseContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/TraverseContext.java
@@ -25,18 +25,26 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 final class TraverseContext {
+	private final ArbitraryProperty rootArbitraryProperty;
 	private final List<ArbitraryProperty> arbitraryProperties;
 	private final List<ContainerInfoManipulator> containerInfoManipulators;
 
 	public TraverseContext(
+		ArbitraryProperty rootArbitraryProperty,
 		List<ArbitraryProperty> arbitraryProperties,
 		List<ContainerInfoManipulator> containerInfoManipulators
 	) {
+		this.rootArbitraryProperty = rootArbitraryProperty;
 		this.arbitraryProperties = arbitraryProperties;
 		this.containerInfoManipulators = containerInfoManipulators;
+	}
+
+	public ArbitraryProperty getRootArbitraryProperty() {
+		return rootArbitraryProperty;
 	}
 
 	public List<ArbitraryProperty> getArbitraryProperties() {
@@ -52,6 +60,12 @@ final class TraverseContext {
 	) {
 		List<ArbitraryProperty> arbitraryProperties = new ArrayList<>(this.arbitraryProperties);
 		arbitraryProperties.add(arbitraryProperty);
-		return new TraverseContext(arbitraryProperties, containerInfoManipulators);
+		return new TraverseContext(rootArbitraryProperty, arbitraryProperties, containerInfoManipulators);
+	}
+
+	public boolean isTraversed(Property property) {
+		return property.equals(rootArbitraryProperty.getObjectProperty().getProperty())
+			|| arbitraryProperties.stream()
+			.anyMatch(it -> property.equals(it.getObjectProperty().getProperty()));
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04Test.java
@@ -68,6 +68,9 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.InterfaceField
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.InterfaceImplementation;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.ListStringObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.NullableObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.RecursiveLeftObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SelfRecursiveListObject;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SelfRecursiveObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.SimpleObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.StaticFieldObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyV04TestSpecs.StringPair;
@@ -1550,5 +1553,43 @@ class FixtureMonkeyV04Test {
 			.getStr();
 
 		then(actual).isEqualTo(expected);
+	}
+
+	@Property
+	void sampleSelfRecursiveObject() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultNotNull(true)
+			.build();
+
+		SelfRecursiveObject actual = sut.giveMeOne(SelfRecursiveObject.class);
+
+		then(actual.getValue()).isNotNull();
+		then(actual.getRecursive()).isNotNull();
+		then(actual.getRecursive().getValue()).isNotNull();
+	}
+
+	@Property
+	void sampleSelfRecursiveList() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultNotNull(true)
+			.build();
+
+		SelfRecursiveListObject actual = sut.giveMeOne(SelfRecursiveListObject.class);
+
+		then(actual.getValue()).isNotNull();
+		then(actual.getRecursives()).isNotNull();
+	}
+
+	@Property
+	void sampleRecursiveObject() {
+		LabMonkey sut = LabMonkey.labMonkeyBuilder()
+			.defaultNotNull(true)
+			.build();
+
+		RecursiveLeftObject actual = sut.giveMeOne(RecursiveLeftObject.class);
+
+		then(actual.getValue()).isNotNull();
+		then(actual.getRecursive()).isNotNull();
+		then(actual.getRecursive().getValue()).isNotNull();
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyV04TestSpecs.java
@@ -174,4 +174,32 @@ class FixtureMonkeyV04TestSpecs {
 	public static class CustomContainerFieldObject {
 		CustomContainer value;
 	}
+
+	@Data
+	public static class SelfRecursiveObject {
+		String value;
+
+		SelfRecursiveObject recursive;
+	}
+
+	@Data
+	public static class SelfRecursiveListObject {
+		String value;
+
+		List<SelfRecursiveObject> recursives;
+	}
+
+	@Data
+	public static class RecursiveLeftObject {
+		String value;
+
+		RecursiveRightObject recursive;
+	}
+
+	@Data
+	public static class RecursiveRightObject {
+		int value;
+
+		RecursiveLeftObject recursive;
+	}
 }


### PR DESCRIPTION
## Summary
Add generating a circular-reference object

## (Optional): Description
순환참조일 경우 1-depth까지만 생성합니다.

For example,
```java
class A {
   B b;
}

class B {
   A a;
}

A a = fixture.giveMeOne(A.class);
```
```json
{
    "b" :  {
        "a" : {
            "b" : null
        }
   }
}

```

## How Has This Been Tested?
* `sampleSelfRecursiveObject`
* `sampleSelfRecursiveList`
* `sampleRecursiveObject`

resolves #495
