### PR TITLE
Add JoinableExpressionGenerator interface

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorExtensions.kt
@@ -1,0 +1,369 @@
+@file:Suppress("unused")
+
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder
+import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
+import java.util.function.Predicate
+import java.util.function.Supplier
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KProperty1
+
+fun <T> ArbitraryBuilder<T>.setExp(expressionGenerator: ExpressionGenerator, value: Any?): ArbitraryBuilder<T> =
+    this.set(expressionGenerator, value)
+
+fun <T> ArbitraryBuilder<T>.setExp(
+    expressionGenerator: ExpressionGenerator,
+    value: Any?,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.set(expressionGenerator, value, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setExpGetter(expressionGenerator: ExpressionGenerator, value: Any?): ArbitraryBuilder<T> =
+    this.set(expressionGenerator, value)
+
+fun <T> ArbitraryBuilder<T>.setExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    value: Any?,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.set(expressionGenerator, value, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
+    this.setNull(expressionGenerator)
+
+fun <T> ArbitraryBuilder<T>.setNullExpGetter(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
+    this.setNull(expressionGenerator)
+
+fun <T> ArbitraryBuilder<T>.setNotNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
+    this.setNotNull(expressionGenerator)
+
+fun <T> ArbitraryBuilder<T>.setNotNullExpGetter(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
+    this.setNotNull(expressionGenerator)
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+    property: KProperty1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+    expressionGenerator: ExpressionGenerator,
+    clazz: Class<U>,
+    filter: Predicate<U>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        expressionGenerator,
+        clazz,
+        filter,
+        limit.toInt()
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+    expressionGenerator: ExpressionGenerator,
+    clazz: Class<U>,
+    filter: Predicate<U>
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        expressionGenerator,
+        clazz,
+        filter
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    clazz: Class<U>,
+    filter: Predicate<U>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        expressionGenerator,
+        clazz,
+        filter,
+        limit.toInt()
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    clazz: Class<U>,
+    filter: Predicate<U>
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        expressionGenerator,
+        clazz,
+        filter
+    )
+
+fun <T> ArbitraryBuilder<T>.sizeExp(
+    expressionGenerator: ExpressionGenerator,
+    size: Int
+): ArbitraryBuilder<T> =
+    this.size(expressionGenerator, size)
+
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    size: Int
+): ArbitraryBuilder<T> =
+    this.size(expressionGenerator, size)
+
+fun <T> ArbitraryBuilder<T>.sizeExp(
+    expressionGenerator: ExpressionGenerator,
+    min: Int,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.size(expressionGenerator, min, max)
+
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    min: Int,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.size(expressionGenerator, min, max)
+
+fun <T> ArbitraryBuilder<T>.minSizeExp(
+    expressionGenerator: ExpressionGenerator,
+    min: Int
+): ArbitraryBuilder<T> =
+    this.minSize(expressionGenerator, min)
+
+fun <T> ArbitraryBuilder<T>.minSizeExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    min: Int
+): ArbitraryBuilder<T> =
+    this.minSize(expressionGenerator, min)
+
+fun <T> ArbitraryBuilder<T>.maxSizeExp(
+    expressionGenerator: ExpressionGenerator,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.maxSize(expressionGenerator, max)
+
+fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.maxSize(expressionGenerator, max)
+
+fun <T> ArbitraryBuilder<T>.setLazyExp(
+    expressionGenerator: ExpressionGenerator,
+    supplier: Supplier<Any?>
+): ArbitraryBuilder<T> =
+    this.setLazy(expressionGenerator, supplier)
+
+fun <T> ArbitraryBuilder<T>.setLazyExp(
+    expressionGenerator: ExpressionGenerator,
+    supplier: Supplier<Any?>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setLazy(expressionGenerator, supplier, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    supplier: Supplier<Any?>
+): ArbitraryBuilder<T> =
+    this.setLazy(expressionGenerator, supplier)
+
+fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
+    expressionGenerator: ExpressionGenerator,
+    supplier: Supplier<Any?>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setLazy(expressionGenerator, supplier, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
+    this.set(property(property), value)
+
+fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
+    this.set(property(property), value, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
+    this.set(property(property), value)
+
+fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
+    this.set(property(property), value, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
+    this.setNull(property(property))
+
+fun <T> ArbitraryBuilder<T>.setNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
+    this.setNull(property(property))
+
+fun <T> ArbitraryBuilder<T>.setNotNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
+    this.setNotNull(property(property))
+
+fun <T> ArbitraryBuilder<T>.setNotNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
+    this.setNotNull(property(property))
+
+fun <T, U> ArbitraryBuilder<T>.setPostCondition(
+    property: KProperty1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostCondition(
+    property: KProperty1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter,
+        limit.toInt()
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
+    property: KProperty1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter,
+        limit.toInt()
+    )
+
+fun <T> ArbitraryBuilder<T>.size(
+    property: KProperty1<T, *>,
+    size: Int
+): ArbitraryBuilder<T> = this.size(property(property), size)
+
+fun <T> ArbitraryBuilder<T>.size(
+    property: KProperty1<T, *>,
+    min: Int,
+    max: Int
+): ArbitraryBuilder<T> = this.size(property(property), min, max)
+
+fun <T> ArbitraryBuilder<T>.sizeExp(
+    property: KProperty1<T, *>,
+    size: Int
+): ArbitraryBuilder<T> = this.size(property(property), size)
+
+fun <T> ArbitraryBuilder<T>.sizeExp(
+    property: KProperty1<T, *>,
+    min: Int,
+    max: Int
+): ArbitraryBuilder<T> = this.size(property(property), min, max)
+
+fun <T> ArbitraryBuilder<T>.minSize(
+    property: KProperty1<T, *>,
+    min: Int
+): ArbitraryBuilder<T> = this.minSize(property(property), min)
+
+fun <T> ArbitraryBuilder<T>.minSizeExp(
+    property: KProperty1<T, *>,
+    min: Int
+): ArbitraryBuilder<T> = this.minSize(property(property), min)
+
+fun <T> ArbitraryBuilder<T>.maxSize(
+    property: KProperty1<T, *>,
+    max: Int
+): ArbitraryBuilder<T> = this.maxSize(property(property), max)
+
+fun <T> ArbitraryBuilder<T>.maxSizeExp(
+    property: KProperty1<T, *>,
+    max: Int
+): ArbitraryBuilder<T> = this.maxSize(property(property), max)
+
+fun <T> ArbitraryBuilder<T>.setLazyExp(
+    property: KProperty1<T, Any?>,
+    supplier: Supplier<Any?>
+): ArbitraryBuilder<T> = this.setLazy(property(property), supplier)
+
+fun <T> ArbitraryBuilder<T>.setLazyExp(
+    property: KProperty1<T, Any?>,
+    supplier: Supplier<Any?>,
+    limit: Long
+): ArbitraryBuilder<T> = this.setLazy(property(property), supplier, limit.toInt())
+
+fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
+    this.set(property(property), value)
+
+fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
+    this.set(
+        property(property),
+        value,
+        limit.toInt()
+    )
+
+fun <T> ArbitraryBuilder<T>.setNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
+    this.setNull(property(property))
+
+fun <T> ArbitraryBuilder<T>.setNotNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
+    this.setNotNull(property(property))
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
+    property: KFunction1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter,
+        limit.toInt()
+    )
+
+fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
+    property: KFunction1<T, *>,
+    clazz: Class<U>,
+    filter: Predicate<U>
+): ArbitraryBuilder<T> =
+    this.setPostCondition(
+        property(property),
+        clazz,
+        filter
+    )
+
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
+    property: KFunction1<T, *>,
+    size: Int
+): ArbitraryBuilder<T> =
+    this.size(property(property), size)
+
+fun <T> ArbitraryBuilder<T>.sizeExpGetter(
+    property: KFunction1<T, *>,
+    min: Int,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.size(property(property), min, max)
+
+fun <T> ArbitraryBuilder<T>.minSizeExpGetter(
+    property: KFunction1<T, *>,
+    min: Int
+): ArbitraryBuilder<T> =
+    this.minSize(property(property), min)
+
+fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
+    property: KFunction1<T, *>,
+    max: Int
+): ArbitraryBuilder<T> =
+    this.maxSize(property(property), max)
+
+fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
+    property: KFunction1<T, Any?>,
+    supplier: Supplier<Any?>
+): ArbitraryBuilder<T> =
+    this.setLazy(property(property), supplier)
+
+fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
+    property: KFunction1<T, Any?>,
+    supplier: Supplier<Any?>,
+    limit: Long
+): ArbitraryBuilder<T> =
+    this.setLazy(property(property), supplier, limit.toInt())

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -23,7 +23,7 @@ interface JoinableExpressionGenerator<F, T> : ExpressionGenerator {
     infix fun <R> intoGetter(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R>
 }
 
-infix fun <F, T, R> KFunction1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<T, R> =
+infix fun <F, T : Any, R : Any> KFunction1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<T, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
@@ -34,7 +34,7 @@ infix fun <F, T, R> KFunction1<F, T?>.intoGetter(getter: KFunction1<T, R?>): Joi
         )
     )
 
-infix fun <F, T, R> KFunction1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<T, R> =
+infix fun <F, T : Any, R> KFunction1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<T, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
@@ -45,7 +45,7 @@ infix fun <F, T, R> KFunction1<F, T?>.into(property: KProperty1<T, R?>): Joinabl
         )
     )
 
-infix fun <F, T, R> KFunction1<F, T?>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+infix fun <F, T : Any, R> KFunction1<F, T?>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
@@ -56,7 +56,18 @@ infix fun <F, T, R> KFunction1<F, T?>.into(expressionGenerator: JoinableExpressi
         )
     )
 
