### PR TITLE
Add fixture-monkey-jakarta-validation

### DIFF
--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -1,0 +1,122 @@
+import com.github.spotbugs.snom.SpotBugsTask
+
+plugins {
+    id "org.ec4j.editorconfig" version "0.0.3"
+    id "com.github.spotbugs" version "4.7.6"
+    id "jacoco"
+    id "checkstyle"
+}
+
+dependencies {
+    api(project(":fixture-monkey-api"))
+    api("jakarta.validation:jakarta.validation-api:3.0.2")
+    api("net.jqwik:jqwik-web:${JQWIK_VERSION}")
+    api("net.jqwik:jqwik-time:${JQWIK_VERSION}")
+    api("com.github.mifmif:generex:1.0.2")
+
+    testRuntimeOnly(project(":fixture-monkey-engine"))
+    testImplementation(project(":fixture-monkey"))
+    testImplementation("org.hibernate.validator:hibernate-validator:6.2.1.Final")
+    testImplementation("org.glassfish:jakarta.el:3.0.4")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
+    testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
+    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.projectlombok:lombok:1.18.24")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+}
+
+editorconfig {
+    excludes = ["build"]
+}
+
+test {
+    useJUnitPlatform {
+        includeEngines "jqwik"
+    }
+}
+
+check.dependsOn editorconfigCheck
+
+checkstyle {
+    configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
+    configProperties = ["suppressionFile": "${project.rootDir}/tool/naver-checkstyle-suppressions.xml"]
+    toolVersion = "8.45.1"
+    ignoreFailures = false
+    maxErrors = 0
+    maxWarnings = 0
+}
+
+spotbugs {
+    ignoreFailures = false
+    reportLevel = "high"
+    spotbugsTest.enabled = false
+}
+
+tasks.withType(SpotBugsTask) {
+    reports {
+        text.enabled = false
+        xml.enabled = true
+        html.enabled = false
+    }
+}
+
+tasks.register("printSpotbugsMain") {
+    doLast {
+        File mainResult = file("${buildDir}/reports/spotbugs/main.text")
+        if (mainResult.exists()) {
+            mainResult.readLines().forEach {
+                println(it)
+            }
+        }
+    }
+}
+tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
+
+jacoco {
+    toolVersion = "0.8.7"
+    reportsDir = file("${buildDir}/reports/jacoco")
+}
+
+jacocoTestReport {
+    afterEvaluate {
+        classDirectories.setFrom(file("${buildDir}/classes/java/main"))
+    }
+
+    reports {
+        xml.enabled true
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
+        csv.enabled false
+        html.enabled true
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
+}
+
+jacocoTestCoverageVerification {
+    afterEvaluate {
+        classDirectories.setFrom(file("${buildDir}/classes/main"))
+    }
+
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                // minimum = 0.3
+            }
+        }
+    }
+}
+check.dependsOn jacocoTestCoverageVerification
+
+
+jar {
+    manifest {
+        attributes(
+                "Specification-Title": artifactName,
+                "Specification-Version": project.version,
+                "Specification-Vendor": "com.navercorp",
+                "Implementation-Title": artifactName,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": "com.navercorp"
+        )
+    }
+}

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation(project(":fixture-monkey"))
-    testImplementation("org.hibernate.validator:hibernate-validator:6.2.1.Final")
+    testImplementation("org.hibernate.validator:hibernate-validator:8.0.0.Final")
     testImplementation("org.glassfish:jakarta.el:3.0.4")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")

