### PR TITLE
Refactor InnerSpec

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -24,11 +24,9 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
 import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
-import com.navercorp.fixturemonkey.customizer.InnerSpec
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Field
 import java.lang.reflect.ParameterizedType
-import java.util.function.Consumer
 import java.util.function.Predicate
 import java.util.function.Supplier
 import kotlin.reflect.KFunction1
@@ -394,30 +392,6 @@ fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
     max: Int
 ): ArbitraryBuilder<T> =
     this.maxSize(expressionGenerator, max)
-
-fun <T> ArbitraryBuilder<T>.setInnerExp(
-    property: KProperty1<T, Any?>,
-    consumer: Consumer<InnerSpec>
-): ArbitraryBuilder<T> =
-    this.setInner(PropertyExpressionGenerator(KotlinProperty(property)), consumer)
-
-fun <T> ArbitraryBuilder<T>.setInnerExpGetter(
-    property: KFunction1<T, Any?>,
-    consumer: Consumer<InnerSpec>
-): ArbitraryBuilder<T> =
-    this.setInner(PropertyExpressionGenerator(KotlinGetterProperty(property)), consumer)
-
-fun <T> ArbitraryBuilder<T>.setInnerExp(
-    expressionGenerator: ExpressionGenerator,
-    consumer: Consumer<InnerSpec>
-): ArbitraryBuilder<T> =
-    this.setInner(expressionGenerator, consumer)
-
-fun <T> ArbitraryBuilder<T>.setInnerExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    consumer: Consumer<InnerSpec>
-): ArbitraryBuilder<T> =
-    this.setInner(expressionGenerator, consumer)
 
 fun <T> ArbitraryBuilder<T>.setLazyExp(
     property: KProperty1<T, Any?>,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -59,9 +59,7 @@ public interface ArbitraryBuilder<T> {
 
 	ArbitraryBuilder<T> set(@Nullable Object value);
 
-	ArbitraryBuilder<T> setInner(String expression, Consumer<InnerSpec> specSupplier);
-
-	ArbitraryBuilder<T> setInner(ExpressionGenerator expressionGenerator, Consumer<InnerSpec> specSupplier);
+	ArbitraryBuilder<T> setInner(InnerSpec innerSpec);
 
 	ArbitraryBuilder<T> setLazy(String expression, Supplier<?> supplier);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
@@ -7,7 +7,6 @@ import javax.annotation.Nullable;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
-import com.navercorp.fixturemonkey.resolver.ApplyNodeCountManipulator;
 import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
 import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
 import com.navercorp.fixturemonkey.resolver.NodeManipulator;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey;
 
 import java.util.function.Supplier;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
@@ -22,6 +22,9 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
@@ -32,6 +35,7 @@ import com.navercorp.fixturemonkey.resolver.NodeNullityManipulator;
 import com.navercorp.fixturemonkey.resolver.NodeSetDecomposedValueManipulator;
 import com.navercorp.fixturemonkey.resolver.NodeSetLazyManipulator;
 
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class MonkeyManipulatorFactory {
 	private final ArbitraryTraverser traverser;
 	private final ManipulateOptions manipulateOptions;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
@@ -1,0 +1,55 @@
+package com.navercorp.fixturemonkey;
+
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.resolver.ApplyNodeCountManipulator;
+import com.navercorp.fixturemonkey.resolver.ArbitraryTraverser;
+import com.navercorp.fixturemonkey.resolver.ManipulateOptions;
+import com.navercorp.fixturemonkey.resolver.NodeManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeNullityManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeSetDecomposedValueManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeSetLazyManipulator;
+
+public final class MonkeyManipulatorFactory {
+	private final ArbitraryTraverser traverser;
+	private final ManipulateOptions manipulateOptions;
+
+	public MonkeyManipulatorFactory(ArbitraryTraverser traverser, ManipulateOptions manipulateOptions) {
+		this.traverser = traverser;
+		this.manipulateOptions = manipulateOptions;
+	}
+
+	public NodeManipulator convertToNodeManipulator(@Nullable Object value) {
+		if (value instanceof Arbitrary) {
+			return new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				LazyArbitrary.lazy(() -> ((Arbitrary<?>)value).sample()),
+				false
+			);
+		} else if (value instanceof Supplier) {
+			return new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				LazyArbitrary.lazy((Supplier<?>)value),
+				false
+			);
+		} else if (value instanceof LazyArbitrary) {
+			return new NodeSetLazyManipulator<>(
+				traverser,
+				manipulateOptions,
+				(LazyArbitrary<?>)value,
+				false
+			);
+		} else if (value == null) {
+			return new NodeNullityManipulator(true);
+		} else {
+			return new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value, false);
+		}
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/MonkeyManipulatorFactory.java
@@ -46,7 +46,9 @@ public final class MonkeyManipulatorFactory {
 	}
 
 	public NodeManipulator convertToNodeManipulator(@Nullable Object value) {
-		if (value instanceof Arbitrary) {
+		if (value == null) {
+			return new NodeNullityManipulator(true);
+		} else if (value instanceof Arbitrary) {
 			return new NodeSetLazyManipulator<>(
 				traverser,
 				manipulateOptions,
@@ -67,8 +69,6 @@ public final class MonkeyManipulatorFactory {
 				(LazyArbitrary<?>)value,
 				false
 			);
-		} else if (value == null) {
-			return new NodeNullityManipulator(true);
 		} else {
 			return new NodeSetDecomposedValueManipulator<>(traverser, manipulateOptions, value, false);
 		}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/OldArbitraryBuilderImpl.java
@@ -272,12 +272,7 @@ public class OldArbitraryBuilderImpl<T> implements ArbitraryBuilder<T> {
 	}
 
 	@Override
-	public ArbitraryBuilder<T> setInner(String expression, Consumer<InnerSpec> specSupplier) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public ArbitraryBuilder<T> setInner(ExpressionGenerator expressionGenerator, Consumer<InnerSpec> specSupplier) {
+	public ArbitraryBuilder<T> setInner(InnerSpec innerSpec) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -630,7 +630,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 		return new ManipulatorInfo(arbitraryManipulators, containerInfoManipulators);
 	}
 
-	public static class ManipulatorInfo {
+	private static class ManipulatorInfo {
 		private final List<ArbitraryManipulator> arbitraryManipulators;
 		private final List<ContainerInfoManipulator> containerInfoManipulators;
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -247,6 +247,7 @@ public final class DefaultArbitraryBuilder<T> extends OldArbitraryBuilderImpl<T>
 			.collect(toList());
 
 		this.context.addManipulators(arbitraryManipulators);
+		this.context.addManipulators(manipulatorSet.getPostConditionManipulators());
 		this.context.addContainerInfoManipulators(manipulatorSet.getContainerInfoManipulators());
 		return this;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
@@ -1,0 +1,46 @@
+package com.navercorp.fixturemonkey.builder;
+
+import java.util.List;
+
+import com.navercorp.fixturemonkey.MonkeyManipulatorFactory;
+import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
+import com.navercorp.fixturemonkey.resolver.ContainerInfoManipulator;
+import com.navercorp.fixturemonkey.resolver.NodeResolver;
+
+public class ManipulatorSet {
+	private final List<NodeResolverObjectHolder> nodeResolverObjectHolders;
+	private final List<ContainerInfoManipulator> containerInfoManipulators;
+
+	public ManipulatorSet(
+		List<NodeResolverObjectHolder> nodeResolverObjectHolders,
+		List<ContainerInfoManipulator> containerInfoManipulators
+	) {
+		this.nodeResolverObjectHolders = nodeResolverObjectHolders;
+		this.containerInfoManipulators = containerInfoManipulators;
+	}
+
+	public List<NodeResolverObjectHolder> getNodeResolverObjectHolders() {
+		return nodeResolverObjectHolders;
+	}
+
+	public List<ContainerInfoManipulator> getContainerInfoManipulators() {
+		return containerInfoManipulators;
+	}
+
+	public static class NodeResolverObjectHolder {
+		private final NodeResolver nodeResolver;
+		private final Object value;
+
+		public NodeResolverObjectHolder(NodeResolver nodeResolver, Object value) {
+			this.nodeResolver = nodeResolver;
+			this.value = value;
+		}
+
+		public ArbitraryManipulator convert(MonkeyManipulatorFactory monkeyManipulatorFactory) {
+			return new ArbitraryManipulator(
+				nodeResolver,
+				monkeyManipulatorFactory.convertToNodeManipulator(this.value)
+			);
+		}
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
@@ -1,13 +1,35 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.builder;
 
 import java.util.List;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.MonkeyManipulatorFactory;
 import com.navercorp.fixturemonkey.resolver.ArbitraryManipulator;
 import com.navercorp.fixturemonkey.resolver.ContainerInfoManipulator;
 import com.navercorp.fixturemonkey.resolver.NodeResolver;
 
-public class ManipulatorSet {
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
+public final class ManipulatorSet {
 	private final List<NodeResolverObjectHolder> nodeResolverObjectHolders;
 	private final List<ContainerInfoManipulator> containerInfoManipulators;
 	private final List<ArbitraryManipulator> postConditionManipulators;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ManipulatorSet.java
@@ -10,13 +10,16 @@ import com.navercorp.fixturemonkey.resolver.NodeResolver;
 public class ManipulatorSet {
 	private final List<NodeResolverObjectHolder> nodeResolverObjectHolders;
 	private final List<ContainerInfoManipulator> containerInfoManipulators;
+	private final List<ArbitraryManipulator> postConditionManipulators;
 
 	public ManipulatorSet(
 		List<NodeResolverObjectHolder> nodeResolverObjectHolders,
-		List<ContainerInfoManipulator> containerInfoManipulators
+		List<ContainerInfoManipulator> containerInfoManipulators,
+		List<ArbitraryManipulator> postConditionManipulators
 	) {
 		this.nodeResolverObjectHolders = nodeResolverObjectHolders;
 		this.containerInfoManipulators = containerInfoManipulators;
+		this.postConditionManipulators = postConditionManipulators;
 	}
 
 	public List<NodeResolverObjectHolder> getNodeResolverObjectHolders() {
@@ -25,6 +28,10 @@ public class ManipulatorSet {
 
 	public List<ContainerInfoManipulator> getContainerInfoManipulators() {
 		return containerInfoManipulators;
+	}
+
+	public List<ArbitraryManipulator> getPostConditionManipulators() {
+		return postConditionManipulators;
 	}
 
 	public static class NodeResolverObjectHolder {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -97,7 +97,6 @@ public final class InnerSpec {
 				null
 			)
 		);
-
 		return this;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -397,10 +397,10 @@ public final class InnerSpec {
 		return listElement(NO_OR_ALL_INDEX_INTEGER_VALUE, consumer);
 	}
 
-	public InnerSpec property(String property, @Nullable Object value) {
+	public InnerSpec property(String propertyName, @Nullable Object value) {
 		if (value instanceof InnerSpec) {
 			InnerSpec prefix = new InnerSpec(
-				new DefaultNodeResolver(new PropertyNameNodePredicate(property)),
+				new DefaultNodeResolver(new PropertyNameNodePredicate(propertyName)),
 				UNINITIALIZED_VALUE,
 				null,
 				null
@@ -411,7 +411,7 @@ public final class InnerSpec {
 
 		this.innerSpecs.add(
 			new InnerSpec(
-				new DefaultNodeResolver(new PropertyNameNodePredicate(property)),
+				new DefaultNodeResolver(new PropertyNameNodePredicate(propertyName)),
 				value,
 				null,
 				null
@@ -421,13 +421,13 @@ public final class InnerSpec {
 		return this;
 	}
 
-	public InnerSpec property(String property, Consumer<InnerSpec> consumer) {
+	public InnerSpec property(String propertyName, Consumer<InnerSpec> consumer) {
 		if (consumer == null) {
-			return property(property, (Object)null);
+			return property(propertyName, (Object)null);
 		}
 
 		InnerSpec nextNodeInnerSpec = new InnerSpec(
-			new DefaultNodeResolver(new PropertyNameNodePredicate(property)),
+			new DefaultNodeResolver(new PropertyNameNodePredicate(propertyName)),
 			UNINITIALIZED_VALUE,
 			null,
 			null

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -46,6 +46,7 @@ import com.navercorp.fixturemonkey.resolver.PropertyNameNodePredicate;
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class InnerSpec {
 	private static final Object UNINITIALIZED_VALUE = new Object();
+
 	private final NodeResolver treePathResolver;
 	@Nullable
 	private final Object value;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -636,7 +636,13 @@ class InnerSpecTest {
 	@Property
 	void setPostCondition() {
 		SimpleObject actual = SUT.giveMeBuilder(SimpleObject.class)
-			.setInner(new InnerSpec().property("str", inner -> inner.postCondition(String.class, it -> it.length() > 5)))
+			.setInner(
+				new InnerSpec()
+				.property(
+					"str",
+					inner -> inner.postCondition(String.class, it -> it.length() > 5)
+				)
+			)
 			.sample();
 
 		then(actual.getStr()).hasSizeGreaterThan(5);

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -34,6 +34,8 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.LabMonkey;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
+import com.navercorp.fixturemonkey.customizer.InnerSpec;
+import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.ComplexObject;
 import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.ComplexObjectObject;
 import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.IntegerMapObject;
 import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.MapObject;
@@ -48,7 +50,10 @@ class InnerSpecTest {
 	void key() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).key("key"))
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(1).key("key"))
+			)
 			.sample();
 
 		then(actual.getStrMap().containsKey("key")).isTrue();
@@ -58,7 +63,10 @@ class InnerSpecTest {
 	void value() {
 		// when
 		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).value("value"))
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(1).value("value"))
+			)
 			.sample()
 			.getStrMap();
 
@@ -69,7 +77,10 @@ class InnerSpecTest {
 	void entry() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).entry("key", "value"))
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(1).entry("key", "value"))
+			)
 			.sample();
 
 		then(actual.getStrMap().get("key")).isEqualTo("value");
@@ -80,10 +91,12 @@ class InnerSpecTest {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
-				"strMap",
-				m -> m.minSize(2)
-					.entry("key1", "value1")
-					.entry("key2", "value2")
+				new InnerSpec()
+					.property("strMap",
+						m -> m.minSize(2)
+							.entry("key1", "value1")
+							.entry("key2", "value2")
+					)
 			)
 			.sample();
 
@@ -95,7 +108,10 @@ class InnerSpecTest {
 	void valueNull() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).value(null))
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(1).value(null))
+			)
 			.sample();
 
 		then(actual.getStrMap().containsValue(null)).isTrue();
@@ -106,7 +122,10 @@ class InnerSpecTest {
 	void keyNullThrows() {
 		thenThrownBy(() ->
 			SUT.giveMeBuilder(MapObject.class)
-				.setInner("strMap", m -> m.minSize(1).key(null))
+				.setInner(
+					new InnerSpec()
+						.property("strMap", m -> m.minSize(1).key(null))
+				)
 				.sample()
 		).isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Map key cannot be null.");
@@ -119,7 +138,10 @@ class InnerSpecTest {
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
-			.setInner("mapKeyMap", m -> m.key(k -> k.key("key")))
+			.setInner(
+				new InnerSpec()
+					.property("mapKeyMap", m -> m.key(k -> k.key("key")))
+			)
 			.sample();
 
 		List<String> keyList = actual.getMapKeyMap().keySet().stream()
@@ -134,7 +156,9 @@ class InnerSpecTest {
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
-			.setInner("mapKeyMap", m -> m.key(k -> k.value("value")))
+			.setInner(
+				new InnerSpec().property("mapKeyMap", m -> m.key(k -> k.value("value")))
+			)
 			.sample();
 
 		List<String> keyList = actual.getMapKeyMap().keySet().stream()
@@ -146,7 +170,10 @@ class InnerSpecTest {
 	void keyInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("mapValueMap", m -> m.minSize(1).value(v -> v.minSize(1).key("key")))
+			.setInner(
+				new InnerSpec()
+					.property("mapValueMap", m -> m.minSize(1).value(v -> v.minSize(1).key("key")))
+			)
 			.sample();
 
 		List<String> valueList = actual.getMapValueMap().values().stream()
@@ -158,7 +185,10 @@ class InnerSpecTest {
 	void valueInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("mapValueMap", m -> m.minSize(1).value(v -> v.minSize(1).value("value")))
+			.setInner(
+				new InnerSpec()
+					.property("mapValueMap", m -> m.minSize(1).value(v -> v.minSize(1).value("value")))
+			)
 			.sample();
 
 		List<String> valueList = actual.getMapValueMap().values().stream()
@@ -170,8 +200,11 @@ class InnerSpecTest {
 	void sizeInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m -> m.size(1)
-				.value(v -> v.size(10)))
+			.setInner(
+				new InnerSpec()
+					.property("listValueMap", m -> m.size(1)
+						.value(v -> v.size(10)))
+			)
 			.sample();
 
 		List<Integer> sizeList = actual.getListValueMap().values().stream()
@@ -183,11 +216,13 @@ class InnerSpecTest {
 	void listElementInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("listValueMap", m -> m.size(1)
-				.value(v -> {
-					v.size(1);
-					v.listElement(0, "test");
-				})
+			.setInner(
+				new InnerSpec()
+					.property("listValueMap", m -> m.size(1)
+						.value(v -> {
+							v.size(1);
+							v.listElement(0, "test");
+						}))
 			)
 			.sample();
 
@@ -200,8 +235,11 @@ class InnerSpecTest {
 	void propertyInValue() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("objectValueMap", m -> m.size(1)
-				.value(v -> v.property("str", "test"))
+			.setInner(
+				new InnerSpec()
+					.property("objectValueMap", m -> m.size(1)
+						.value(v -> v.property("str", "test"))
+					)
 			)
 			.sample();
 
@@ -215,8 +253,10 @@ class InnerSpecTest {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
-				"mapValueMap",
-				m -> m.minSize(1).entry("key1", v -> v.minSize(1).entry("key2", "value"))
+				new InnerSpec()
+					.property("mapValueMap",
+						m -> m.minSize(1).entry("key1", v -> v.minSize(1).entry("key2", "value"))
+					)
 			)
 			.sample();
 
@@ -234,11 +274,11 @@ class InnerSpecTest {
 
 		// when
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
-			.setInner("mapKeyMap", m ->
-				m.entry(
-					k -> k.entry("key", "value2"),
-					"value1"
-				)
+			.setInner(
+				new InnerSpec()
+					.property("mapKeyMap",
+						m -> m.entry(k -> k.entry("key", "value2"), "value1")
+					)
 			)
 			.sample();
 
@@ -256,8 +296,11 @@ class InnerSpecTest {
 	void entryValueSetNull() {
 		// when
 		MapObject actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.size(1)
-				.entry("key", null)
+			.setInner(
+				new InnerSpec()
+					.property("strMap",
+						m -> m.size(1).entry("key", null)
+					)
 			)
 			.sample();
 
@@ -268,13 +311,17 @@ class InnerSpecTest {
 	void listElementInListElement() {
 		// when
 		NestedListStringObject actual = SUT.giveMeBuilder(NestedListStringObject.class)
-			.setInner("values", m -> {
-				m.size(1);
-				m.listElement(0, l -> {
-					l.size(1);
-					l.listElement(0, "test");
-				});
-			})
+			.setInner(
+				new InnerSpec()
+					.property("values",
+						m -> {
+							m.size(1);
+							m.listElement(0, l -> {
+								l.size(1);
+								l.listElement(0, "test");
+							});
+						})
+			)
 			.sample();
 
 		then(actual.getValues().get(0).get(0)).isEqualTo("test");
@@ -284,8 +331,11 @@ class InnerSpecTest {
 	void propertyInProperty() {
 		// when
 		ComplexObjectObject actual = SUT.giveMeBuilder(ComplexObjectObject.class)
-			.setInner("value", m ->
-				m.property("value", o -> o.property("str", "test"))
+			.setInner(
+				new InnerSpec()
+					.property("value",
+						m -> m.property("value", o -> o.property("str", "test"))
+					)
 			)
 			.sample();
 
@@ -297,11 +347,13 @@ class InnerSpecTest {
 		// when
 		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
-				"strMap",
-				m -> {
-					m.size(4);
-					m.entry("key", "test");
-				}
+				new InnerSpec()
+					.property("strMap",
+						m -> {
+							m.size(4);
+							m.entry("key", "test");
+						}
+					)
 			)
 			.sample()
 			.getStrMap();
@@ -315,11 +367,13 @@ class InnerSpecTest {
 		// when
 		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
-				"strMap",
-				m -> {
-					m.entry("key", "test");
-					m.size(4);
-				}
+				new InnerSpec()
+					.property("strMap",
+						m -> {
+							m.entry("key", "test");
+							m.size(4);
+						}
+					)
 			)
 			.sample()
 			.getStrMap();
@@ -333,12 +387,14 @@ class InnerSpecTest {
 		// when
 		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
-				"strMap",
-				m -> {
-					m.size(1);
-					m.entry("key", "test");
-					m.size(0);
-				}
+				new InnerSpec()
+					.property("strMap",
+						m -> {
+							m.size(1);
+							m.entry("key", "test");
+							m.size(0);
+						}
+					)
 			)
 			.sample()
 			.getStrMap();
@@ -350,7 +406,12 @@ class InnerSpecTest {
 	void keyLazy() {
 		ArbitraryBuilder<String> variable = SUT.giveMeBuilder(String.class);
 		ArbitraryBuilder<MapObject> builder = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.size(1).keyLazy(variable::sample));
+			.setInner(
+				new InnerSpec()
+					.property("strMap",
+						m -> m.size(1).keyLazy(variable::sample)
+					)
+			);
 		variable.set("key");
 
 		MapObject actual = builder.sample();
@@ -362,7 +423,12 @@ class InnerSpecTest {
 	void valueLazy() {
 		ArbitraryBuilder<String> variable = SUT.giveMeBuilder(String.class);
 		ArbitraryBuilder<MapObject> builder = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).valueLazy(variable::sample));
+			.setInner(
+				new InnerSpec()
+					.property("strMap",
+						m -> m.minSize(1).valueLazy(variable::sample)
+					)
+			);
 		variable.set("value");
 
 		MapObject actual = builder.sample();
@@ -375,7 +441,12 @@ class InnerSpecTest {
 		ArbitraryBuilder<String> keyVariable = SUT.giveMeBuilder(String.class);
 		ArbitraryBuilder<String> valueVariable = SUT.giveMeBuilder(String.class);
 		ArbitraryBuilder<MapObject> builder = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.minSize(1).entryLazy(keyVariable::sample, valueVariable::sample));
+			.setInner(
+				new InnerSpec()
+					.property("strMap",
+						m -> m.minSize(1).entryLazy(keyVariable::sample, valueVariable::sample)
+					)
+			);
 		keyVariable.set("key");
 		valueVariable.set("value");
 
@@ -388,7 +459,12 @@ class InnerSpecTest {
 	void keyLazyNullThrows() {
 		thenThrownBy(() ->
 			SUT.giveMeBuilder(MapObject.class)
-				.setInner("strMap", m -> m.minSize(1).keyLazy(() -> null))
+				.setInner(
+					new InnerSpec()
+						.property("strMap",
+							m -> m.minSize(1).keyLazy(() -> null)
+						)
+				)
 				.sample()
 		).isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Map key cannot be null.");
@@ -397,7 +473,12 @@ class InnerSpecTest {
 	@Property
 	void allKeyLazy() {
 		IntegerMapObject actual = SUT.giveMeBuilder(IntegerMapObject.class)
-			.setInner("integerMap", m -> m.allKeyLazy(() -> Arbitraries.integers().between(0, 100)))
+			.setInner(
+				new InnerSpec()
+					.property("integerMap",
+						m -> m.allKeyLazy(() -> Arbitraries.integers().between(0, 100))
+					)
+			)
 			.sample();
 
 		then(actual.getIntegerMap().keySet()).allMatch(it -> it >= 0 && it <= 100);
@@ -406,7 +487,12 @@ class InnerSpecTest {
 	@Property
 	void allValueLazy() {
 		IntegerMapObject actual = SUT.giveMeBuilder(IntegerMapObject.class)
-			.setInner("integerMap", m -> m.allValueLazy(() -> Arbitraries.integers().between(0, 100)))
+			.setInner(
+				new InnerSpec()
+					.property("integerMap",
+						m -> m.allValueLazy(() -> Arbitraries.integers().between(0, 100))
+					)
+			)
 			.sample();
 
 		then(actual.getIntegerMap().values()).allMatch(it -> it >= 0 && it <= 100);
@@ -415,10 +501,15 @@ class InnerSpecTest {
 	@Property
 	void allEntry() {
 		IntegerMapObject actual = SUT.giveMeBuilder(IntegerMapObject.class)
-			.setInner("integerMap", m -> m.allEntry(
-				() -> Arbitraries.integers().between(0, 100),
-				100
-			))
+			.setInner(
+				new InnerSpec()
+					.property("integerMap",
+						m -> m.allEntry(
+							() -> Arbitraries.integers().between(0, 100),
+							100
+						)
+					)
+			)
 			.sample();
 
 		then(actual.getIntegerMap().keySet()).allMatch(it -> it >= 0 && it <= 100);
@@ -428,10 +519,15 @@ class InnerSpecTest {
 	@Property
 	void allEntryLazy() {
 		IntegerMapObject actual = SUT.giveMeBuilder(IntegerMapObject.class)
-			.setInner("integerMap", m -> m.allEntryLazy(
-				() -> Arbitraries.integers().between(0, 100),
-				() -> Arbitraries.integers().between(0, 100)
-			))
+			.setInner(
+				new InnerSpec()
+					.property("integerMap",
+						m -> m.allEntryLazy(
+							() -> Arbitraries.integers().between(0, 100),
+							() -> Arbitraries.integers().between(0, 100)
+						)
+					)
+			)
 			.sample();
 
 		then(actual.getIntegerMap().keySet()).allMatch(it -> it >= 0 && it <= 100);
@@ -443,9 +539,14 @@ class InnerSpecTest {
 		String expected = "test";
 
 		List<String> actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("objectKeyMap", m -> m.allKey(v ->
-				v.property("str", expected)
-			))
+			.setInner(
+				new InnerSpec()
+					.property("objectKeyMap",
+						m -> m.allKey(v ->
+							v.property("str", expected)
+						)
+					)
+			)
 			.sample()
 			.getObjectKeyMap()
 			.keySet()
@@ -461,7 +562,12 @@ class InnerSpecTest {
 		String expected = "test";
 
 		Collection<String> actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("strMap", m -> m.allValue(expected))
+			.setInner(
+				new InnerSpec()
+					.property("strMap",
+						m -> m.allValue(expected)
+					)
+			)
 			.sample()
 			.getStrMap()
 			.values();
@@ -474,9 +580,14 @@ class InnerSpecTest {
 		String expected = "test";
 
 		List<String> actual = SUT.giveMeBuilder(MapObject.class)
-			.setInner("objectValueMap", m -> m.allValue(v ->
-				v.property("str", expected)
-			))
+			.setInner(
+				new InnerSpec()
+					.property("objectValueMap",
+						m -> m.allValue(v ->
+							v.property("str", expected)
+						)
+					)
+			)
 			.sample()
 			.getObjectValueMap()
 			.values()
@@ -494,7 +605,10 @@ class InnerSpecTest {
 		// when
 		List<String> actual = SUT.giveMeBuilder(new TypeReference<List<String>>() {
 			})
-			.setInner("$", l -> l.allListElement(expected))
+			.setInner(
+				new InnerSpec()
+					.allListElement(expected)
+			)
 			.sample();
 
 		then(actual).allMatch(expected::equals);
@@ -507,12 +621,37 @@ class InnerSpecTest {
 		// when
 		List<String> actual = SUT.giveMeBuilder(new TypeReference<List<List<String>>>() {
 			})
-			.setInner("$", l -> l.allListElement(inner -> inner.allListElement(expected)))
+			.setInner(
+				new InnerSpec()
+					.allListElement(inner -> inner.allListElement(expected))
+			)
 			.sample()
 			.stream()
 			.flatMap(Collection::stream)
 			.collect(Collectors.toList());
 
 		then(actual).allMatch(expected::equals);
+	}
+
+	@Property
+	void inner() {
+		InnerSpec innerSpec = new InnerSpec().property("str", "test");
+
+		SimpleObject actual = SUT.giveMeBuilder(SimpleObject.class)
+			.setInner(new InnerSpec().inner(innerSpec))
+			.sample();
+
+		then(actual.getStr()).isEqualTo("test");
+	}
+
+	@Property
+	void propertyInner() {
+		InnerSpec innerSpec = new InnerSpec().property("str", "test");
+
+		ComplexObject actual = SUT.giveMeBuilder(ComplexObject.class)
+			.setInner(new InnerSpec().property("value", innerSpec))
+			.sample();
+
+		then(actual.getValue().getStr()).isEqualTo("test");
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -634,6 +634,15 @@ class InnerSpecTest {
 	}
 
 	@Property
+	void setPostCondition() {
+		SimpleObject actual = SUT.giveMeBuilder(SimpleObject.class)
+			.setInner(new InnerSpec().property("str", inner -> inner.postCondition(String.class, it -> it.length() > 5)))
+			.sample();
+
+		then(actual.getStr()).hasSizeGreaterThan(5);
+	}
+
+	@Property
 	void inner() {
 		InnerSpec innerSpec = new InnerSpec().property("str", "test");
 


### PR DESCRIPTION
## Summary
Refactors InnerSpec

## (Optional): Description
InnerSpec no longer depends on `ArbitraryTraverser` and `ManipulateOptions`. `MonkeyManipulatorFactory` now has the responsibility to create `NodeManipulator`s.

## How Has This Been Tested?