-infix fun <F, T, R> KProperty1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R> =
+infix fun <F, T : Any, R> KFunction1<F, T?>.intoGetter(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
+        JoinExpressionGenerator(
+            listOf(
+                property(this),
+                DotExpressionGenerator(),
+                expressionGenerator
+            )
+        )
+    )
+
+infix fun <F, T : Any, R> KProperty1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
@@ -67,7 +78,7 @@ infix fun <F, T, R> KProperty1<F, T?>.into(property: KProperty1<T, R?>): Joinabl
         )
     )
 
-infix fun <F, T, R> KProperty1<F, T>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+infix fun <F, T : Any, R> KProperty1<F, T?>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
@@ -78,7 +89,18 @@ infix fun <F, T, R> KProperty1<F, T>.into(expressionGenerator: JoinableExpressio
         )
     )
 
-infix fun <F, T, R> KProperty1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R> =
+infix fun <F, T : Any, R> KProperty1<F, T?>.intoGetter(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
+        JoinExpressionGenerator(
+            listOf(
+                property(this),
+                DotExpressionGenerator(),
+                expressionGenerator
+            )
+        )
+    )
+
+infix fun <F, T : Any, R> KProperty1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R> =
     DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -1,34 +1,11 @@
-/*
- * Fixture Monkey
- *
- * Copyright (c) 2021-present NAVER Corp.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@file:Suppress("unused")
-
 package com.navercorp.fixturemonkey.kotlin
 
-import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
 import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Field
 import java.lang.reflect.ParameterizedType
-import java.util.function.Predicate
-import java.util.function.Supplier
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
@@ -36,657 +13,234 @@ import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinProperty
 
-class Exp<T> internal constructor(private val delegate: ExpressionGenerator) : ExpressionGenerator by delegate {
-    constructor() : this(EmptyExpressionGenerator())
+interface JoinableExpressionGenerator<F, T> : ExpressionGenerator {
+    infix fun <R> into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R>
 
-    constructor(exp: Exp<T>) : this(exp.delegate)
+    infix fun <R> intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R>
 
-    infix fun <R> into(property: KProperty1<T, R?>): Exp<R> =
-        Exp(delegate.join(PropertyExpressionGenerator(KotlinProperty(property))))
+    infix fun <R> into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R>
 
-    @JvmName("getterBoolean")
-    infix fun intoGetter(getter: KFunction1<T, Boolean>): Exp<Boolean> =
-        Exp(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
-
-    infix fun <R> intoGetter(getter: KFunction1<T, R?>): Exp<R> =
-        Exp(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
-
-    infix fun <R> into(exp: ExpList<T, R>): Exp<R> = Exp(delegate.join(exp))
-
-    infix fun <R> intoGetter(exp: ExpList<T, R>): Exp<R> = Exp(delegate.join(exp))
-
-    @JvmName("intoList")
-    infix fun <R : Collection<E>, E : Any> into(property: KProperty1<T, R?>): ExpList<T, E> =
-        ExpList(delegate.join(PropertyExpressionGenerator(KotlinProperty(property))))
-
-    @JvmName("getterIntoList")
-    infix fun <R : Collection<E>, E : Any> intoGetter(getter: KFunction1<T, R?>): ExpList<T, E> =
-        ExpList(delegate.join(PropertyExpressionGenerator(KotlinGetterProperty(getter))))
+    infix fun <R> intoGetter(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R>
 }
 
-fun <T, R> Exp(expList: ExpList<T, R>) = Exp<R>(expList)
-
-fun <T, R> Exp(property: KProperty1<T, R?>) = Exp<R>(PropertyExpressionGenerator(KotlinProperty(property)))
-
-fun <T, R> ExpGetter(property: KFunction1<T, R?>) = Exp<R>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
-fun <T, R> ExpGetter(expList: ExpList<T, R>) = Exp<R>(expList)
-
-@JvmName("getterBoolean")
-fun ExpGetter(property: KFunction1<*, Boolean>) =
-    Exp<Boolean>(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinProperty(property)), value)
-
-fun <T> ArbitraryBuilder<T>.set(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinProperty(property)), value, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinProperty(property)), value)
-
-fun <T> ArbitraryBuilder<T>.setExp(property: KProperty1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinProperty(property)), value, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?): ArbitraryBuilder<T> =
-    this.set(PropertyExpressionGenerator(KotlinGetterProperty(property)), value)
-
-fun <T> ArbitraryBuilder<T>.setExpGetter(property: KFunction1<T, Any?>, value: Any?, limit: Long): ArbitraryBuilder<T> =
-    this.set(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        value,
-        limit.toInt()
-    )
-
-fun <T> ArbitraryBuilder<T>.setExp(expressionGenerator: ExpressionGenerator, value: Any?): ArbitraryBuilder<T> =
-    this.set(expressionGenerator, value)
-
-fun <T> ArbitraryBuilder<T>.setExp(
-    expressionGenerator: ExpressionGenerator,
-    value: Any?,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.set(expressionGenerator, value, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setExpGetter(expressionGenerator: ExpressionGenerator, value: Any?): ArbitraryBuilder<T> =
-    this.set(expressionGenerator, value)
-
-fun <T> ArbitraryBuilder<T>.setExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    value: Any?,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.set(expressionGenerator, value, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
-    this.setNull(PropertyExpressionGenerator(KotlinProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
-    this.setNull(PropertyExpressionGenerator(KotlinProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
-    this.setNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
-    this.setNull(expressionGenerator)
-
-fun <T> ArbitraryBuilder<T>.setNullExpGetter(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
-    this.setNull(expressionGenerator)
-
-fun <T> ArbitraryBuilder<T>.setNotNull(property: KProperty1<T, *>): ArbitraryBuilder<T> =
-    this.setNotNull(PropertyExpressionGenerator(KotlinProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNotNullExp(property: KProperty1<T, *>): ArbitraryBuilder<T> =
-    this.setNotNull(PropertyExpressionGenerator(KotlinProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNotNullExpGetter(property: KFunction1<T, *>): ArbitraryBuilder<T> =
-    this.setNotNull(PropertyExpressionGenerator(KotlinGetterProperty(property)))
-
-fun <T> ArbitraryBuilder<T>.setNotNullExp(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
-    this.setNotNull(expressionGenerator)
-
-fun <T> ArbitraryBuilder<T>.setNotNullExpGetter(expressionGenerator: ExpressionGenerator): ArbitraryBuilder<T> =
-    this.setNotNull(expressionGenerator)
-
-fun <T, U> ArbitraryBuilder<T>.setPostCondition(
-    property: KProperty1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinProperty(property)),
-        clazz,
-        filter
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostCondition(
-    property: KProperty1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinProperty(property)),
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
-    property: KProperty1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinProperty(property)),
-        clazz,
-        filter
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
-    property: KFunction1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
-    property: KProperty1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinProperty(property)),
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
-    property: KFunction1<T, *>,
-    clazz: Class<U>,
-    filter: Predicate<U>
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        PropertyExpressionGenerator(KotlinGetterProperty(property)),
-        clazz,
-        filter
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
-    expressionGenerator: ExpressionGenerator,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        expressionGenerator,
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExp(
-    expressionGenerator: ExpressionGenerator,
-    clazz: Class<U>,
-    filter: Predicate<U>
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        expressionGenerator,
-        clazz,
-        filter
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    clazz: Class<U>,
-    filter: Predicate<U>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        expressionGenerator,
-        clazz,
-        filter,
-        limit.toInt()
-    )
-
-fun <T, U> ArbitraryBuilder<T>.setPostConditionExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    clazz: Class<U>,
-    filter: Predicate<U>
-): ArbitraryBuilder<T> =
-    this.setPostCondition(
-        expressionGenerator,
-        clazz,
-        filter
-    )
-
-fun <T> ArbitraryBuilder<T>.size(
-    property: KProperty1<T, *>,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinProperty(property)), size)
-
-fun <T> ArbitraryBuilder<T>.size(
-    property: KProperty1<T, *>,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinProperty(property)), min, max)
-
-fun <T> ArbitraryBuilder<T>.sizeExp(
-    property: KProperty1<T, *>,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinProperty(property)), size)
-
-fun <T> ArbitraryBuilder<T>.sizeExpGetter(
-    property: KFunction1<T, *>,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinGetterProperty(property)), size)
-
-fun <T> ArbitraryBuilder<T>.sizeExp(
-    expressionGenerator: ExpressionGenerator,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(expressionGenerator, size)
-
-fun <T> ArbitraryBuilder<T>.sizeExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    size: Int
-): ArbitraryBuilder<T> =
-    this.size(expressionGenerator, size)
-
-fun <T> ArbitraryBuilder<T>.sizeExp(
-    property: KProperty1<T, *>,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinProperty(property)), min, max)
-
-fun <T> ArbitraryBuilder<T>.sizeExpGetter(
-    property: KFunction1<T, *>,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(PropertyExpressionGenerator(KotlinGetterProperty(property)), min, max)
-
-fun <T> ArbitraryBuilder<T>.sizeExp(
-    expressionGenerator: ExpressionGenerator,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(expressionGenerator, min, max)
-
-fun <T> ArbitraryBuilder<T>.sizeExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    min: Int,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.size(expressionGenerator, min, max)
-
-fun <T> ArbitraryBuilder<T>.minSize(
-    property: KProperty1<T, *>,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(PropertyExpressionGenerator(KotlinProperty(property)), min)
-
-fun <T> ArbitraryBuilder<T>.minSizeExp(
-    property: KProperty1<T, *>,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(PropertyExpressionGenerator(KotlinProperty(property)), min)
-
-fun <T> ArbitraryBuilder<T>.minSizeExpGetter(
-    property: KFunction1<T, *>,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(PropertyExpressionGenerator(KotlinGetterProperty(property)), min)
-
-fun <T> ArbitraryBuilder<T>.minSizeExp(
-    expressionGenerator: ExpressionGenerator,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(expressionGenerator, min)
-
-fun <T> ArbitraryBuilder<T>.minSizeExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    min: Int
-): ArbitraryBuilder<T> =
-    this.minSize(expressionGenerator, min)
-
-fun <T> ArbitraryBuilder<T>.maxSize(
-    property: KProperty1<T, *>,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(PropertyExpressionGenerator(KotlinProperty(property)), max)
-
-fun <T> ArbitraryBuilder<T>.maxSizeExp(
-    property: KProperty1<T, *>,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(PropertyExpressionGenerator(KotlinProperty(property)), max)
-
-fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
-    property: KFunction1<T, *>,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(PropertyExpressionGenerator(KotlinGetterProperty(property)), max)
-
-fun <T> ArbitraryBuilder<T>.maxSizeExp(
-    expressionGenerator: ExpressionGenerator,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(expressionGenerator, max)
-
-fun <T> ArbitraryBuilder<T>.maxSizeExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    max: Int
-): ArbitraryBuilder<T> =
-    this.maxSize(expressionGenerator, max)
-
-fun <T> ArbitraryBuilder<T>.setLazyExp(
-    property: KProperty1<T, Any?>,
-    supplier: Supplier<Any?>
-): ArbitraryBuilder<T> =
-    this.setLazy(PropertyExpressionGenerator(KotlinProperty(property)), supplier)
-
-fun <T> ArbitraryBuilder<T>.setLazyExp(
-    property: KProperty1<T, Any?>,
-    supplier: Supplier<Any?>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setLazy(PropertyExpressionGenerator(KotlinProperty(property)), supplier, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
-    property: KFunction1<T, Any?>,
-    supplier: Supplier<Any?>
-): ArbitraryBuilder<T> =
-    this.setLazy(PropertyExpressionGenerator(KotlinGetterProperty(property)), supplier)
-
-fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
-    property: KFunction1<T, Any?>,
-    supplier: Supplier<Any?>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setLazy(PropertyExpressionGenerator(KotlinGetterProperty(property)), supplier, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setLazyExp(
-    expressionGenerator: ExpressionGenerator,
-    supplier: Supplier<Any?>
-): ArbitraryBuilder<T> =
-    this.setLazy(expressionGenerator, supplier)
-
-fun <T> ArbitraryBuilder<T>.setLazyExp(
-    expressionGenerator: ExpressionGenerator,
-    supplier: Supplier<Any?>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setLazy(expressionGenerator, supplier, limit.toInt())
-
-fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    supplier: Supplier<Any?>
-): ArbitraryBuilder<T> =
-    this.setLazy(expressionGenerator, supplier)
-
-fun <T> ArbitraryBuilder<T>.setLazyExpGetter(
-    expressionGenerator: ExpressionGenerator,
-    supplier: Supplier<Any?>,
-    limit: Long
-): ArbitraryBuilder<T> =
-    this.setLazy(expressionGenerator, supplier, limit.toInt())
-
-infix fun <T, R, E> KProperty1<T, R?>.into(property: KProperty1<R, E?>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KFunction1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<T, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                PropertyExpressionGenerator(KotlinProperty(property))
+                property(getter)
             )
         )
     )
 
-infix fun <T, R, E> KProperty1<T, R?>.intoGetter(property: KFunction1<R, E?>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KFunction1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<T, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                PropertyExpressionGenerator(KotlinGetterProperty(property))
+                property(property)
             )
         )
     )
 
-infix fun <T, R, E> KProperty1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KFunction1<F, T?>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                expList
+                expressionGenerator
             )
         )
     )
 
-infix fun <T, R, E> KProperty1<T, R?>.intoGetter(expList: ExpList<R, E>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KProperty1<F, T?>.into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                expList
+                property(property)
             )
         )
     )
 
-infix fun <T, R, E> KFunction1<T, R?>.intoGetter(property: KFunction1<R, E?>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KProperty1<F, T>.into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinGetterProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                PropertyExpressionGenerator(KotlinGetterProperty(property))
+                expressionGenerator
             )
         )
     )
 
-infix fun <T, R, E> KFunction1<T, R?>.into(property: KProperty1<R, E?>): Exp<E> =
-    Exp(
+infix fun <F, T, R> KProperty1<F, T?>.intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinGetterProperty(this)),
+                property(this),
                 DotExpressionGenerator(),
-                PropertyExpressionGenerator(KotlinProperty(property))
+                property(getter)
             )
         )
     )
 
-infix fun <T, R, E> KFunction1<T, R?>.into(expList: ExpList<R, E>): Exp<E> =
-    Exp(
+infix operator fun <T, R : Collection<E>, E : Any> JoinableExpressionGenerator<T, R?>.get(index: Int): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                PropertyExpressionGenerator(KotlinGetterProperty(this)),
-                DotExpressionGenerator(),
-                expList
-            )
-        )
-    )
-
-infix fun <T, R, E> KFunction1<T, R?>.intoGetter(expList: ExpList<R, E>): Exp<E> =
-    Exp(
-        JoinExpressionGenerator(
-            listOf(
-                PropertyExpressionGenerator(KotlinGetterProperty(this)),
-                DotExpressionGenerator(),
-                expList
-            )
-        )
-    )
-
-infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): ExpList<T, E> =
-    ExpList(ArrayExpressionGenerator(KotlinProperty(this), index))
-
-infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): ExpList<T, E> =
-    ExpList(MapExpressionGenerator(KotlinProperty(this), key))
-
-@JvmName("getNestedList")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R?>.get(
-    index: Int
-): ExpList<T, N?> = ExpList(ArrayExpressionGenerator(KotlinProperty(this), index))
-
-@JvmName("getNestedMap")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R?>.get(
-    key: String
-): ExpList<T, N?> = ExpList(MapExpressionGenerator(KotlinProperty(this), key))
-
-infix operator
-fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(index: Int): ExpList<T, E> =
-    ExpList(ArrayExpressionGenerator(KotlinGetterProperty(this), index))
-
-infix operator
-fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(key: String): ExpList<T, E> =
-    ExpList(MapExpressionGenerator(KotlinGetterProperty(this), key))
-
-@JvmName("getNestedList")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KFunction1<T, R?>.get(
-    index: Int
-): ExpList<T, N?> = ExpList(ArrayExpressionGenerator(KotlinGetterProperty(this), index))
-
-@JvmName("getNestedMap")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KFunction1<T, R?>.get(
-    key: String
-): ExpList<T, N?> = ExpList(MapExpressionGenerator(KotlinGetterProperty(this), key))
-
-@Suppress("unused")
-class ExpList<E, L> internal constructor(val delegate: ExpressionGenerator) : ExpressionGenerator by delegate {
-    infix fun <R> into(expList: ExpList<L, R>) =
-        Exp<R>(
-            JoinExpressionGenerator(
-                listOf(
-                    this.delegate,
-                    DotExpressionGenerator(),
-                    expList.delegate
-                )
-            )
-        )
-
-    infix fun <R> intoGetter(expList: ExpList<L, R>) =
-        Exp<R>(
-            JoinExpressionGenerator(
-                listOf(
-                    this.delegate,
-                    DotExpressionGenerator(),
-                    expList.delegate
-                )
-            )
-        )
-
-    infix fun <R> into(property: KProperty1<L, R?>): Exp<R> =
-        Exp(
-            JoinExpressionGenerator(
-                listOf(
-                    this,
-                    DotExpressionGenerator(),
-                    PropertyExpressionGenerator(KotlinProperty(property))
-                )
-            )
-        )
-
-    infix fun <R> intoGetter(property: KFunction1<L, R?>): Exp<R> =
-        Exp(
-            JoinExpressionGenerator(
-                listOf(
-                    this,
-                    DotExpressionGenerator(),
-                    PropertyExpressionGenerator(KotlinGetterProperty(property))
-                )
-            )
-        )
-}
-
-infix operator
-fun <T, R : Collection<E>, E : Any> ExpList<T, R?>.get(index: Int): ExpList<T, E> =
-    ExpList(
-        JoinExpressionGenerator(
-            listOf(
-                delegate,
+                this,
                 IndexExpressionGenerator(index)
             )
         )
     )
 
-infix operator
-fun <T, R : Collection<E>, E : Any> ExpList<T, R?>.get(key: String): ExpList<T, E> =
-    ExpList(JoinExpressionGenerator(listOf(delegate, KeyExpressionGenerator(key))))
-
-@JvmName("getNestedList")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> ExpList<T, R?>.get(
-    index: Int
-): ExpList<T, N?> =
-    ExpList(
+infix operator fun <T, R : Collection<E>, E : Any> JoinableExpressionGenerator<T, R?>.get(key: String): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(
         JoinExpressionGenerator(
             listOf(
-                delegate,
+                this,
+                KeyExpressionGenerator(key)
+            )
+        )
+    )
+
+@JvmName("getNestedList")
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> JoinableExpressionGenerator<T, R?>.get(
+    index: Int
+): JoinableExpressionGenerator<T, N?> =
+    DefaultJoinableExpressionGenerator(
+        JoinExpressionGenerator(
+            listOf(
+                this,
                 IndexExpressionGenerator(index)
             )
         )
     )
 
 @JvmName("getNestedMap")
-infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> ExpList<T, R?>.get(
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> JoinableExpressionGenerator<T, R?>.get(
     key: String
-): ExpList<T, N?> =
-    ExpList(JoinExpressionGenerator(listOf(delegate, KeyExpressionGenerator(key))))
+): JoinableExpressionGenerator<T, N?> =
+    DefaultJoinableExpressionGenerator(JoinExpressionGenerator(listOf(this, KeyExpressionGenerator(key))))
 
-private class JoinExpressionGenerator(private val expressionGenerators: List<ExpressionGenerator>) :
-    ExpressionGenerator {
+infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(index: Int): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(array(this, index))
+
+infix operator fun <T, R : Collection<E>, E : Any> KProperty1<T, R?>.get(key: String): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(map(this, key))
+
+@JvmName("getNestedList")
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R?>.get(
+    index: Int
+): JoinableExpressionGenerator<T, N?> = DefaultJoinableExpressionGenerator(array(this, index))
+
+@JvmName("getNestedMap")
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KProperty1<T, R?>.get(
+    key: String
+): JoinableExpressionGenerator<T, N?> = DefaultJoinableExpressionGenerator(map(this, key))
+
+infix operator fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(index: Int): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(array(this, index))
+
+infix operator fun <T, R : Collection<E>, E : Any> KFunction1<T, R?>.get(key: String): JoinableExpressionGenerator<T, E> =
+    DefaultJoinableExpressionGenerator(map(this, key))
+
+@JvmName("getNestedList")
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KFunction1<T, R?>.get(
+    index: Int
+): JoinableExpressionGenerator<T, N?> = DefaultJoinableExpressionGenerator(array(this, index))
+
+@JvmName("getNestedMap")
+infix operator fun <T, R : Collection<N>, N : Collection<E>, E : Any> KFunction1<T, R?>.get(
+    key: String
+): JoinableExpressionGenerator<T, N?> = DefaultJoinableExpressionGenerator(map(this, key))
+
+class DefaultJoinableExpressionGenerator<F, T>(
+    private val delegate: ExpressionGenerator
+) : JoinableExpressionGenerator<F, T> {
+    override fun <R> into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R> =
+        DefaultJoinableExpressionGenerator(
+            JoinExpressionGenerator(
+                listOf(
+                    delegate,
+                    DotExpressionGenerator(),
+                    property(property)
+                )
+            )
+        )
+
+    override fun <R> intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R> =
+        DefaultJoinableExpressionGenerator(
+            JoinExpressionGenerator(
+                listOf(
+                    delegate,
+                    DotExpressionGenerator(),
+                    property(getter)
+                )
+            )
+        )
+
+    override fun <R> into(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+        DefaultJoinableExpressionGenerator(
+            JoinExpressionGenerator(
+                listOf(
+                    delegate,
+                    DotExpressionGenerator(),
+                    expressionGenerator
+                )
+            )
+        )
+
+    override fun <R> intoGetter(expressionGenerator: JoinableExpressionGenerator<T, R>): JoinableExpressionGenerator<F, R> =
+        DefaultJoinableExpressionGenerator(
+            JoinExpressionGenerator(
+                listOf(
+                    delegate,
+                    DotExpressionGenerator(),
+                    expressionGenerator
+                )
+            )
+        )
+
+    override fun generate(propertyNameResolver: PropertyNameResolver?): String = delegate.generate(propertyNameResolver)
+}
+
+private class JoinExpressionGenerator(
+    private val expressionGenerators: List<ExpressionGenerator>
+) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         expressionGenerators.joinToString(separator = "") { expressionGenerator ->
             expressionGenerator.generate(propertyNameResolver)
         }
 }
 
-private class PropertyExpressionGenerator(private val property: Property) :
-    ExpressionGenerator {
-    override fun generate(propertyNameResolver: PropertyNameResolver): String =
-        propertyNameResolver.resolve(property)
-}
-
-private class IndexExpressionGenerator(val index: Int) : ExpressionGenerator {
+private class IndexExpressionGenerator(private val index: Int) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         "[$index]"
 }
 
 private class ArrayExpressionGenerator(
     private val property: Property,
-    val index: Int
-) :
-    ExpressionGenerator {
+    private val index: Int
+) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         "${propertyNameResolver.resolve(property)}[$index]"
 }
 
 private class MapExpressionGenerator(
     private val property: Property,
-    val key: String
-) :
-    ExpressionGenerator {
+    private val key: String
+) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         "${propertyNameResolver.resolve(property)}[$key]"
 }
 
-private class KeyExpressionGenerator(private val key: String) :
-    ExpressionGenerator {
+private class KeyExpressionGenerator(private val key: String) : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         "[$key]"
 }
@@ -699,27 +253,36 @@ private class EmptyExpressionGenerator : ExpressionGenerator {
     override fun generate(propertyNameResolver: PropertyNameResolver): String = ""
 }
 
-fun ExpressionGenerator.join(joinerExpressionGenerator: ExpressionGenerator): ExpressionGenerator =
-    if (this is EmptyExpressionGenerator) {
-        joinerExpressionGenerator
-    } else {
-        JoinExpressionGenerator(
-            listOf(
-                this,
-                DotExpressionGenerator(),
-                joinerExpressionGenerator
-            )
-        )
-    }
+internal fun <R, E> property(property: KProperty1<R, E?>): ExpressionGenerator =
+    PropertyExpressionGenerator(KotlinProperty(property))
 
-private class KotlinProperty<V, R>(private val property: KProperty1<V, R>) :
-    Property {
+internal fun <R, E> property(function: KFunction1<R, E?>): ExpressionGenerator =
+    PropertyExpressionGenerator(KotlinGetterProperty(function))
 
+internal fun <T, R : Collection<E>, E : Any> array(function: KFunction1<T, R?>, index: Int): ExpressionGenerator =
+    ArrayExpressionGenerator(KotlinGetterProperty(function), index)
+
+internal fun <T, R : Collection<E>, E : Any> array(property: KProperty1<T, R?>, index: Int): ExpressionGenerator =
+    ArrayExpressionGenerator(KotlinProperty(property), index)
+
+internal fun <T, R : Collection<E>, E : Any> map(function: KFunction1<T, R?>, key: String): ExpressionGenerator =
+    MapExpressionGenerator(KotlinGetterProperty(function), key)
+
+internal fun <T, R : Collection<E>, E : Any> map(property: KProperty1<T, R?>, key: String): ExpressionGenerator =
+    MapExpressionGenerator(KotlinProperty(property), key)
+
+private class PropertyExpressionGenerator(private val property: Property) : ExpressionGenerator {
+    override fun generate(propertyNameResolver: PropertyNameResolver): String =
+        propertyNameResolver.resolve(property)
+}
+
+private class KotlinProperty<V, R>(private val property: KProperty1<V, R>) : Property {
     private val propertyAnnotations: List<Annotation> = property.annotations
     private val getterAnnotations: List<Annotation> =
         property.getter.annotations.toList()
     private val fieldAnnotations: List<Annotation> =
         property.javaField?.annotations?.toList() ?: listOf()
+
     override fun getType(): Class<*> = property.javaField!!.type
 
     override fun getAnnotatedType(): AnnotatedType =

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorJavaTestSpecs.java
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorJavaTestSpecs.java
@@ -114,10 +114,13 @@ public class ExpressionGeneratorJavaTestSpecs {
 		@Nullable
 		private final String nullableName;
 
-		public DogJava(String name, List<Integer> loves, @Nullable String nullableName) {
+		private final boolean cute;
+
+		public DogJava(String name, List<Integer> loves, @Nullable String nullableName, boolean cute) {
 			this.name = name;
 			this.loves = loves;
 			this.nullableName = nullableName;
+			this.cute = cute;
 		}
 
 		public String getName() {
@@ -131,6 +134,10 @@ public class ExpressionGeneratorJavaTestSpecs {
 		@Nullable
 		public String getNullableName() {
 			return nullableName;
+		}
+
+		public boolean isCute() {
+			return cute;
 		}
 	}
 }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGeneratorsTest.kt
@@ -25,51 +25,7 @@ import org.junit.jupiter.api.Test
 
 class ExpressionGeneratorsTest {
     @Test
-    fun getPropertyExpressionField() {
-        // given
-        val generator = Exp<Person>() into Person::dogs
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs")
-    }
-
-    @Test
-    fun getPropertyExpressionFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::dog)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog")
-    }
-
-    @Test
     fun getPropertyExpressionNestedField() {
-        // given
-        val generator = Exp<Person>() into Person::dog into Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.name")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::dog into Dog::name)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.name")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithoutExp() {
         // given
         val generator = Person::dog into Dog::name
 
@@ -82,28 +38,6 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionNestedFieldWithIndex() {
         // given
-        val generator = Exp<Person>() into Person::dog into Dog::loves[0]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[0]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithIndexWithConstructor() {
-        // given
-        val generator = Exp<Person>(Person::dog into Dog::loves[0])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[0]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithIndexWithoutExp() {
-        // given
         val generator = Person::dog into Dog::loves[0]
 
         // when
@@ -114,28 +48,6 @@ class ExpressionGeneratorsTest {
 
     @Test
     fun getPropertyExpressionNestedFieldWithAllIndex() {
-        // given
-        val generator = Exp<Person>() into Person::dog into Dog::loves["*"]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[*]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithAllIndexWithConstructor() {
-        // given
-        val generator = Exp(Person::dog into Dog::loves["*"])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[*]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedFieldWithAllIndexWithoutExp() {
         // given
         val generator = Person::dog into Dog::loves["*"]
 
@@ -148,28 +60,6 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionListWithIndexOnce() {
         // given
-        val generator = Exp<Person>() into Person::dogs[1]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[1]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexOnceWithConstructor() {
-        // given
-        val generator = Exp(Person::dogs[1])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[1]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexOnceWithoutExp() {
-        // given
         val generator = Person::dogs[1]
 
         // when
@@ -180,28 +70,6 @@ class ExpressionGeneratorsTest {
 
     @Test
     fun getPropertyExpressionListWithAllIndexOnce() {
-        // given
-        val generator = Exp<Person>() into Person::dogs["*"]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[*]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithAllIndexOnceWithConstructor() {
-        // given
-        val generator = Exp(Person::dogs["*"])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[*]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithAllIndexOnceWithoutExp() {
         // given
         val generator = Person::dogs["*"]
 
@@ -214,18 +82,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionNestedListWithIndex() {
         // given
-        val generator = Exp<Person>() into Person::nestedDogs[1]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedListWithIndexWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedDogs[1])
+        val generator = Person::nestedDogs[1]
 
         // when
         val actual = generator.generate()
@@ -236,18 +93,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionNestedListWithAllIndex() {
         // given
-        val generator = Exp<Person>() into Person::nestedDogs["*"]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*]")
-    }
-
-    @Test
-    fun getPropertyExpressionNestedListWithAllIndexWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedDogs["*"])
+        val generator = Person::nestedDogs["*"]
 
         // when
         val actual = generator.generate()
@@ -258,18 +104,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionListWithIndexAndAllIndex() {
         // given
-        val generator = Exp<Person>() into Person::nestedDogs[1]["*"]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][*]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexAndAllIndexWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedDogs[1]["*"])
+        val generator = Person::nestedDogs[1]["*"]
 
         // when
         val actual = generator.generate()
@@ -280,18 +115,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionListWithAllIndexAndIndex() {
         // given
-        val generator = Exp<Person>() into Person::nestedDogs["*"][2]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*][2]")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithAllIndexAndIndexWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedDogs["*"][2])
+        val generator = Person::nestedDogs["*"][2]
 
         // when
         val actual = generator.generate()
@@ -301,28 +125,6 @@ class ExpressionGeneratorsTest {
 
     @Test
     fun getPropertyExpressionListWithAllIndexTwiceWithField() {
-        // given
-        val generator = Exp<Person>() into Person::nestedDogs["*"]["*"] into Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*][*].name")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithAllIndexTwiceWithFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedDogs["*"]["*"] into Dog::name)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[*][*].name")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithAllIndexTwiceWithFieldWithoutExp() {
         // given
         val generator = Person::nestedDogs["*"]["*"] into Dog::name
 
@@ -335,44 +137,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionListWithIndexTwiceWithFieldDiffExpression1() {
         // given
-        val generator = Exp<Person>() into Person::nestedDogs[1][2] into Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexTwiceWithFieldDiffExpression2() {
-        // given
-        val generator = Exp<Person>() into (Person::nestedDogs get 1 get 2) into Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexTwiceWithFieldDiffExpression3() {
-        // given
-        val generator = Exp<Person>()
-            .into((Person::nestedDogs)[1][2])
-            .into(Dog::name)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getPropertyExpressionListWithIndexTwiceWithFieldDiffExpression4() {
-        // given
-        val generator = Exp<Person>()
-            .into(Person::nestedDogs[1][2])
-            .into(Dog::name)
+        val generator = Person::nestedDogs[1][2] into Dog::name
 
         // when
         val actual = generator.generate()
@@ -383,19 +148,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionFieldWithIndexThrice() {
         // given
-        val generator = Exp<Person>()
-            .into(Person::nestedThriceDogs[1][2][2])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedThriceDogs[1][2][2]")
-    }
-
-    @Test
-    fun getPropertyExpressionFieldWithIndexThriceWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedThriceDogs[1][2][2])
+        val generator = Person::nestedThriceDogs[1][2][2]
 
         // when
         val actual = generator.generate()
@@ -406,74 +159,16 @@ class ExpressionGeneratorsTest {
     @Test
     fun getPropertyExpressionFieldWithIndexThriceWithField() {
         // given
-        val generator = Exp<Person>()
-            .into(Person::nestedThriceDogs[1][2][2])
-            .into(Dog::name)
+        val generator = Person::nestedThriceDogs[1][2][2] into Dog::name
 
         // when
         val actual = generator.generate()
 
         then(actual).isEqualTo("nestedThriceDogs[1][2][2].name")
-    }
-
-    @Test
-    fun getPropertyExpressionFieldWithIndexThriceWithFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::nestedThriceDogs[1][2][2] into Dog::name)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedThriceDogs[1][2][2].name")
-    }
-
-    //
-    @Test
-    fun getGetterExpressionField() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getDogs
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs")
-    }
-
-    @Test
-    fun getGetterExpressionFieldWithConstructor() {
-        // given
-        val generator = ExpGetter(PersonJava::getDogs)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs")
     }
 
     @Test
     fun getGetterExpressionNestedField() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog intoGetter DogJava::getName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.name")
-    }
-
-    @Test
-    fun getGetterExpressionNestedFieldWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getDog intoGetter DogJava::getName)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.name")
-    }
-
-    @Test
-    fun getGetterExpressionNestedFieldWithoutExp() {
         // given
         val generator = PersonJava::getDog intoGetter DogJava::getName
 
@@ -486,18 +181,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithIndex() {
         // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog into DogJava::getLoves[0]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[0]")
-    }
-
-    @Test
-    fun getGetterExpressionNestedFieldWithIndexWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getDog into DogJava::getLoves[0])
+        val generator = PersonJava::getDog into DogJava::getLoves[0]
 
         // when
         val actual = generator.generate()
@@ -508,18 +192,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedFieldWithAllIndex() {
         // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getDog into DogJava::getLoves["*"]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dog.loves[*]")
-    }
-
-    @Test
-    fun getGetterExpressionNestedFieldWithAllIndexWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getDog into DogJava::getLoves["*"])
+        val generator = PersonJava::getDog into DogJava::getLoves["*"]
 
         // when
         val actual = generator.generate()
@@ -530,7 +203,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithIndexOnce() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDogs[1]
+        val generator = PersonJava::getDogs[1]
 
         // when
         val actual = generator.generate()
@@ -541,7 +214,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithAllIndexOnce() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getDogs["*"]
+        val generator = PersonJava::getDogs["*"]
 
         // when
         val actual = generator.generate()
@@ -552,7 +225,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedListWithIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs[1]
+        val generator = PersonJava::getNestedDogs[1]
 
         // when
         val actual = generator.generate()
@@ -563,7 +236,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionNestedListWithAllIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs["*"]
+        val generator = PersonJava::getNestedDogs["*"]
 
         // when
         val actual = generator.generate()
@@ -574,7 +247,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithIndexAndAllIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs[1]["*"]
+        val generator = PersonJava::getNestedDogs[1]["*"]
 
         // when
         val actual = generator.generate()
@@ -585,7 +258,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithAllIndexAndIndex() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs["*"][2]
+        val generator = PersonJava::getNestedDogs["*"][2]
 
         // when
         val actual = generator.generate()
@@ -596,7 +269,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithAllIndexTwiceWithField() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs["*"]["*"] intoGetter DogJava::getName
+        val generator = PersonJava::getNestedDogs["*"]["*"] intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -607,44 +280,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression1() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNestedDogs[1][2] intoGetter DogJava::getName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression2() {
-        // given
-        val generator = Exp<PersonJava>() into (PersonJava::getNestedDogs get 1 get 2) intoGetter DogJava::getName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression3() {
-        // given
-        val generator = Exp<PersonJava>()
-            .into((PersonJava::getNestedDogs)[1][2])
-            .intoGetter(DogJava::getName)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nestedDogs[1][2].name")
-    }
-
-    @Test
-    fun getGetterExpressionListWithIndexTwiceWithFieldDiffExpression4() {
-        // given
-        val generator = Exp<PersonJava>()
-            .into(PersonJava::getNestedDogs[1][2])
-            .intoGetter(DogJava::getName)
+        val generator = PersonJava::getNestedDogs[1][2] intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -655,8 +291,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionFieldWithIndexThrice() {
         // given
-        val generator = Exp<PersonJava>()
-            .into(PersonJava::getNestedThriceDogs[1][2][2])
+        val generator = PersonJava::getNestedThriceDogs[1][2][2]
 
         // when
         val actual = generator.generate()
@@ -667,9 +302,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getGetterExpressionFieldWithIndexThriceWithField() {
         // given
-        val generator = Exp<PersonJava>()
-            .into(PersonJava::getNestedThriceDogs[1][2][2])
-            .intoGetter(DogJava::getName)
+        val generator = PersonJava::getNestedThriceDogs[1][2][2] intoGetter DogJava::getName
 
         // when
         val actual = generator.generate()
@@ -678,40 +311,7 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
-    fun notGetter() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::notGetter
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("notGetter")
-    }
-
-    @Test
     fun getterNullableField() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getNullableDog intoGetter DogJava::getName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDog.name")
-    }
-
-    @Test
-    fun getterNullableFieldWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getNullableDog intoGetter DogJava::getName)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDog.name")
-    }
-
-    @Test
-    fun getterNullableFieldWithoutExp() {
         // given
         val generator = PersonJava::getNullableDog intoGetter DogJava::getName
 
@@ -724,18 +324,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableNestedField() {
         // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getNullableDog intoGetter DogJava::getNullableName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDog.nullableName")
-    }
-
-    @Test
-    fun getterNullableNestedFieldWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getNullableDog intoGetter DogJava::getNullableName)
+        val generator = PersonJava::getNullableDog intoGetter DogJava::getNullableName
 
         // when
         val actual = generator.generate()
@@ -746,18 +335,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun getterNullableList() {
         // given
-        val generator = Exp<PersonJava>() into PersonJava::getNullableDogs[0]
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDogs[0]")
-    }
-
-    @Test
-    fun getterNullableListWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getNullableDogs[0])
+        val generator = PersonJava::getNullableDogs[0]
 
         // when
         val actual = generator.generate()
@@ -768,18 +346,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun propertyNullableField() {
         // given
-        val generator = Exp<Person>() into Person::nullableDog into Dog::name
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDog.name")
-    }
-
-    @Test
-    fun propertyNullableFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::nullableDog into Dog::name)
+        val generator = Person::nullableDog into Dog::name
 
         // when
         val actual = generator.generate()
@@ -790,18 +357,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun propertyNullableNestedField() {
         // given
-        val generator = Exp<Person>() into Person::nullableDog into Dog::nullableName
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDog.nullableName")
-    }
-
-    @Test
-    fun propertyNullableNestedFieldWithConstructor() {
-        // given
-        val generator = Exp(Person::nullableDog into Dog::nullableName)
+        val generator = Person::nullableDog into Dog::nullableName
 
         // when
         val actual = generator.generate()
@@ -812,7 +368,7 @@ class ExpressionGeneratorsTest {
     @Test
     fun propertyNullableList() {
         // given
-        val generator = Exp<Person>() into Person::nullableDogs[0]
+        val generator = Person::nullableDogs[0]
 
         // when
         val actual = generator.generate()
@@ -821,29 +377,7 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
-    fun propertyNullableListWithConstructor() {
-        // given
-        val generator = Exp(Person::nullableDogs[0])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("nullableDogs[0]")
-    }
-
-    @Test
-    fun propertyListCombinesListWithConstructor() {
-        // given
-        val generator = Exp(Person::dogs[0] into Dog::loves[0])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[0].loves[0]")
-    }
-
-    @Test
-    fun propertyListCombinesListWithoutExp() {
+    fun propertyListCombinesList() {
         // given
         val generator = Person::dogs[0] into Dog::loves[0]
 
@@ -854,106 +388,7 @@ class ExpressionGeneratorsTest {
     }
 
     @Test
-    fun propertyBoolean() {
-        // given
-        val generator = Exp<Person>() into Person::married
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("married")
-    }
-
-    @Test
-    fun propertyBooleanWithConstructor() {
-        // given
-        val generator = Exp(Person::married)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("married")
-    }
-
-    @Test
-    fun propertyNullableBoolean() {
-        // given
-        val generator = Exp<Person>() into Person::happy
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("happy")
-    }
-
-    @Test
-    fun propertyNullableBooleanWithConstructor() {
-        // given
-        val generator = Exp(Person::happy)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("happy")
-    }
-
-    @Test
-    fun getterBoolean() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::isMarried
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("married")
-    }
-
-    @Test
-    fun getterBooleanWithConstructor() {
-        // given
-        val generator = ExpGetter(PersonJava::isMarried)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("married")
-    }
-
-    @Test
-    fun getterNullableBoolean() {
-        // given
-        val generator = Exp<PersonJava>() intoGetter PersonJava::getHappy
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("happy")
-    }
-
-    @Test
-    fun getterNullableBooleanWithConstructor() {
-        // given
-        val generator = ExpGetter(PersonJava::getHappy)
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("happy")
-    }
-
-    @Test
-    fun getterListCombinesListWithConstructor() {
-        // given
-        val generator = Exp(PersonJava::getDogs[0] into DogJava::getLoves[0])
-
-        // when
-        val actual = generator.generate()
-
-        then(actual).isEqualTo("dogs[0].loves[0]")
-    }
-
-    @Test
-    fun getterListCombinesListWithoutExp() {
+    fun getterListCombinesList() {
         // given
         val generator = PersonJava::getDogs[0] into DogJava::getLoves[0]
 

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/KotlinExpJacksonPropertyTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/KotlinExpJacksonPropertyTest.kt
@@ -59,7 +59,7 @@ data class JsonPropertyDataValue(
     var intValue: Int,
 
     @field:JsonProperty("string")
-    val stringValue: String,
+    val stringValue: String
 ) {
     @JsonProperty("intValue")
     fun getInt() = this.intValue


### PR DESCRIPTION
## Summary
Add JoinableExpressionGenerator for Exp

## (Optional): Description
Removing class `Exp`, `ExpList`
Splitting ExpressionGenerators into `ExpressionGeneratorExtensions` and `ExpressionGenerators` for better readability