--- a/fixture-monkey-jakarta-validation/gradle.properties
+++ b/fixture-monkey-jakarta-validation/gradle.properties
@@ -1,0 +1,3 @@
+artifactId=fixture-monkey-jakarta-validation
+artifactName=Fixture Monkey Jakarta Validation
+artifactDescription=Fixture Monkey Jakarta Validation supports.

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
@@ -34,7 +34,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.1", status = Status.EXPERIMENTAL)
 public final class JakartaValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
 	public static final Set<Class<? extends Annotation>> JAKARTA_VALIDATION_CONTAINER_ANNOTATIONS;
 

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
@@ -34,7 +34,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 
-@API(since = "0.4.1", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
 	public static final Set<Class<? extends Annotation>> JAKARTA_VALIDATION_CONTAINER_ANNOTATIONS;
 

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
@@ -1,0 +1,85 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.generator;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
+	public static final Set<Class<? extends Annotation>> JAKARTA_VALIDATION_CONTAINER_ANNOTATIONS;
+
+	static {
+		Set<Class<? extends Annotation>> set = new HashSet<>();
+		set.add(Size.class);
+		set.add(NotEmpty.class);
+		JAKARTA_VALIDATION_CONTAINER_ANNOTATIONS = Collections.unmodifiableSet(set);
+	}
+
+	@Override
+	public ArbitraryContainerInfo generate(ContainerPropertyGeneratorContext context) {
+		Integer min = null;
+		Integer max = null;
+		Optional<Size> sizeAnnotation = context.getProperty().getAnnotation(Size.class);
+		if (sizeAnnotation.isPresent()) {
+			Size size = sizeAnnotation.get();
+			min = size.min();
+			if (size.max() != Integer.MAX_VALUE) {    // not initialized for preventing OOM
+				max = size.max();
+			} else {
+				int defaultArbitraryContainerSize = context.getGenerateOptions()
+					.getDefaultArbitraryContainerSize();
+				max = min + defaultArbitraryContainerSize;
+			}
+		}
+
+		if (context.getProperty().getAnnotation(NotEmpty.class).isPresent()) {
+			if (min != null) {
+				min = Math.max(1, min);
+			} else {
+				min = 1;
+			}
+		}
+
+		if (min == null) {
+			min = 0;
+		}
+
+		if (max == null) {
+			int defaultArbitraryContainerSize = context.getGenerateOptions()
+				.getDefaultArbitraryContainerSize();
+			max = min + defaultArbitraryContainerSize;
+		}
+
+		return new ArbitraryContainerInfo(min, max, false);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationNullInjectGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationNullInjectGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.generator;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+
+import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.type.Types;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationNullInjectGenerator implements NullInjectGenerator {
+	private final NullInjectGenerator delegate;
+
+	public JakartaValidationNullInjectGenerator() {
+		this(new DefaultNullInjectGenerator());
+	}
+
+	public JakartaValidationNullInjectGenerator(NullInjectGenerator delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public double generate(ObjectPropertyGeneratorContext context) {
+		Set<Class<? extends Annotation>> annotations = context.getProperty().getAnnotations().stream()
+			.map(Annotation::annotationType)
+			.collect(toSet());
+
+		if (annotations.contains(Null.class)) {
+			return 1.0d;
+		}
+
+		double nullInject = this.delegate.generate(context);
+		if (nullInject == 0.0d) {
+			return nullInject;
+		}
+
+		if (annotations.contains(NotNull.class)) {
+			return 0.0d;
+		}
+
+		if (Types.getActualType(context.getProperty().getType()) == String.class) {
+			if (annotations.contains(NotBlank.class) || annotations.contains(NotEmpty.class)) {
+				return 0.0d;
+			}
+		}
+
+		if (context.isContainer() && annotations.contains(NotEmpty.class)) {
+			return 0.0d;
+		}
+
+		return nullInject;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationNullInjectGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationNullInjectGenerator.java
@@ -36,7 +36,7 @@ import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.type.Types;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationNullInjectGenerator implements NullInjectGenerator {
 	private final NullInjectGenerator delegate;
 

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationBooleanIntrospector.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationBooleanIntrospector.java
@@ -32,7 +32,7 @@ import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.Matchers;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationBooleanIntrospector extends ArbitraryIntrospectDelegator {
 	public JakartaValidationBooleanIntrospector() {
 		super(Matchers.BOOLEAN_TYPE_MATCHER, new BooleanIntrospector());

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationBooleanIntrospector.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationBooleanIntrospector.java
@@ -1,0 +1,53 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectDelegator;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
+import com.navercorp.fixturemonkey.api.matcher.Matchers;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationBooleanIntrospector extends ArbitraryIntrospectDelegator {
+	public JakartaValidationBooleanIntrospector() {
+		super(Matchers.BOOLEAN_TYPE_MATCHER, new BooleanIntrospector());
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		if (context.findAnnotation(AssertTrue.class).isPresent()) {
+			return new ArbitraryIntrospectorResult(Arbitraries.of(true));
+		}
+
+		if (context.findAnnotation(AssertFalse.class).isPresent()) {
+			return new ArbitraryIntrospectorResult(Arbitraries.of(false));
+		}
+
+		return super.introspect(context);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
@@ -41,7 +41,7 @@ import jakarta.validation.constraints.Size;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public class JakartaValidationConstraintGenerator {
 	private static final BigInteger BIG_INTEGER_MIN_LONG = BigInteger.valueOf(Long.MIN_VALUE);
 	private static final BigInteger BIG_INTEGER_MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
@@ -1,0 +1,332 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public class JakartaValidationConstraintGenerator {
+	private static final BigInteger BIG_INTEGER_MIN_LONG = BigInteger.valueOf(Long.MIN_VALUE);
+	private static final BigInteger BIG_INTEGER_MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+	private static final BigInteger BIG_INTEGER_MIN_INT = BigInteger.valueOf(Integer.MIN_VALUE);
+	private static final BigInteger BIG_INTEGER_MAX_INT = BigInteger.valueOf(Integer.MAX_VALUE);
+	private static final BigInteger BIG_INTEGER_MIN_SHORT = BigInteger.valueOf(Short.MIN_VALUE);
+	private static final BigInteger BIG_INTEGER_MAX_SHORT = BigInteger.valueOf(Short.MAX_VALUE);
+	private static final BigInteger BIG_INTEGER_MIN_BYTE = BigInteger.valueOf(Byte.MIN_VALUE);
+	private static final BigInteger BIG_INTEGER_MAX_BYTE = BigInteger.valueOf(Byte.MAX_VALUE);
+
+	public JakartaValidationStringConstraint generateStringConstraint(ArbitraryGeneratorContext context) {
+		BigInteger min = null;
+		BigInteger max = null;
+		boolean digits = false;
+		boolean notBlank = context.findAnnotation(NotBlank.class).isPresent();
+
+		if (notBlank || context.findAnnotation(NotEmpty.class).isPresent()) {
+			min = BigInteger.ONE;
+		}
+
+		Optional<Size> size = context.findAnnotation(Size.class);
+		if (size.isPresent()) {
+			int minValue = size.map(Size::min).get();
+			if (min == null) {
+				min = BigInteger.valueOf(minValue);
+			} else if (minValue > 1) {
+				min = BigInteger.valueOf(minValue);
+			}
+
+			max = BigInteger.valueOf(size.map(Size::max).get());
+		}
+
+		// TODO: support fraction
+		Optional<Digits> digitsAnnotation = context.findAnnotation(Digits.class);
+		if (digitsAnnotation.isPresent()) {
+			digits = true;
+			notBlank = true;
+
+			BigInteger maxValue = digitsAnnotation.map(Digits::integer).map(BigInteger::valueOf).get();
+			if (max == null) {
+				max = maxValue;
+			} else if (max.compareTo(maxValue) > 0) {
+				max = maxValue;
+			}
+		}
+
+		return new JakartaValidationStringConstraint(min, max, digits, notBlank);
+	}
+
+	public JakartaValidationIntegerConstraint generateIntegerConstraint(ArbitraryGeneratorContext context) {
+		BigInteger min = null;
+		BigInteger max = null;
+
+		Optional<Digits> digits = context.findAnnotation(Digits.class);
+		if (digits.isPresent()) {
+			BigInteger value = BigInteger.ONE;
+			int integer = digits.get().integer();
+			if (integer > 1) {
+				value = BigInteger.TEN.pow(integer - 1);
+			}
+			max = value.multiply(BigInteger.TEN).subtract(BigInteger.ONE);
+			min = max.negate();
+		}
+
+		Optional<Min> minAnnotation = context.findAnnotation(Min.class);
+		if (minAnnotation.isPresent()) {
+			BigInteger minValue = minAnnotation.map(Min::value).map(BigInteger::valueOf).get();
+			if (min == null) {
+				min = minValue;
+			} else if (min.compareTo(minValue) > 0) {
+				min = minValue;
+			}
+		}
+
+		Optional<DecimalMin> decimalMinAnnotation = context.findAnnotation(DecimalMin.class);
+		if (decimalMinAnnotation.isPresent()) {
+			BigInteger decimalMin = decimalMinAnnotation
+				.map(DecimalMin::value)
+				.map(BigInteger::new)
+				.get();
+
+			if (!decimalMinAnnotation.map(DecimalMin::inclusive).get()) {
+				decimalMin = decimalMin.add(BigInteger.ONE);
+			}
+
+			if (min == null) {
+				min = decimalMin;
+			} else if (min.compareTo(decimalMin) < 0) {
+				min = decimalMin;
+			}
+		}
+
+		Optional<Max> maxAnnotation = context.findAnnotation(Max.class);
+		if (maxAnnotation.isPresent()) {
+			BigInteger maxValue = maxAnnotation.map(Max::value).map(BigInteger::valueOf).get();
+			if (max == null) {
+				max = maxValue;
+			} else if (max.compareTo(maxValue) > 0) {
+				max = maxValue;
+			}
+		}
+
+		Optional<DecimalMax> decimalMaxAnnotation = context.findAnnotation(DecimalMax.class);
+		if (decimalMaxAnnotation.isPresent()) {
+			BigInteger decimalMax = decimalMaxAnnotation
+				.map(DecimalMax::value)
+				.map(BigInteger::new)
+				.get();
+			if (!decimalMaxAnnotation.map(DecimalMax::inclusive).get()) {
+				decimalMax = decimalMax.subtract(BigInteger.ONE);
+			}
+
+			if (max == null) {
+				max = decimalMax;
+			} else if (max.compareTo(decimalMax) > 0) {
+				max = decimalMax;
+			}
+		}
+
+		if (context.findAnnotation(Negative.class).isPresent()) {
+			if (max == null || max.compareTo(BigInteger.ZERO) > 0) {
+				max = BigInteger.valueOf(-1);
+			}
+		}
+
+		if (context.findAnnotation(NegativeOrZero.class).isPresent()) {
+			if (max == null || max.compareTo(BigInteger.ZERO) > 0) {
+				max = BigInteger.ZERO;
+			}
+		}
+
+		if (context.findAnnotation(Positive.class).isPresent()) {
+			if (min == null || min.compareTo(BigInteger.ZERO) < 0) {
+				min = BigInteger.ONE;
+			}
+		}
+
+		if (context.findAnnotation(PositiveOrZero.class).isPresent()) {
+			if (min == null || min.compareTo(BigInteger.ZERO) < 0) {
+				min = BigInteger.ZERO;
+			}
+		}
+
+		Type type = context.getType();
+		if (min != null) {
+			if ((type == Long.class || type == long.class) && min.compareTo(BIG_INTEGER_MIN_LONG) < 0) {
+				min = BIG_INTEGER_MIN_LONG;
+			}
+			if ((type == Integer.class || type == int.class) && min.compareTo(BIG_INTEGER_MIN_INT) < 0) {
+				min = BIG_INTEGER_MIN_INT;
+			}
+			if ((type == Short.class || type == short.class) && min.compareTo(BIG_INTEGER_MIN_SHORT) < 0) {
+				min = BIG_INTEGER_MIN_SHORT;
+			}
+			if ((type == Byte.class || type == byte.class) && min.compareTo(BIG_INTEGER_MIN_BYTE) < 0) {
+				min = BIG_INTEGER_MIN_BYTE;
+			}
+		}
+		if (max != null) {
+			if ((type == Long.class || type == long.class) && max.compareTo(BIG_INTEGER_MAX_LONG) > 0) {
+				max = BIG_INTEGER_MAX_LONG;
+			}
+			if ((type == Integer.class || type == int.class) && max.compareTo(BIG_INTEGER_MAX_INT) > 0) {
+				max = BIG_INTEGER_MAX_INT;
+			}
+			if ((type == Short.class || type == short.class) && max.compareTo(BIG_INTEGER_MAX_SHORT) > 0) {
+				max = BIG_INTEGER_MAX_SHORT;
+			}
+			if ((type == Byte.class || type == byte.class) && max.compareTo(BIG_INTEGER_MAX_BYTE) > 0) {
+				max = BIG_INTEGER_MAX_BYTE;
+			}
+		}
+
+		return new JakartaValidationIntegerConstraint(min, max);
+	}
+
+	public JakartaValidationDecimalConstraint generateDecimalConstraint(ArbitraryGeneratorContext context) {
+		BigDecimal min = null;
+		Boolean minInclusive = null;
+		BigDecimal max = null;
+		Boolean maxInclusive = null;
+		Integer scale = null;
+
+		Optional<Digits> digits = context.findAnnotation(Digits.class);
+		if (digits.isPresent()) {
+			BigDecimal value = BigDecimal.ONE;
+			int integer = digits.get().integer();
+			if (integer > 1) {
+				value = BigDecimal.TEN.pow(integer - 1);
+			}
+			max = value.multiply(BigDecimal.TEN).subtract(BigDecimal.ONE);
+			min = max.negate();
+			scale = digits.get().fraction();
+		}
+
+		Optional<Min> minAnnotation = context.findAnnotation(Min.class);
+		if (minAnnotation.isPresent()) {
+			BigDecimal minValue = minAnnotation.map(Min::value).map(BigDecimal::valueOf).get();
+			if (min == null) {
+				min = minValue;
+			} else if (min.compareTo(minValue) > 0) {
+				min = minValue;
+			}
+		}
+
+		Optional<DecimalMin> decimalMinAnnotation = context.findAnnotation(DecimalMin.class);
+		if (decimalMinAnnotation.isPresent()) {
+			BigDecimal decimalMin = decimalMinAnnotation
+				.map(DecimalMin::value)
+				.map(BigDecimal::new)
+				.get();
+
+			if (!decimalMinAnnotation.map(DecimalMin::inclusive).get()) {
+				minInclusive = false;
+			}
+
+			if (min == null) {
+				min = decimalMin;
+			} else if (min.compareTo(decimalMin) < 0) {
+				min = decimalMin;
+			}
+		}
+
+		Optional<Max> maxAnnotation = context.findAnnotation(Max.class);
+		if (maxAnnotation.isPresent()) {
+			BigDecimal maxValue = maxAnnotation.map(Max::value).map(BigDecimal::valueOf).get();
+			if (max == null) {
+				max = maxValue;
+			} else if (max.compareTo(maxValue) > 0) {
+				max = maxValue;
+			}
+		}
+
+		Optional<DecimalMax> decimalMaxAnnotation = context.findAnnotation(DecimalMax.class);
+		if (decimalMaxAnnotation.isPresent()) {
+			BigDecimal decimalMax = decimalMaxAnnotation
+				.map(DecimalMax::value)
+				.map(BigDecimal::new)
+				.get();
+
+			if (!decimalMaxAnnotation.map(DecimalMax::inclusive).get()) {
+				maxInclusive = false;
+			}
+
+			if (max == null) {
+				max = decimalMax;
+			} else if (max.compareTo(decimalMax) > 0) {
+				max = decimalMax;
+			}
+		}
+
+		if (context.findAnnotation(Negative.class).isPresent()) {
+			if (max == null || max.compareTo(BigDecimal.ZERO) > 0) {
+				max = BigDecimal.ZERO;
+				maxInclusive = false;
+			}
+		}
+
+		if (context.findAnnotation(NegativeOrZero.class).isPresent()) {
+			if (max == null || max.compareTo(BigDecimal.ZERO) > 0) {
+				max = BigDecimal.ZERO;
+			}
+		}
+
+		if (context.findAnnotation(Positive.class).isPresent()) {
+			if (min == null || min.compareTo(BigDecimal.ZERO) < 0) {
+				min = BigDecimal.ZERO;
+				minInclusive = false;
+			}
+		}
+
+		if (context.findAnnotation(PositiveOrZero.class).isPresent()) {
+			if (min == null || min.compareTo(BigDecimal.ZERO) < 0) {
+				min = BigDecimal.ZERO;
+			}
+		}
+
+		if (min != null && minInclusive == null) {
+			minInclusive = true;
+		}
+
+		if (max != null && maxInclusive == null) {
+			maxInclusive = true;
+		}
+
+		return new JakartaValidationDecimalConstraint(min, minInclusive, max, maxInclusive, scale);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationDateConstraint {
 	@Nullable
 	private final LocalDate min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateConstraint.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.LocalDate;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationDateConstraint {
+	@Nullable
+	private final LocalDate min;
+
+	@Nullable
+	private final LocalDate max;
+
+	public JakartaValidationDateConstraint(@Nullable LocalDate min, @Nullable LocalDate max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public LocalDate getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public LocalDate getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateTimeConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateTimeConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationDateTimeConstraint {
 	@Nullable
 	private final LocalDateTime min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateTimeConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDateTimeConstraint.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.LocalDateTime;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationDateTimeConstraint {
+	@Nullable
+	private final LocalDateTime min;
+
+	@Nullable
+	private final LocalDateTime max;
+
+	public JakartaValidationDateTimeConstraint(@Nullable LocalDateTime min, @Nullable LocalDateTime max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public LocalDateTime getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public LocalDateTime getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDecimalConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDecimalConstraint.java
@@ -1,0 +1,83 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.math.BigDecimal;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationDecimalConstraint {
+	@Nullable
+	private final BigDecimal min;
+
+	@Nullable
+	private final Boolean minInclusive;
+
+	@Nullable
+	private final BigDecimal max;
+
+	@Nullable
+	private final Boolean maxInclusive;
+
+	@Nullable
+	private final Integer scale;
+
+	public JakartaValidationDecimalConstraint(
+		@Nullable BigDecimal min,
+		@Nullable Boolean minInclusive,
+		@Nullable BigDecimal max,
+		@Nullable Boolean maxInclusive,
+		@Nullable Integer scale
+	) {
+		this.min = min;
+		this.minInclusive = minInclusive;
+		this.max = max;
+		this.maxInclusive = maxInclusive;
+		this.scale = scale;
+	}
+
+	@Nullable
+	public BigDecimal getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public Boolean getMinInclusive() {
+		return this.minInclusive;
+	}
+
+	@Nullable
+	public BigDecimal getMax() {
+		return this.max;
+	}
+
+	@Nullable
+	public Boolean getMaxInclusive() {
+		return this.maxInclusive;
+	}
+
+	@Nullable
+	public Integer getScale() {
+		return scale;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDecimalConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationDecimalConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationDecimalConstraint {
 	@Nullable
 	private final BigDecimal min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationIntegerConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationIntegerConstraint.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.math.BigInteger;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationIntegerConstraint {
+	@Nullable
+	private final BigInteger min;
+
+	@Nullable
+	private final BigInteger max;
+
+	public JakartaValidationIntegerConstraint(@Nullable BigInteger min, @Nullable BigInteger max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public BigInteger getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public BigInteger getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationIntegerConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationIntegerConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationIntegerConstraint {
 	@Nullable
 	private final BigInteger min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
@@ -48,7 +48,7 @@ import jakarta.validation.constraints.Pattern;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationJavaArbitraryResolver implements JavaArbitraryResolver {
 	private static final String CONTROL_BLOCK = "\u0000-\u001f\u007f";
 	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
@@ -1,0 +1,325 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import static java.util.stream.Collectors.toList;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.BigDecimalArbitrary;
+import net.jqwik.api.arbitraries.BigIntegerArbitrary;
+import net.jqwik.api.arbitraries.ByteArbitrary;
+import net.jqwik.api.arbitraries.CharacterArbitrary;
+import net.jqwik.api.arbitraries.DoubleArbitrary;
+import net.jqwik.api.arbitraries.FloatArbitrary;
+import net.jqwik.api.arbitraries.IntegerArbitrary;
+import net.jqwik.api.arbitraries.LongArbitrary;
+import net.jqwik.api.arbitraries.ShortArbitrary;
+import net.jqwik.api.arbitraries.StringArbitrary;
+import net.jqwik.web.api.Web;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationJavaArbitraryResolver implements JavaArbitraryResolver {
+	private static final String CONTROL_BLOCK = "\u0000-\u001f\u007f";
+	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
+
+	private final JakartaValidationConstraintGenerator constraintGenerator;
+
+	public JakartaValidationJavaArbitraryResolver() {
+		this(new JakartaValidationConstraintGenerator());
+	}
+
+	public JakartaValidationJavaArbitraryResolver(JakartaValidationConstraintGenerator constraintGenerator) {
+		this.constraintGenerator = constraintGenerator;
+	}
+
+	@Override
+	public Arbitrary<String> strings(
+		StringArbitrary stringArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationStringConstraint constraint = this.constraintGenerator.generateStringConstraint(context);
+		BigInteger min = constraint.getMinSize();
+		BigInteger max = constraint.getMaxSize();
+		boolean digits = constraint.isDigits();
+		boolean notBlank = constraint.isNotBlank();
+
+		Optional<Pattern> pattern = context.findAnnotation(Pattern.class);
+		if (pattern.isPresent()) {
+			Integer minValue = min != null ? min.intValue() : null;
+			Integer maxValue = max != null ? max.intValue() : null;
+			List<String> values = REGEX_GENERATOR.generateAll(pattern.get(), minValue, maxValue);
+			if (notBlank) {
+				values = values.stream()
+					.filter(it -> it != null && !it.trim().isEmpty())
+					.collect(toList());
+			}
+
+			return Arbitraries.of(values);
+		}
+
+		Arbitrary<String> arbitrary;
+		if (context.findAnnotation(Email.class).isPresent()) {
+			arbitrary = Web.emails().allowIpv4Host();
+			if (min != null) {
+				int emailMinLength = min.intValue();
+				arbitrary = arbitrary.filter(it -> it != null && it.length() >= emailMinLength);
+			}
+			if (max != null) {
+				int emailMaxLength = max.intValue();
+				arbitrary = arbitrary.filter(it -> it != null && it.length() <= emailMaxLength);
+			}
+		} else {
+			if (min != null) {
+				stringArbitrary = stringArbitrary.ofMinLength(min.intValue());
+			}
+			if (max != null) {
+				stringArbitrary = stringArbitrary.ofMaxLength(max.intValue());
+			}
+			if (digits) {
+				stringArbitrary = stringArbitrary.numeric();
+			} else {
+				stringArbitrary = stringArbitrary.ascii();
+			}
+			arbitrary = stringArbitrary;
+		}
+
+		return arbitrary
+			.filter(it -> {
+				if (!notBlank) {
+					return true;
+				}
+
+				if (it == null || it.trim().length() == 0) {
+					return false;
+				}
+
+				return !CONTROL_BLOCK.equals(it.trim());
+			});
+	}
+
+	@Override
+	public Arbitrary<Character> characters(
+		CharacterArbitrary characterArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		return characterArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Short> shorts(
+		ShortArbitrary shortArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			shortArbitrary = shortArbitrary.greaterOrEqual(min.shortValueExact());
+		}
+		if (max != null) {
+			shortArbitrary = shortArbitrary.lessOrEqual(max.shortValueExact());
+		}
+
+		return shortArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Byte> bytes(
+		ByteArbitrary byteArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			byteArbitrary = byteArbitrary.greaterOrEqual(min.byteValueExact());
+		}
+		if (max != null) {
+			byteArbitrary = byteArbitrary.lessOrEqual(max.byteValueExact());
+		}
+
+		return byteArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Float> floats(
+		FloatArbitrary floatArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				floatArbitrary = floatArbitrary.greaterThan(min.floatValue());
+			} else {
+				floatArbitrary = floatArbitrary.greaterOrEqual(min.floatValue());
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				floatArbitrary = floatArbitrary.lessThan(max.floatValue());
+			} else {
+				floatArbitrary = floatArbitrary.lessOrEqual(max.floatValue());
+			}
+		}
+
+		return floatArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Double> doubles(
+		DoubleArbitrary doubleArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				doubleArbitrary = doubleArbitrary.greaterThan(min.doubleValue());
+			} else {
+				doubleArbitrary = doubleArbitrary.greaterOrEqual(min.doubleValue());
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				doubleArbitrary = doubleArbitrary.lessThan(max.doubleValue());
+			} else {
+				doubleArbitrary = doubleArbitrary.lessOrEqual(max.doubleValue());
+			}
+		}
+
+		return doubleArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Integer> integers(
+		IntegerArbitrary integerArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			integerArbitrary = integerArbitrary.greaterOrEqual(min.intValueExact());
+		}
+		if (max != null) {
+			integerArbitrary = integerArbitrary.lessOrEqual(max.intValueExact());
+		}
+
+		return integerArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Long> longs(
+		LongArbitrary longArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			longArbitrary = longArbitrary.greaterOrEqual(min.longValueExact());
+		}
+		if (max != null) {
+			longArbitrary = longArbitrary.lessOrEqual(max.longValueExact());
+		}
+
+		return longArbitrary;
+	}
+
+	@Override
+	public Arbitrary<BigInteger> bigIntegers(
+		BigIntegerArbitrary bigIntegerArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationIntegerConstraint constraint = this.constraintGenerator.generateIntegerConstraint(context);
+		BigInteger min = constraint.getMin();
+		BigInteger max = constraint.getMax();
+
+		if (min != null) {
+			bigIntegerArbitrary = bigIntegerArbitrary.greaterOrEqual(min);
+		}
+		if (max != null) {
+			bigIntegerArbitrary = bigIntegerArbitrary.lessOrEqual(max);
+		}
+
+		return bigIntegerArbitrary;
+	}
+
+	@Override
+	public Arbitrary<BigDecimal> bigDecimals(
+		BigDecimalArbitrary bigDecimalArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDecimalConstraint constraint = this.constraintGenerator.generateDecimalConstraint(context);
+		BigDecimal min = constraint.getMin();
+		BigDecimal max = constraint.getMax();
+		Boolean minInclusive = constraint.getMinInclusive();
+		Boolean maxInclusive = constraint.getMaxInclusive();
+		Integer scale = constraint.getScale();
+
+		if (min != null) {
+			if (minInclusive != null && !minInclusive) {
+				bigDecimalArbitrary = bigDecimalArbitrary.greaterThan(min);
+			} else {
+				bigDecimalArbitrary = bigDecimalArbitrary.greaterOrEqual(min);
+			}
+		}
+		if (max != null) {
+			if (maxInclusive != null && !maxInclusive) {
+				bigDecimalArbitrary = bigDecimalArbitrary.lessThan(max);
+			} else {
+				bigDecimalArbitrary = bigDecimalArbitrary.lessOrEqual(max);
+			}
+		}
+
+		if (scale != null) {
+			bigDecimalArbitrary = bigDecimalArbitrary.ofScale(scale);
+		}
+
+		return bigDecimalArbitrary;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaTimeArbitraryResolver.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaTimeArbitraryResolver.java
@@ -57,7 +57,7 @@ import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationJavaTimeArbitraryResolver implements JavaTimeArbitraryResolver {
 	private final JakartaValidationTimeConstraintGenerator constraintGenerator;
 

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaTimeArbitraryResolver.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaTimeArbitraryResolver.java
@@ -1,0 +1,337 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.time.api.arbitraries.CalendarArbitrary;
+import net.jqwik.time.api.arbitraries.DateArbitrary;
+import net.jqwik.time.api.arbitraries.DurationArbitrary;
+import net.jqwik.time.api.arbitraries.InstantArbitrary;
+import net.jqwik.time.api.arbitraries.LocalDateArbitrary;
+import net.jqwik.time.api.arbitraries.LocalDateTimeArbitrary;
+import net.jqwik.time.api.arbitraries.LocalTimeArbitrary;
+import net.jqwik.time.api.arbitraries.MonthDayArbitrary;
+import net.jqwik.time.api.arbitraries.OffsetDateTimeArbitrary;
+import net.jqwik.time.api.arbitraries.OffsetTimeArbitrary;
+import net.jqwik.time.api.arbitraries.PeriodArbitrary;
+import net.jqwik.time.api.arbitraries.YearArbitrary;
+import net.jqwik.time.api.arbitraries.YearMonthArbitrary;
+import net.jqwik.time.api.arbitraries.ZoneOffsetArbitrary;
+import net.jqwik.time.api.arbitraries.ZonedDateTimeArbitrary;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationJavaTimeArbitraryResolver implements JavaTimeArbitraryResolver {
+	private final JakartaValidationTimeConstraintGenerator constraintGenerator;
+
+	public JakartaValidationJavaTimeArbitraryResolver() {
+		this(new JakartaValidationTimeConstraintGenerator());
+	}
+
+	public JakartaValidationJavaTimeArbitraryResolver(JakartaValidationTimeConstraintGenerator constraintGenerator) {
+		this.constraintGenerator = constraintGenerator;
+	}
+
+	@Override
+	public Arbitrary<Calendar> calendars(
+		CalendarArbitrary calendarArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			Calendar calendar = Calendar.getInstance();
+			calendar.set(min.getYear(), min.getMonth().ordinal(), min.getDayOfMonth() + 1);
+			calendarArbitrary = calendarArbitrary.atTheEarliest(calendar);
+		}
+		if (max != null) {
+			Calendar calendar = Calendar.getInstance();
+			calendar.set(max.getYear(), max.getMonth().ordinal(), max.getDayOfMonth());
+			calendarArbitrary = calendarArbitrary.atTheLatest(calendar);
+		}
+
+		return calendarArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Date> dates(
+		DateArbitrary dateArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			Calendar calendar = Calendar.getInstance();
+			calendar.set(min.getYear(), min.getMonth().ordinal(), min.getDayOfMonth() + 1);
+			dateArbitrary = dateArbitrary.atTheEarliest(calendar.getTime());
+		}
+		if (max != null) {
+			Calendar calendar = Calendar.getInstance();
+			calendar.set(max.getYear(), max.getMonth().ordinal(), max.getDayOfMonth());
+			dateArbitrary = dateArbitrary.atTheLatest(calendar.getTime());
+		}
+
+		return dateArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Instant> instants(
+		InstantArbitrary instantArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			instantArbitrary = instantArbitrary.atTheEarliest(min.atZone(ZoneOffset.systemDefault()).toInstant());
+		}
+		if (max != null) {
+			instantArbitrary = instantArbitrary.atTheLatest(max.atZone(ZoneOffset.systemDefault()).toInstant());
+		}
+
+		return instantArbitrary;
+	}
+
+	@Override
+	public Arbitrary<LocalDate> localDates(
+		LocalDateArbitrary localDateArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateConstraint constraint = this.constraintGenerator.generateDateConstraint(context);
+		LocalDate min = constraint.getMin();
+		LocalDate max = constraint.getMax();
+
+		if (min != null) {
+			localDateArbitrary = localDateArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			localDateArbitrary = localDateArbitrary.atTheLatest(max);
+		}
+
+		return localDateArbitrary;
+	}
+
+	@Override
+	public Arbitrary<LocalDateTime> localDateTimes(
+		LocalDateTimeArbitrary localDateTimeArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			localDateTimeArbitrary = localDateTimeArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			localDateTimeArbitrary = localDateTimeArbitrary.atTheLatest(max);
+		}
+
+		return localDateTimeArbitrary;
+	}
+
+	@Override
+	public Arbitrary<LocalTime> localTimes(
+		LocalTimeArbitrary localTimeArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationTimeConstraint constraint = this.constraintGenerator.generateTimeConstraint(context);
+		LocalTime min = constraint.getMin();
+		LocalTime max = constraint.getMax();
+
+		if (min != null) {
+			localTimeArbitrary = localTimeArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			localTimeArbitrary = localTimeArbitrary.atTheLatest(max);
+		}
+
+		return localTimeArbitrary;
+	}
+
+	@Override
+	public Arbitrary<ZonedDateTime> zonedDateTimes(
+		ZonedDateTimeArbitrary zonedDateTimeArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			zonedDateTimeArbitrary = zonedDateTimeArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			zonedDateTimeArbitrary = zonedDateTimeArbitrary.atTheLatest(max);
+		}
+
+		return zonedDateTimeArbitrary;
+	}
+
+	@Override
+	public Arbitrary<MonthDay> monthDays(
+		MonthDayArbitrary monthDayArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateConstraint constraint = this.constraintGenerator.generateDateConstraint(context);
+		LocalDate min = constraint.getMin();
+		LocalDate max = constraint.getMax();
+
+		if (min != null) {
+			monthDayArbitrary = monthDayArbitrary.atTheEarliest(MonthDay.of(min.getMonth(), min.getDayOfMonth()));
+		}
+		if (max != null) {
+			monthDayArbitrary = monthDayArbitrary.atTheLatest(MonthDay.of(max.getMonth(), max.getDayOfMonth()));
+		}
+
+		return monthDayArbitrary;
+	}
+
+	@Override
+	public Arbitrary<OffsetDateTime> offsetDateTimes(
+		OffsetDateTimeArbitrary offsetDateTimeArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationDateTimeConstraint constraint =
+			this.constraintGenerator.generateDateTimeConstraint(context);
+		LocalDateTime min = constraint.getMin();
+		LocalDateTime max = constraint.getMax();
+
+		if (min != null) {
+			offsetDateTimeArbitrary = offsetDateTimeArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			offsetDateTimeArbitrary = offsetDateTimeArbitrary.atTheLatest(max);
+		}
+
+		return offsetDateTimeArbitrary;
+	}
+
+	@Override
+	public Arbitrary<OffsetTime> offsetTimes(
+		OffsetTimeArbitrary offsetTimeArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationTimeConstraint constraint = this.constraintGenerator.generateTimeConstraint(context);
+		LocalTime min = constraint.getMin();
+		LocalTime max = constraint.getMax();
+
+		if (min != null) {
+			offsetTimeArbitrary = offsetTimeArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			offsetTimeArbitrary = offsetTimeArbitrary.atTheLatest(max);
+		}
+
+		return offsetTimeArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Year> years(
+		YearArbitrary yearArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationYearConstraint constraint = this.constraintGenerator.generateYearConstraint(context);
+		Year min = constraint.getMin();
+		Year max = constraint.getMax();
+
+		if (min != null) {
+			yearArbitrary = yearArbitrary.between(min.getValue(), Year.MAX_VALUE);
+		}
+		if (max != null) {
+			yearArbitrary = yearArbitrary.between(Year.MIN_VALUE, max.getValue());
+		}
+
+		return yearArbitrary;
+	}
+
+	@Override
+	public Arbitrary<YearMonth> yearMonths(
+		YearMonthArbitrary yearMonthArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		JakartaValidationYearMonthConstraint constraint = this.constraintGenerator.generateYearMonthConstraint(context);
+		YearMonth min = constraint.getMin();
+		YearMonth max = constraint.getMax();
+
+		if (min != null) {
+			yearMonthArbitrary = yearMonthArbitrary.atTheEarliest(min);
+		}
+		if (max != null) {
+			yearMonthArbitrary = yearMonthArbitrary.atTheLatest(max);
+		}
+
+		return yearMonthArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Period> periods(
+		PeriodArbitrary periodArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		return periodArbitrary;
+	}
+
+	@Override
+	public Arbitrary<Duration> durations(
+		DurationArbitrary durationArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		return durationArbitrary;
+	}
+
+	@Override
+	public Arbitrary<ZoneOffset> zoneOffsets(
+		ZoneOffsetArbitrary zoneOffsetArbitrary,
+		ArbitraryGeneratorContext context
+	) {
+		return zoneOffsetArbitrary;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationStringConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationStringConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationStringConstraint {
 	@Nullable
 	private final BigInteger minSize;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationStringConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationStringConstraint.java
@@ -1,0 +1,69 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.math.BigInteger;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationStringConstraint {
+	@Nullable
+	private final BigInteger minSize;
+
+	@Nullable
+	private final BigInteger maxSize;
+
+	private final boolean digits;
+
+	private final boolean notBlank;
+
+	public JakartaValidationStringConstraint(
+		@Nullable BigInteger minSize,
+		@Nullable BigInteger maxSize,
+		boolean digits,
+		boolean notBlank
+	) {
+		this.minSize = minSize;
+		this.maxSize = maxSize;
+		this.digits = digits;
+		this.notBlank = notBlank;
+	}
+
+	@Nullable
+	public BigInteger getMinSize() {
+		return this.minSize;
+	}
+
+	@Nullable
+	public BigInteger getMaxSize() {
+		return this.maxSize;
+	}
+
+	public boolean isDigits() {
+		return this.digits;
+	}
+
+	public boolean isNotBlank() {
+		return this.notBlank;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraint.java
@@ -1,0 +1,50 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.LocalTime;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationTimeConstraint {
+	@Nullable
+	private final LocalTime min;
+
+	@Nullable
+	private final LocalTime max;
+
+	public JakartaValidationTimeConstraint(@Nullable LocalTime min, @Nullable LocalTime max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public LocalTime getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public LocalTime getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationTimeConstraint {
 	@Nullable
 	private final LocalTime min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraintGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraintGenerator.java
@@ -35,7 +35,7 @@ import jakarta.validation.constraints.PastOrPresent;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public class JakartaValidationTimeConstraintGenerator {
 
 	public JakartaValidationDateTimeConstraint generateDateTimeConstraint(ArbitraryGeneratorContext context) {

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraintGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationTimeConstraintGenerator.java
@@ -1,0 +1,135 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public class JakartaValidationTimeConstraintGenerator {
+
+	public JakartaValidationDateTimeConstraint generateDateTimeConstraint(ArbitraryGeneratorContext context) {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime min = null;
+		if (context.findAnnotation(Future.class).isPresent()) {
+			min = now.plus(3, ChronoUnit.SECONDS);    // 3000 is buffer for future time
+		} else if (context.findAnnotation(FutureOrPresent.class).isPresent()) {
+			min = now.plus(2, ChronoUnit.SECONDS);    // 2000 is buffer for future time
+		}
+
+		LocalDateTime max = null;
+		if (context.findAnnotation(Past.class).isPresent()) {
+			max = now.minus(1, ChronoUnit.SECONDS);
+		} else if (context.findAnnotation(PastOrPresent.class).isPresent()) {
+			max = now;
+		}
+
+		return new JakartaValidationDateTimeConstraint(min, max);
+	}
+
+	public JakartaValidationDateConstraint generateDateConstraint(ArbitraryGeneratorContext context) {
+		LocalDate now = LocalDate.now();
+		LocalDate min = null;
+		if (context.findAnnotation(Future.class).isPresent()) {
+			min = now.plusDays(1);
+		} else if (context.findAnnotation(FutureOrPresent.class).isPresent()) {
+			min = now;
+		}
+
+		LocalDate max = null;
+		if (context.findAnnotation(Past.class).isPresent()) {
+			max = now.minusDays(1);
+		} else if (context.findAnnotation(PastOrPresent.class).isPresent()) {
+			max = now;
+		}
+
+		return new JakartaValidationDateConstraint(min, max);
+	}
+
+	public JakartaValidationTimeConstraint generateTimeConstraint(ArbitraryGeneratorContext context) {
+		LocalTime now = LocalTime.now();
+		LocalTime min = null;
+		if (context.findAnnotation(Future.class).isPresent()) {
+			min = now.plusSeconds(3);    // 3000 is buffer for future time
+		} else if (context.findAnnotation(FutureOrPresent.class).isPresent()) {
+			min = now.plusSeconds(2);    // 2000 is buffer for future time
+		}
+
+		LocalTime max = null;
+		if (context.findAnnotation(Past.class).isPresent()) {
+			max = now.minusNanos(1L);
+		} else if (context.findAnnotation(PastOrPresent.class).isPresent()) {
+			max = now;
+		}
+
+		return new JakartaValidationTimeConstraint(min, max);
+	}
+
+	public JakartaValidationYearConstraint generateYearConstraint(ArbitraryGeneratorContext context) {
+		Year now = Year.now();
+		Year min = null;
+		if (context.findAnnotation(Future.class).isPresent()) {
+			min = now.plusYears(1);
+		} else if (context.findAnnotation(FutureOrPresent.class).isPresent()) {
+			min = now;
+		}
+
+		Year max = null;
+		if (context.findAnnotation(Past.class).isPresent()) {
+			max = now.minusYears(1);
+		} else if (context.findAnnotation(PastOrPresent.class).isPresent()) {
+			max = now;
+		}
+
+		return new JakartaValidationYearConstraint(min, max);
+	}
+
+	public JakartaValidationYearMonthConstraint generateYearMonthConstraint(ArbitraryGeneratorContext context) {
+		YearMonth now = YearMonth.now();
+		YearMonth min = null;
+		if (context.findAnnotation(Future.class).isPresent()) {
+			min = now.plusMonths(1);
+		} else if (context.findAnnotation(FutureOrPresent.class).isPresent()) {
+			min = now;
+		}
+
+		YearMonth max = null;
+		if (context.findAnnotation(Past.class).isPresent()) {
+			max = now.minusMonths(1);
+		} else if (context.findAnnotation(PastOrPresent.class).isPresent()) {
+			max = now;
+		}
+
+		return new JakartaValidationYearMonthConstraint(min, max);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearConstraint.java
@@ -1,0 +1,46 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.Year;
+
+import javax.annotation.Nullable;
+
+public final class JakartaValidationYearConstraint {
+	@Nullable
+	private final Year min;
+
+	@Nullable
+	private final Year max;
+
+	public JakartaValidationYearConstraint(@Nullable Year min, @Nullable Year max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public Year getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public Year getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearConstraint.java
@@ -22,6 +22,10 @@ import java.time.Year;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationYearConstraint {
 	@Nullable
 	private final Year min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.1", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationYearMonthConstraint {
 	@Nullable
 	private final YearMonth min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
@@ -1,0 +1,46 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import java.time.YearMonth;
+
+import javax.annotation.Nullable;
+
+public final class JakartaValidationYearMonthConstraint {
+	@Nullable
+	private final YearMonth min;
+
+	@Nullable
+	private final YearMonth max;
+
+	public JakartaValidationYearMonthConstraint(@Nullable YearMonth min, @Nullable YearMonth max) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Nullable
+	public YearMonth getMin() {
+		return this.min;
+	}
+
+	@Nullable
+	public YearMonth getMax() {
+		return this.max;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationYearMonthConstraint.java
@@ -22,6 +22,10 @@ import java.time.YearMonth;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.1", status = Status.EXPERIMENTAL)
 public final class JakartaValidationYearMonthConstraint {
 	@Nullable
 	private final YearMonth min;

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/RegexGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/RegexGenerator.java
@@ -1,0 +1,100 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.introspector;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.mifmif.common.regex.Generex;
+
+import dk.brics.automaton.RegExp;
+import jakarta.validation.constraints.Pattern;
+
+final class RegexGenerator {
+	private static final Map<String, String> PREDEFINED_CHARACTER_CLASSES;
+
+	static {
+		Map<String, String> characterClasses = new HashMap<>();
+		characterClasses.put("\\\\d", "[0-9]");
+		characterClasses.put("\\\\D", "[^0-9]");
+		characterClasses.put("\\\\s", "[ \t\n\f\r]");
+		characterClasses.put("\\\\S", "[^ \t\n\f\r]");
+		characterClasses.put("\\\\w", "[a-zA-Z_0-9]");
+		characterClasses.put("\\\\W", "[^a-zA-Z_0-9]");
+		PREDEFINED_CHARACTER_CLASSES = Collections.unmodifiableMap(characterClasses);
+	}
+
+	public List<String> generateAll(Pattern pattern) {
+		return this.generateAll(pattern, null, null);
+	}
+
+	public List<String> generateAll(Pattern pattern, @Nullable Integer min, @Nullable Integer max) {
+		String regex = pattern.regexp();
+		for (Map.Entry<String, String> charClass : PREDEFINED_CHARACTER_CLASSES.entrySet()) {
+			regex = regex.replaceAll(charClass.getKey(), charClass.getValue());
+		}
+
+		RegExp regExp;
+		Pattern.Flag[] flags = pattern.flags();
+		if (flags.length == 0) {
+			regExp = new RegExp(regex);
+		} else {
+			int intFlag = 0;
+			for (Pattern.Flag flag : flags) {
+				intFlag = intFlag | flag.getValue();
+			}
+			regExp = new RegExp(regex, intFlag);
+		}
+
+		Generex generex = new Generex(regExp.toAutomaton());
+		return this.generateAll(generex, min, max);
+	}
+
+	public List<String> generateAll(String regex) {
+		return this.generateAll(regex, null, null);
+	}
+
+	public List<String> generateAll(String regex, @Nullable Integer min, @Nullable Integer max) {
+		return this.generateAll(new Generex(regex), min, max);
+	}
+
+	private List<String> generateAll(Generex generex, @Nullable Integer min, @Nullable Integer max) {
+		if (min == null) {
+			min = 0;
+		}
+
+		if (max == null) {
+			max = 255;
+		}
+
+		Integer regexMin = min;
+		Integer regexMax = max;
+		List<String> result = generex.getMatchedStrings(100).stream()
+			.filter(it -> it.length() >= regexMin && it.length() <= regexMax)
+			.collect(toList());
+		Collections.shuffle(result);
+		return result;
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/plugin/JakartaValidationPlugin.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/plugin/JakartaValidationPlugin.java
@@ -1,0 +1,106 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.plugin;
+
+import java.util.Arrays;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
+import com.navercorp.fixturemonkey.api.plugin.Plugin;
+import com.navercorp.fixturemonkey.jakarta.validation.generator.JakartaValidationArbitraryContainerInfoGenerator;
+import com.navercorp.fixturemonkey.jakarta.validation.generator.JakartaValidationNullInjectGenerator;
+import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationBooleanIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationConstraintGenerator;
+import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationJavaArbitraryResolver;
+import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationJavaTimeArbitraryResolver;
+import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationTimeConstraintGenerator;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+public final class JakartaValidationPlugin implements Plugin {
+	private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
+	};
+	private JakartaValidationConstraintGenerator jakartaValidationConstraintGenerator =
+		new JakartaValidationConstraintGenerator();
+	private JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator =
+		new JavaTimeTypeArbitraryGenerator() {
+		};
+	private JakartaValidationTimeConstraintGenerator jakartaValidationTimeConstraintGenerator =
+		new JakartaValidationTimeConstraintGenerator();
+
+	public JakartaValidationPlugin javaTypeArbitraryGenerator(
+		JavaTypeArbitraryGenerator javaTypeArbitraryGenerator
+	) {
+		this.javaTypeArbitraryGenerator = javaTypeArbitraryGenerator;
+		return this;
+	}
+
+	public JakartaValidationPlugin validationConstraintGenerator(
+		JakartaValidationConstraintGenerator jakartaValidationConstraintGenerator
+	) {
+		this.jakartaValidationConstraintGenerator = jakartaValidationConstraintGenerator;
+		return this;
+	}
+
+	public JakartaValidationPlugin javaTimeTypeArbitraryGenerator(
+		JavaTimeTypeArbitraryGenerator javaTimeTypeArbitraryGenerator
+	) {
+		this.javaTimeTypeArbitraryGenerator = javaTimeTypeArbitraryGenerator;
+		return this;
+	}
+
+	public JakartaValidationPlugin validationTimeConstraintGenerator(
+		JakartaValidationTimeConstraintGenerator jakartaValidationTimeConstraintGenerator
+	) {
+		this.jakartaValidationTimeConstraintGenerator = jakartaValidationTimeConstraintGenerator;
+		return this;
+	}
+
+	@Override
+	public void accept(GenerateOptionsBuilder optionsBuilder) {
+		optionsBuilder
+			.defaultNullInjectGeneratorOperator(JakartaValidationNullInjectGenerator::new)
+			.insertFirstArbitraryContainerInfoGenerator(
+				prop -> true,
+				new JakartaValidationArbitraryContainerInfoGenerator()
+			)
+			.javaTypeArbitraryGenerator(javaTypeArbitraryGenerator)
+			.javaArbitraryResolver(
+				new JakartaValidationJavaArbitraryResolver(this.jakartaValidationConstraintGenerator)
+			)
+			.javaTimeTypeArbitraryGenerator(javaTimeTypeArbitraryGenerator)
+			.javaTimeArbitraryResolver(
+				new JakartaValidationJavaTimeArbitraryResolver(
+					this.jakartaValidationTimeConstraintGenerator
+				)
+			)
+			.priorityIntrospector(current ->
+				new CompositeArbitraryIntrospector(
+					Arrays.asList(
+						new JakartaValidationBooleanIntrospector(),
+						current
+					)
+				)
+			);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/plugin/JakartaValidationPlugin.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/plugin/JakartaValidationPlugin.java
@@ -36,7 +36,7 @@ import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValida
 import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationJavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.jakarta.validation.introspector.JakartaValidationTimeConstraintGenerator;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
+@API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationPlugin implements Plugin {
 	private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
 	};

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
@@ -1,0 +1,380 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+import net.jqwik.api.Property;
+
+import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.BigDecimalIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.BigIntegerIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.BooleanIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.ByteIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.CharacterIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.ContainerAnnotationIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.DoubleIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.FloatIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.IntIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.LongIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.NullAnnotationIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.ShortIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.StringIntrospectorSpec;
+import com.navercorp.fixturemonkey.jakarta.validation.spec.TimeIntrospectorSpec;
+
+class JakartaValidationFixtureMonkeyTest {
+	private static final LabMonkey SUT = LabMonkey.labMonkeyBuilder()
+		.plugin(new JakartaValidationPlugin())
+		.defaultNotNull(true)
+		.build();
+
+	@Property
+	void sampleBigDecimal() {
+		BigDecimalIntrospectorSpec actual = SUT.giveMeOne(BigDecimalIntrospectorSpec.class);
+
+		then(actual.getDigitsValue()).isBetween(BigDecimal.valueOf(-999), BigDecimal.valueOf(999));
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual.getDecimalMinExclusive()).isGreaterThan(BigDecimal.valueOf(100.1));
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(BigDecimal.valueOf(100.1));
+		then(actual.getDecimalMaxExclusive()).isLessThan(BigDecimal.valueOf(100.1));
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(BigDecimal.ZERO);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
+	}
+
+	@Property
+	void sampleBigInteger() {
+		BigIntegerIntrospectorSpec actual = SUT.giveMeOne(BigIntegerIntrospectorSpec.class);
+
+		then(actual.getDigitsValue()).isBetween(BigInteger.valueOf(-999), BigInteger.valueOf(999));
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual.getDecimalMinExclusive()).isGreaterThan(BigInteger.valueOf(100));
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(BigInteger.valueOf(100));
+		then(actual.getDecimalMaxExclusive()).isLessThan(BigInteger.valueOf(100));
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(BigInteger.ZERO);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigInteger.ZERO);
+	}
+
+	@Property
+	void sampleBoolean() {
+		BooleanIntrospectorSpec actual = SUT.giveMeOne(BooleanIntrospectorSpec.class);
+
+		then(actual.isBoolValue()).isIn(true, false);
+		then(actual.isAssertFalse()).isFalse();
+		then(actual.isAssertTrue()).isTrue();
+	}
+
+	@Property
+	void sampleByte() {
+		ByteIntrospectorSpec actual = SUT.giveMeOne(ByteIntrospectorSpec.class);
+
+		then(actual.getByteValue()).isBetween(Byte.MIN_VALUE, Byte.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween((byte)-99, (byte)99);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo((byte)100);
+		then(actual.getDecimalMinExclusive()).isGreaterThan((byte)100);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo((byte)100);
+		then(actual.getDecimalMaxExclusive()).isLessThan((byte)100);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo((byte)0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((byte)0);
+	}
+
+	@Property
+	void sampleCharacter() {
+		CharacterIntrospectorSpec actual = SUT.giveMeOne(CharacterIntrospectorSpec.class);
+
+		then(actual.getCharacter()).isBetween(Character.MIN_VALUE, Character.MAX_VALUE);
+	}
+
+	@Property
+	void sampleDouble() {
+		DoubleIntrospectorSpec actual = SUT.giveMeOne(DoubleIntrospectorSpec.class);
+
+		then(actual.getDoubleValue()).isBetween(-Double.MAX_VALUE, Double.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween(-999d, 999d);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(100.1d);
+		then(actual.getDecimalMinExclusive()).isGreaterThan(100.1d);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(100.1d);
+		then(actual.getDecimalMaxExclusive()).isLessThanOrEqualTo(100.1d);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void sampleFloat() {
+		FloatIntrospectorSpec actual = SUT.giveMeOne(FloatIntrospectorSpec.class);
+
+		then(actual.getFloatValue()).isBetween(-Float.MAX_VALUE, Float.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween(-999f, 999f);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(100.1f);
+		then(actual.getDecimalMinExclusive()).isGreaterThan(100.1f);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(100.1f);
+		then(actual.getDecimalMaxExclusive()).isLessThan(1001.f);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void sampleInt() {
+		IntIntrospectorSpec actual = SUT.giveMeOne(IntIntrospectorSpec.class);
+
+		then(actual.getIntValue()).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween(-999, 999);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(100);
+		then(actual.getDecimalMinExclusive()).isGreaterThan(100);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(100);
+		then(actual.getDecimalMaxExclusive()).isLessThan(100);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void sampleLong() {
+		LongIntrospectorSpec actual = SUT.giveMeOne(LongIntrospectorSpec.class);
+
+		then(actual.getLongValue()).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween(-999L, 999L);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo(100);
+		then(actual.getDecimalMinExclusive()).isGreaterThan(100);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo(100);
+		then(actual.getDecimalMaxExclusive()).isLessThan(100);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo(0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Property
+	void sampleShort() {
+		ShortIntrospectorSpec actual = SUT.giveMeOne(ShortIntrospectorSpec.class);
+
+		then(actual.getShortValue()).isBetween(Short.MIN_VALUE, Short.MAX_VALUE);
+		then(actual.getDigitsValue()).isBetween((short)-999, (short)999);
+		then(actual.getDecimalMin()).isGreaterThanOrEqualTo((short)100);
+		then(actual.getDecimalMinExclusive()).isGreaterThan((short)100);
+		then(actual.getDecimalMax()).isLessThanOrEqualTo((short)100);
+		then(actual.getDecimalMaxExclusive()).isLessThan((short)100);
+		then(actual.getNegative()).isNegative();
+		then(actual.getNegativeOrZero()).isLessThanOrEqualTo((short)0);
+		then(actual.getPositive()).isPositive();
+		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((short)0);
+	}
+
+	@Property
+	void sampleString() {
+		StringIntrospectorSpec actual = SUT.giveMeOne(StringIntrospectorSpec.class);
+
+		then(actual.getNotBlank()).isNotBlank();
+		then(actual.getNotEmpty()).isNotEmpty();
+		then(actual.getSize()).hasSizeBetween(5, 10);
+		then(actual.getDigits()).hasSizeLessThanOrEqualTo(10);
+		thenNoException().isThrownBy(() -> Long.parseLong(actual.getDigits()));
+		Pattern pattern = Pattern.compile("[e-o]");
+		then(pattern.asPredicate().test(actual.getPattern())).isTrue();
+		for (int i = 0; i < actual.getPattern().length(); i++) {
+			char ch = actual.getPattern().charAt(i);
+			then(ch).isBetween('e', 'o');
+		}
+		then(actual.getEmail()).containsOnlyOnce("@");
+	}
+
+	@Property
+	void sampleCalendar() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		Calendar now = Calendar.getInstance();
+		then(actual.getCalendarPast().toInstant().toEpochMilli()).isLessThan(now.toInstant().toEpochMilli());
+		then(actual.getCalendarPastOrPresent().getTimeInMillis()).isLessThanOrEqualTo(now.toInstant().toEpochMilli());
+		then(actual.getCalendarFuture().getTimeInMillis()).isGreaterThan(now.toInstant().toEpochMilli());
+		then(actual.getCalendarFutureOrPresent().getTimeInMillis())
+			.isGreaterThanOrEqualTo(now.toInstant().toEpochMilli());
+	}
+
+	@Property
+	void sampleDate() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		Date now = new Date();
+		then(actual.getDatePast().getTime()).isLessThan(now.getTime());
+		then(actual.getDatePastOrPresent().getTime()).isLessThanOrEqualTo(now.getTime());
+		then(actual.getDateFuture().getTime()).isGreaterThan(now.getTime());
+		then(actual.getDateFutureOrPresent().getTime()).isGreaterThanOrEqualTo(now.getTime());
+	}
+
+	@Property
+	void sampleInstant() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		Instant now = Instant.now();
+		then(actual.getInstantPast()).isBefore(now);
+		then(actual.getInstantPastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getInstantFuture()).isAfter(now);
+		then(actual.getInstantFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleLocalDate() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		LocalDate now = LocalDate.now();
+		then(actual.getLocalDatePast()).isBefore(now);
+		then(actual.getLocalDatePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getLocalDateFuture()).isAfter(now);
+		then(actual.getLocalDateFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleLocalDateTime() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		LocalDateTime now = LocalDateTime.now();
+		then(actual.getLocalDateTimePast()).isBefore(now);
+		then(actual.getLocalDateTimePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getLocalDateTimeFuture()).isAfter(now);
+		then(actual.getLocalDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleLocalTime() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		LocalTime now = LocalTime.now();
+		then(actual.getLocalTimePast()).isBefore(now);
+		then(actual.getLocalTimePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getLocalTimeFuture()).isAfter(now);
+		then(actual.getLocalTimeFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleZonedDateTime() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		ZonedDateTime now = ZonedDateTime.now();
+		then(actual.getZonedDateTimePast()).isBefore(now);
+		then(actual.getZonedDateTimePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getZonedDateTimeFuture()).isAfter(now);
+		then(actual.getZonedDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleMonthDay() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		MonthDay now = MonthDay.now();
+		then(actual.getMonthDayPast()).isLessThan(now);
+		then(actual.getMonthDayPastOrPresent()).isLessThanOrEqualTo(now);
+		then(actual.getMonthDayFuture()).isGreaterThan(now);
+		then(actual.getMonthDayFutureOrPresent()).isGreaterThanOrEqualTo(now);
+	}
+
+	@Property
+	void sampleOffsetDateTime() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		OffsetDateTime now = OffsetDateTime.now();
+		then(actual.getOffsetDateTimePast()).isBefore(now);
+		then(actual.getOffsetDateTimePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getOffsetDateTimeFuture()).isAfter(now);
+		then(actual.getOffsetDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleOffsetTime() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		OffsetTime now = OffsetTime.now();
+		then(actual.getOffsetTimePast()).isBefore(now);
+		then(actual.getOffsetTimePastOrPresent()).isBeforeOrEqualTo(now);
+		then(actual.getOffsetTimeFuture()).isAfter(now);
+		then(actual.getOffsetTimeFutureOrPresent()).isAfterOrEqualTo(now);
+	}
+
+	@Property
+	void sampleYear() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		Year now = Year.now();
+		then(actual.getYearPast()).isLessThan(now);
+		then(actual.getYearPastOrPresent()).isLessThanOrEqualTo(now);
+		then(actual.getYearFuture()).isGreaterThan(now);
+		then(actual.getYearFutureOrPresent()).isGreaterThanOrEqualTo(now);
+	}
+
+	@Property
+	void sampleYearMonth() {
+		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
+
+		YearMonth now = YearMonth.now();
+		then(actual.getYearMonthPast()).isLessThan(now);
+		then(actual.getYearMonthPastOrPresent()).isLessThanOrEqualTo(now);
+		then(actual.getYearMonthFuture()).isGreaterThan(now);
+		then(actual.getYearMonthFutureOrPresent()).isGreaterThanOrEqualTo(now);
+	}
+
+	@Property
+	void sampleNullAnnotations() {
+		NullAnnotationIntrospectorSpec actual = SUT.giveMeOne(NullAnnotationIntrospectorSpec.class);
+
+		then(actual.getNullValue()).isNull();
+		then(actual.getNotNull()).isNotNull();
+		then(actual.getNotBlank()).isNotBlank();
+		then(actual.getNotEmpty()).isNotEmpty();
+		then(actual.getNotEmptyContainer()).isNotEmpty();
+	}
+
+	@Property
+	void sampleContainerAnnotations() {
+		ContainerAnnotationIntrospectorSpec actual = SUT.giveMeOne(ContainerAnnotationIntrospectorSpec.class);
+
+		then(actual.getDefaultSizeContainer()).hasSizeBetween(0, 3);
+		then(actual.getSizeContainer()).hasSizeBetween(5, 10);
+		then(actual.getMinSizeContainer()).hasSizeGreaterThanOrEqualTo(3);
+		then(actual.getMaxSizeContainer()).hasSizeLessThanOrEqualTo(5);
+		then(actual.getNotEmptyContainer()).isNotEmpty();
+		then(actual.getNotEmptyAndMaxSizeContainer()).hasSizeBetween(1, 5);
+	}
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
@@ -32,6 +32,8 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
@@ -62,7 +64,10 @@ class JakartaValidationFixtureMonkeyTest {
 		.defaultNotNull(true)
 		.build();
 
-	@Property
+	private static final ZoneId ZONED_ID = ZoneId.systemDefault();
+	private static final ZoneOffset ZONE_OFFSET = ZoneOffset.UTC;
+
+	@Property(tries = 100)
 	void sampleBigDecimal() {
 		BigDecimalIntrospectorSpec actual = SUT.giveMeOne(BigDecimalIntrospectorSpec.class);
 
@@ -77,7 +82,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleBigInteger() {
 		BigIntegerIntrospectorSpec actual = SUT.giveMeOne(BigIntegerIntrospectorSpec.class);
 
@@ -92,7 +97,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigInteger.ZERO);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleBoolean() {
 		BooleanIntrospectorSpec actual = SUT.giveMeOne(BooleanIntrospectorSpec.class);
 
@@ -101,7 +106,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.isAssertTrue()).isTrue();
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleByte() {
 		ByteIntrospectorSpec actual = SUT.giveMeOne(ByteIntrospectorSpec.class);
 
@@ -117,14 +122,14 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((byte)0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleCharacter() {
 		CharacterIntrospectorSpec actual = SUT.giveMeOne(CharacterIntrospectorSpec.class);
 
 		then(actual.getCharacter()).isBetween(Character.MIN_VALUE, Character.MAX_VALUE);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleDouble() {
 		DoubleIntrospectorSpec actual = SUT.giveMeOne(DoubleIntrospectorSpec.class);
 
@@ -140,7 +145,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleFloat() {
 		FloatIntrospectorSpec actual = SUT.giveMeOne(FloatIntrospectorSpec.class);
 
@@ -156,7 +161,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleInt() {
 		IntIntrospectorSpec actual = SUT.giveMeOne(IntIntrospectorSpec.class);
 
@@ -172,7 +177,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLong() {
 		LongIntrospectorSpec actual = SUT.giveMeOne(LongIntrospectorSpec.class);
 
@@ -188,7 +193,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleShort() {
 		ShortIntrospectorSpec actual = SUT.giveMeOne(ShortIntrospectorSpec.class);
 
@@ -204,7 +209,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((short)0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleString() {
 		StringIntrospectorSpec actual = SUT.giveMeOne(StringIntrospectorSpec.class);
 
@@ -222,7 +227,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getEmail()).containsOnlyOnce("@");
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleCalendar() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -234,7 +239,7 @@ class JakartaValidationFixtureMonkeyTest {
 			.isGreaterThanOrEqualTo(now.toInstant().toEpochMilli());
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleDate() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -245,7 +250,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getDateFutureOrPresent().getTime()).isGreaterThanOrEqualTo(now.getTime());
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleInstant() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -256,7 +261,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getInstantFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalDate() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -267,7 +272,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getLocalDateFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -278,29 +283,29 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getLocalDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalTime() {
+		LocalTime now = LocalTime.now();
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		LocalTime now = LocalTime.now();
 		then(actual.getLocalTimePast()).isBefore(now);
 		then(actual.getLocalTimePastOrPresent()).isBeforeOrEqualTo(now);
 		then(actual.getLocalTimeFuture()).isAfter(now);
 		then(actual.getLocalTimeFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleZonedDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		ZonedDateTime now = ZonedDateTime.now();
-		then(actual.getZonedDateTimePast()).isBefore(now);
-		then(actual.getZonedDateTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getZonedDateTimeFuture()).isAfter(now);
-		then(actual.getZonedDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		ZonedDateTime now = ZonedDateTime.now().withZoneSameLocal(ZONED_ID);
+		then(actual.getZonedDateTimePast().withZoneSameLocal(ZONED_ID)).isBefore(now);
+		then(actual.getZonedDateTimePastOrPresent().withZoneSameLocal(ZONED_ID)).isBeforeOrEqualTo(now);
+		then(actual.getZonedDateTimeFuture().withZoneSameLocal(ZONED_ID)).isAfter(now);
+		then(actual.getZonedDateTimeFutureOrPresent().withZoneSameLocal(ZONED_ID)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleMonthDay() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -311,29 +316,29 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getMonthDayFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleOffsetDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		OffsetDateTime now = OffsetDateTime.now();
-		then(actual.getOffsetDateTimePast()).isBefore(now);
-		then(actual.getOffsetDateTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getOffsetDateTimeFuture()).isAfter(now);
-		then(actual.getOffsetDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		OffsetDateTime now = OffsetDateTime.now().withOffsetSameLocal(ZONE_OFFSET);
+		then(actual.getOffsetDateTimePast().withOffsetSameLocal(ZONE_OFFSET)).isBefore(now);
+		then(actual.getOffsetDateTimePastOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isBeforeOrEqualTo(now);
+		then(actual.getOffsetDateTimeFuture().withOffsetSameLocal(ZONE_OFFSET)).isAfter(now);
+		then(actual.getOffsetDateTimeFutureOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleOffsetTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		OffsetTime now = OffsetTime.now();
-		then(actual.getOffsetTimePast()).isBefore(now);
-		then(actual.getOffsetTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getOffsetTimeFuture()).isAfter(now);
-		then(actual.getOffsetTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		OffsetTime now = OffsetTime.now().withOffsetSameLocal(ZONE_OFFSET);
+		then(actual.getOffsetTimePast().withOffsetSameLocal(ZONE_OFFSET)).isBefore(now);
+		then(actual.getOffsetTimePastOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isBeforeOrEqualTo(now);
+		then(actual.getOffsetTimeFuture().withOffsetSameLocal(ZONE_OFFSET)).isAfter(now);
+		then(actual.getOffsetTimeFutureOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleYear() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -344,7 +349,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getYearFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleYearMonth() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -355,7 +360,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getYearMonthFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleNullAnnotations() {
 		NullAnnotationIntrospectorSpec actual = SUT.giveMeOne(NullAnnotationIntrospectorSpec.class);
 
@@ -366,7 +371,7 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getNotEmptyContainer()).isNotEmpty();
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleContainerAnnotations() {
 		ContainerAnnotationIntrospectorSpec actual = SUT.giveMeOne(ContainerAnnotationIntrospectorSpec.class);
 

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BigDecimalIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BigDecimalIntrospectorSpec.java
@@ -1,0 +1,54 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BigDecimalIntrospectorSpec {
+	private BigDecimal bigDecimalValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private BigDecimal digitsValue;
+
+	@Min(100)
+	private BigDecimal minValue;
+
+	@Max(100)
+	private BigDecimal maxValue;
+
+	@DecimalMin(value = "100.1")
+	private BigDecimal decimalMin;
+
+	@DecimalMin(value = "100.1", inclusive = false)
+	private BigDecimal decimalMinExclusive;
+
+	@DecimalMax(value = "100.1")
+	private BigDecimal decimalMax;
+
+	@DecimalMax(value = "100.1", inclusive = false)
+	private BigDecimal decimalMaxExclusive;
+
+	@Negative
+	private BigDecimal negative;
+
+	@NegativeOrZero
+	private BigDecimal negativeOrZero;
+
+	@Positive
+	private BigDecimal positive;
+
+	@PositiveOrZero
+	private BigDecimal positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BigIntegerIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BigIntegerIntrospectorSpec.java
@@ -1,0 +1,54 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import java.math.BigInteger;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BigIntegerIntrospectorSpec {
+	private BigInteger bigIntegerValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private BigInteger digitsValue;
+
+	@Min(100)
+	private BigInteger minValue;
+
+	@Max(100)
+	private BigInteger maxValue;
+
+	@DecimalMin(value = "100")
+	private BigInteger decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private BigInteger decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private BigInteger decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private BigInteger decimalMaxExclusive;
+
+	@Negative
+	private BigInteger negative;
+
+	@NegativeOrZero
+	private BigInteger negativeOrZero;
+
+	@Positive
+	private BigInteger positive;
+
+	@PositiveOrZero
+	private BigInteger positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BooleanIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/BooleanIntrospectorSpec.java
@@ -1,0 +1,36 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BooleanIntrospectorSpec {
+	private boolean boolValue;
+
+	@AssertTrue
+	private boolean assertTrue;
+
+	@AssertFalse
+	private boolean assertFalse;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ByteIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ByteIntrospectorSpec.java
@@ -1,0 +1,70 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ByteIntrospectorSpec {
+	private byte byteValue;
+
+	@Digits(integer = 2, fraction = 0)
+	private byte digitsValue;
+
+	@Min(100)
+	private byte minValue;
+
+	@Max(100)
+	private byte maxValue;
+
+	@DecimalMin(value = "100")
+	private byte decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private byte decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private byte decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private byte decimalMaxExclusive;
+
+	@Negative
+	private byte negative;
+
+	@NegativeOrZero
+	private byte negativeOrZero;
+
+	@Positive
+	private byte positive;
+
+	@PositiveOrZero
+	private byte positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/CharacterIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/CharacterIntrospectorSpec.java
@@ -1,0 +1,28 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CharacterIntrospectorSpec {
+	char character;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ContainerAnnotationIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ContainerAnnotationIntrospectorSpec.java
@@ -1,0 +1,33 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ContainerAnnotationIntrospectorSpec {
+	private List<String> container;
+
+	@Size
+	private List<String> defaultSizeContainer;
+
+	@Size(min = 5, max = 10)
+	private List<String> sizeContainer;
+
+	@Size(min = 3)
+	private List<String> minSizeContainer;
+
+	@Size(max = 5)
+	private List<String> maxSizeContainer;
+
+	@NotEmpty
+	private List<String> notEmptyContainer;
+
+	@Size(max = 5)
+	@NotEmpty
+	private List<String> notEmptyAndMaxSizeContainer;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/DoubleIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/DoubleIntrospectorSpec.java
@@ -1,0 +1,52 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DoubleIntrospectorSpec {
+	private double doubleValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private double digitsValue;
+
+	@Min(100)
+	private double minValue;
+
+	@Max(100)
+	private double maxValue;
+
+	@DecimalMin(value = "100.1")
+	private double decimalMin;
+
+	@DecimalMin(value = "100.1", inclusive = false)
+	private double decimalMinExclusive;
+
+	@DecimalMax(value = "100.1")
+	private double decimalMax;
+
+	@DecimalMax(value = "100.1", inclusive = false)
+	private double decimalMaxExclusive;
+
+	@Negative
+	private double negative;
+
+	@NegativeOrZero
+	private double negativeOrZero;
+
+	@Positive
+	private double positive;
+
+	@PositiveOrZero
+	private double positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/FloatIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/FloatIntrospectorSpec.java
@@ -1,0 +1,52 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FloatIntrospectorSpec {
+	private float floatValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private float digitsValue;
+
+	@Min(100)
+	private float minValue;
+
+	@Max(100)
+	private float maxValue;
+
+	@DecimalMin(value = "100.1")
+	private float decimalMin;
+
+	@DecimalMin(value = "100.1", inclusive = false)
+	private float decimalMinExclusive;
+
+	@DecimalMax(value = "100.1")
+	private float decimalMax;
+
+	@DecimalMax(value = "100.1", inclusive = false)
+	private float decimalMaxExclusive;
+
+	@Negative
+	private float negative;
+
+	@NegativeOrZero
+	private float negativeOrZero;
+
+	@Positive
+	private float positive;
+
+	@PositiveOrZero
+	private float positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/IntIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/IntIntrospectorSpec.java
@@ -1,0 +1,70 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IntIntrospectorSpec {
+	private int intValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private int digitsValue;
+
+	@Min(100)
+	private int minValue;
+
+	@Max(100)
+	private int maxValue;
+
+	@DecimalMin(value = "100")
+	private int decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private int decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private int decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private int decimalMaxExclusive;
+
+	@Negative
+	private int negative;
+
+	@NegativeOrZero
+	private int negativeOrZero;
+
+	@Positive
+	private int positive;
+
+	@PositiveOrZero
+	private int positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/LongIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/LongIntrospectorSpec.java
@@ -1,0 +1,52 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LongIntrospectorSpec {
+	private long longValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private long digitsValue;
+
+	@Min(100)
+	private long minValue;
+
+	@Max(100)
+	private long maxValue;
+
+	@DecimalMin(value = "100")
+	private long decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private long decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private long decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private long decimalMaxExclusive;
+
+	@Negative
+	private long negative;
+
+	@NegativeOrZero
+	private long negativeOrZero;
+
+	@Positive
+	private long positive;
+
+	@PositiveOrZero
+	private long positiveOrZero;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/NullAnnotationIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/NullAnnotationIntrospectorSpec.java
@@ -1,0 +1,31 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NullAnnotationIntrospectorSpec {
+	@Null
+	private String nullValue;
+
+	@NotNull
+	private String notNull;
+
+	@NotBlank
+	private String notBlank;
+
+	@NotEmpty
+	private String notEmpty;
+
+	private String defaultValue;
+
+	@NotEmpty
+	private List<String> notEmptyContainer;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ShortIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/ShortIntrospectorSpec.java
@@ -1,0 +1,73 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ShortIntrospectorSpec {
+	private short shortValue;
+
+	@Digits(integer = 3, fraction = 0)
+	private short digitsValue;
+
+	@Min(100)
+	private short minValue;
+
+	@Max(100)
+	private short maxValue;
+
+	@DecimalMin(value = "100")
+	private short decimalMin;
+
+	@DecimalMin(value = "100", inclusive = false)
+	private short decimalMinExclusive;
+
+	@DecimalMax(value = "100")
+	private short decimalMax;
+
+	@DecimalMax(value = "100", inclusive = false)
+	private short decimalMaxExclusive;
+
+	@Negative
+	private short negative;
+
+	@NegativeOrZero
+	private short negativeOrZero;
+
+	@Positive
+	private short positive;
+
+	@PositiveOrZero
+	private short positiveOrZero;
+
+	@Digits(integer = 20, fraction = 0)
+	private short overflow;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/StringIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/StringIntrospectorSpec.java
@@ -1,0 +1,53 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StringIntrospectorSpec {
+	private String str;
+
+	@NotBlank
+	private String notBlank;
+
+	@NotEmpty
+	private String notEmpty;
+
+	@Size(min = 5, max = 10)
+	private String size;
+
+	@Digits(integer = 10, fraction = 0)
+	private String digits;
+
+	@Pattern(regexp = "[e-o]")
+	@NotBlank
+	private String pattern;
+
+	@Email
+	private String email;
+}

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/TimeIntrospectorSpec.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/spec/TimeIntrospectorSpec.java
@@ -1,0 +1,202 @@
+package com.navercorp.fixturemonkey.jakarta.validation.spec;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TimeIntrospectorSpec {
+	private Calendar calendar;
+
+	@Past
+	private Calendar calendarPast;
+
+	@PastOrPresent
+	private Calendar calendarPastOrPresent;
+
+	@Future
+	private Calendar calendarFuture;
+
+	@FutureOrPresent
+	private Calendar calendarFutureOrPresent;
+
+	private Date date;
+
+	@Past
+	private Date datePast;
+
+	@PastOrPresent
+	private Date datePastOrPresent;
+
+	@Future
+	private Date dateFuture;
+
+	@FutureOrPresent
+	private Date dateFutureOrPresent;
+
+	private Instant instant;
+
+	@Past
+	private Instant instantPast;
+
+	@PastOrPresent
+	private Instant instantPastOrPresent;
+
+	@Future
+	private Instant instantFuture;
+
+	@FutureOrPresent
+	private Instant instantFutureOrPresent;
+
+	private LocalDate localDate;
+
+	@Past
+	private LocalDate localDatePast;
+
+	@PastOrPresent
+	private LocalDate localDatePastOrPresent;
+
+	@Future
+	private LocalDate localDateFuture;
+
+	@FutureOrPresent
+	private LocalDate localDateFutureOrPresent;
+
+	private LocalDateTime localDateTime;
+
+	@Past
+	private LocalDateTime localDateTimePast;
+
+	@PastOrPresent
+	private LocalDateTime localDateTimePastOrPresent;
+
+	@Future
+	private LocalDateTime localDateTimeFuture;
+
+	@FutureOrPresent
+	private LocalDateTime localDateTimeFutureOrPresent;
+
+	private LocalTime localTime;
+
+	@Past
+	private LocalTime localTimePast;
+
+	@PastOrPresent
+	private LocalTime localTimePastOrPresent;
+
+	@Future
+	private LocalTime localTimeFuture;
+
+	@FutureOrPresent
+	private LocalTime localTimeFutureOrPresent;
+
+	private ZonedDateTime zonedDateTime;
+
+	@Past
+	private ZonedDateTime zonedDateTimePast;
+
+	@PastOrPresent
+	private ZonedDateTime zonedDateTimePastOrPresent;
+
+	@Future
+	private ZonedDateTime zonedDateTimeFuture;
+
+	@FutureOrPresent
+	private ZonedDateTime zonedDateTimeFutureOrPresent;
+
+	private MonthDay monthDay;
+
+	@Past
+	private MonthDay monthDayPast;
+
+	@PastOrPresent
+	private MonthDay monthDayPastOrPresent;
+
+	@Future
+	private MonthDay monthDayFuture;
+
+	@FutureOrPresent
+	private MonthDay monthDayFutureOrPresent;
+
+	private OffsetDateTime offsetDateTime;
+
+	@Past
+	private OffsetDateTime offsetDateTimePast;
+
+	@PastOrPresent
+	private OffsetDateTime offsetDateTimePastOrPresent;
+
+	@Future
+	private OffsetDateTime offsetDateTimeFuture;
+
+	@FutureOrPresent
+	private OffsetDateTime offsetDateTimeFutureOrPresent;
+
+	private OffsetTime offsetTime;
+
+	@Past
+	private OffsetTime offsetTimePast;
+
+	@PastOrPresent
+	private OffsetTime offsetTimePastOrPresent;
+
+	@Future
+	private OffsetTime offsetTimeFuture;
+
+	@FutureOrPresent
+	private OffsetTime offsetTimeFutureOrPresent;
+
+	private Year year;
+
+	@Past
+	private Year yearPast;
+
+	@PastOrPresent
+	private Year yearPastOrPresent;
+
+	@Future
+	private Year yearFuture;
+
+	@FutureOrPresent
+	private Year yearFutureOrPresent;
+
+	private YearMonth yearMonth;
+
+	@Past
+	private YearMonth yearMonthPast;
+
+	@PastOrPresent
+	private YearMonth yearMonthPastOrPresent;
+
+	@Future
+	private YearMonth yearMonthFuture;
+
+	@FutureOrPresent
+	private YearMonth yearMonthFutureOrPresent;
+
+	private Period period;
+
+	private Duration duration;
+
+	private ZoneOffset zoneOffset;
+}

--- a/fixture-monkey-jakarta-validation/src/test/lombok.config
+++ b/fixture-monkey-jakarta-validation/src/test/lombok.config
@@ -1,0 +1,1 @@
+lombok.anyConstructor.addConstructorProperties=true

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationYearConstraint.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationYearConstraint.java
@@ -22,6 +22,10 @@ import java.time.Year;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationYearConstraint {
 	@Nullable
 	private final Year min;

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationYearMonthConstraint.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationYearMonthConstraint.java
@@ -22,6 +22,10 @@ import java.time.YearMonth;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationYearMonthConstraint {
 	@Nullable
 	private final YearMonth min;

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
@@ -32,6 +32,8 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
@@ -62,7 +64,10 @@ class JavaxValidationFixtureMonkeyTest {
 		.defaultNotNull(true)
 		.build();
 
-	@Property
+	private static final ZoneId ZONED_ID = ZoneId.systemDefault();
+	private static final ZoneOffset ZONE_OFFSET = ZoneOffset.UTC;
+
+	@Property(tries = 100)
 	void sampleBigDecimal() {
 		BigDecimalIntrospectorSpec actual = SUT.giveMeOne(BigDecimalIntrospectorSpec.class);
 
@@ -77,7 +82,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleBigInteger() {
 		BigIntegerIntrospectorSpec actual = SUT.giveMeOne(BigIntegerIntrospectorSpec.class);
 
@@ -92,7 +97,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(BigInteger.ZERO);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleBoolean() {
 		BooleanIntrospectorSpec actual = SUT.giveMeOne(BooleanIntrospectorSpec.class);
 
@@ -101,7 +106,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.isAssertTrue()).isTrue();
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleByte() {
 		ByteIntrospectorSpec actual = SUT.giveMeOne(ByteIntrospectorSpec.class);
 
@@ -117,14 +122,14 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((byte)0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleCharacter() {
 		CharacterIntrospectorSpec actual = SUT.giveMeOne(CharacterIntrospectorSpec.class);
 
 		then(actual.getCharacter()).isBetween(Character.MIN_VALUE, Character.MAX_VALUE);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleDouble() {
 		DoubleIntrospectorSpec actual = SUT.giveMeOne(DoubleIntrospectorSpec.class);
 
@@ -140,7 +145,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleFloat() {
 		FloatIntrospectorSpec actual = SUT.giveMeOne(FloatIntrospectorSpec.class);
 
@@ -156,7 +161,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleInt() {
 		IntIntrospectorSpec actual = SUT.giveMeOne(IntIntrospectorSpec.class);
 
@@ -172,7 +177,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLong() {
 		LongIntrospectorSpec actual = SUT.giveMeOne(LongIntrospectorSpec.class);
 
@@ -188,7 +193,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo(0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleShort() {
 		ShortIntrospectorSpec actual = SUT.giveMeOne(ShortIntrospectorSpec.class);
 
@@ -204,7 +209,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getPositiveOrZero()).isGreaterThanOrEqualTo((short)0);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleString() {
 		StringIntrospectorSpec actual = SUT.giveMeOne(StringIntrospectorSpec.class);
 
@@ -222,7 +227,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getEmail()).containsOnlyOnce("@");
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleCalendar() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -234,7 +239,7 @@ class JavaxValidationFixtureMonkeyTest {
 			.isGreaterThanOrEqualTo(now.toInstant().toEpochMilli());
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleDate() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -245,7 +250,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getDateFutureOrPresent().getTime()).isGreaterThanOrEqualTo(now.getTime());
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleInstant() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -256,7 +261,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getInstantFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalDate() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -267,7 +272,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getLocalDateFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -278,29 +283,29 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getLocalDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleLocalTime() {
+		LocalTime now = LocalTime.now(); // to fix @Future latency
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		LocalTime now = LocalTime.now();
 		then(actual.getLocalTimePast()).isBefore(now);
 		then(actual.getLocalTimePastOrPresent()).isBeforeOrEqualTo(now);
 		then(actual.getLocalTimeFuture()).isAfter(now);
 		then(actual.getLocalTimeFutureOrPresent()).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleZonedDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		ZonedDateTime now = ZonedDateTime.now();
-		then(actual.getZonedDateTimePast()).isBefore(now);
-		then(actual.getZonedDateTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getZonedDateTimeFuture()).isAfter(now);
-		then(actual.getZonedDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		ZonedDateTime now = ZonedDateTime.now().withZoneSameLocal(ZONED_ID);
+		then(actual.getZonedDateTimePast().withZoneSameLocal(ZONED_ID)).isBefore(now);
+		then(actual.getZonedDateTimePastOrPresent().withZoneSameLocal(ZONED_ID)).isBeforeOrEqualTo(now);
+		then(actual.getZonedDateTimeFuture().withZoneSameLocal(ZONED_ID)).isAfter(now);
+		then(actual.getZonedDateTimeFutureOrPresent().withZoneSameLocal(ZONED_ID)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleMonthDay() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -311,29 +316,29 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getMonthDayFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleOffsetDateTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		OffsetDateTime now = OffsetDateTime.now();
-		then(actual.getOffsetDateTimePast()).isBefore(now);
-		then(actual.getOffsetDateTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getOffsetDateTimeFuture()).isAfter(now);
-		then(actual.getOffsetDateTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		OffsetDateTime now = OffsetDateTime.now().withOffsetSameLocal(ZONE_OFFSET);
+		then(actual.getOffsetDateTimePast().withOffsetSameLocal(ZONE_OFFSET)).isBefore(now);
+		then(actual.getOffsetDateTimePastOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isBeforeOrEqualTo(now);
+		then(actual.getOffsetDateTimeFuture().withOffsetSameLocal(ZONE_OFFSET)).isAfter(now);
+		then(actual.getOffsetDateTimeFutureOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleOffsetTime() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
-		OffsetTime now = OffsetTime.now();
-		then(actual.getOffsetTimePast()).isBefore(now);
-		then(actual.getOffsetTimePastOrPresent()).isBeforeOrEqualTo(now);
-		then(actual.getOffsetTimeFuture()).isAfter(now);
-		then(actual.getOffsetTimeFutureOrPresent()).isAfterOrEqualTo(now);
+		OffsetTime now = OffsetTime.now().withOffsetSameLocal(ZONE_OFFSET);
+		then(actual.getOffsetTimePast().withOffsetSameLocal(ZONE_OFFSET)).isBefore(now);
+		then(actual.getOffsetTimePastOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isBeforeOrEqualTo(now);
+		then(actual.getOffsetTimeFuture().withOffsetSameLocal(ZONE_OFFSET)).isAfter(now);
+		then(actual.getOffsetTimeFutureOrPresent().withOffsetSameLocal(ZONE_OFFSET)).isAfterOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleYear() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -344,7 +349,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getYearFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleYearMonth() {
 		TimeIntrospectorSpec actual = SUT.giveMeOne(TimeIntrospectorSpec.class);
 
@@ -355,7 +360,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getYearMonthFutureOrPresent()).isGreaterThanOrEqualTo(now);
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleNullAnnotations() {
 		NullAnnotationIntrospectorSpec actual = SUT.giveMeOne(NullAnnotationIntrospectorSpec.class);
 
@@ -366,7 +371,7 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getNotEmptyContainer()).isNotEmpty();
 	}
 
-	@Property
+	@Property(tries = 100)
 	void sampleContainerAnnotations() {
 		ContainerAnnotationIntrospectorSpec actual = SUT.giveMeOne(ContainerAnnotationIntrospectorSpec.class);
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,3 +11,4 @@ include "fixture-monkey-mockito"
 include "fixture-monkey-starter"
 include "fixture-monkey-starter-kotlin"
 include "fixture-monkey-junit-jupiter"
+include 'fixture-monkey-jakarta-validation'


### PR DESCRIPTION
## Summary
Add fixture-monkey-jakarta-validation

Related to #16 
## (Optional): Description
fixture-monkey-javax-validation 를 그대로 가져와서 아래 항목을 반영했습니다.
- javax.validation => jakarta.validation 으로 변경
- 파일명/메소드명 등을 javax => jakarta 로 변경
- 이외 로직 변경은 없습니다.


## How Has This Been Tested?
DateTime 관련한 테스트가 몇개 실패하는데 원인을 못찾았습니다.. 도움을 받을 수 있을까 하여 우선 draft 로 올립니다!
실패 테스트 : `JakartaValidationFixtureMonkeyTest` 의 `sampleOffsetDateTime`, `sampleOffsetTime`, `sampleZonedDateTime`