### PR TITLE
Add CombinableArbitrary for adding metadata

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContext.java
@@ -23,19 +23,18 @@ import java.util.TreeMap;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitrary;
-
 import com.navercorp.fixturemonkey.api.collection.LruCache;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class MonkeyContext {
-	private final LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
+	private final LruCache<Property, CombinableArbitrary> arbitrariesByProperty;
 	private final LruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
 
 	public MonkeyContext(
-		LruCache<Property, Arbitrary<?>> arbitrariesByProperty,
+		LruCache<Property, CombinableArbitrary> arbitrariesByProperty,
 		LruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty
 	) {
 		this.arbitrariesByProperty = arbitrariesByProperty;
@@ -46,12 +45,12 @@ public final class MonkeyContext {
 		return new MonkeyContextBuilder();
 	}
 
-	public Arbitrary<?> getCachedArbitrary(Property property) {
+	public CombinableArbitrary getCachedArbitrary(Property property) {
 		return arbitrariesByProperty.get(property);
 	}
 
-	public void putCachedArbitrary(Property property, Arbitrary<?> arbitrary) {
-		arbitrariesByProperty.put(property, arbitrary);
+	public void putCachedArbitrary(Property property, CombinableArbitrary combinableArbitrary) {
+		arbitrariesByProperty.put(property, combinableArbitrary);
 	}
 
 	public MonkeyGeneratorContext retrieveGeneratorContext(RootProperty rootProperty) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
@@ -21,20 +21,21 @@ package com.navercorp.fixturemonkey.api.context;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitrary;
-
 import com.navercorp.fixturemonkey.api.collection.LruCache;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class MonkeyContextBuilder {
-	private LruCache<Property, Arbitrary<?>> arbitrariesByProperty;
+	private LruCache<Property, CombinableArbitrary> arbitrariesByProperty;
 	private LruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
 	private int cacheSize = 2000;
 	private int generatorContextSize = 1000;
 
-	public MonkeyContextBuilder arbitrariesByProperty(LruCache<Property, Arbitrary<?>> arbitrariesByProperty) {
+	public MonkeyContextBuilder arbitrariesByProperty(
+		LruCache<Property, CombinableArbitrary> arbitrariesByProperty
+	) {
 		this.arbitrariesByProperty = arbitrariesByProperty;
 		return this;
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGenerator.java
@@ -21,10 +21,8 @@ package com.navercorp.fixturemonkey.api.generator;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitrary;
-
 @API(since = "0.4.0", status = Status.MAINTAINED)
 @FunctionalInterface
 public interface ArbitraryGenerator {
-	Arbitrary<?> generate(ArbitraryGeneratorContext context);
+	CombinableArbitrary generate(ArbitraryGeneratorContext context);
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -54,7 +54,7 @@ public final class ArbitraryGeneratorContext {
 	@Nullable
 	private final ArbitraryGeneratorContext ownerContext;
 
-	private final BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, Arbitrary<Object>> resolveArbitrary;
+	private final BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, CombinableArbitrary> resolveArbitrary;
 
 	@SuppressWarnings("rawtypes")
 	private final List<MatcherOperator<? extends FixtureCustomizer>> fixtureCustomizers;
@@ -72,7 +72,7 @@ public final class ArbitraryGeneratorContext {
 		ArbitraryProperty property,
 		List<ArbitraryProperty> children,
 		@Nullable ArbitraryGeneratorContext ownerContext,
-		BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, Arbitrary<Object>> resolveArbitrary,
+		BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, CombinableArbitrary> resolveArbitrary,
 		List<MatcherOperator<? extends FixtureCustomizer>> fixtureCustomizers,
 		MonkeyGeneratorContext monkeyGeneratorContext
 	) {
@@ -109,12 +109,12 @@ public final class ArbitraryGeneratorContext {
 		return Collections.unmodifiableList(this.children);
 	}
 
-	public Map<String, LazyArbitrary<Arbitrary<?>>> getArbitrariesByResolvedName() {
-		return childArbitraryContext.getValue().getArbitrariesByResolvedName();
+	public Map<String, CombinableArbitrary> getCombinableArbitrariesByResolvedName() {
+		return childArbitraryContext.getValue().getCombinableArbitrariesByResolvedName();
 	}
 
-	public Map<String, LazyArbitrary<Arbitrary<?>>> getArbitrariesByPropertyName() {
-		return childArbitraryContext.getValue().getArbitrariesByPropertyName();
+	public Map<String, CombinableArbitrary> getCombinableArbitrariesByPropertyName() {
+		return childArbitraryContext.getValue().getCombinableArbitraryByPropertyName();
 	}
 
 	public List<Arbitrary<?>> getArbitraries() {
@@ -161,9 +161,10 @@ public final class ArbitraryGeneratorContext {
 	}
 
 	private ChildArbitraryContext initChildArbitraryContext() {
-		Map<ArbitraryProperty, LazyArbitrary<Arbitrary<?>>> childrenValues = new LinkedHashMap<>();
+		Map<ArbitraryProperty, CombinableArbitrary> childrenValues = new LinkedHashMap<>();
 		for (ArbitraryProperty child : this.getChildren()) {
-			childrenValues.put(child, LazyArbitrary.lazy(() -> this.resolveArbitrary.apply(this, child)));
+			CombinableArbitrary arbitrary = this.resolveArbitrary.apply(this, child);
+			childrenValues.put(child, arbitrary);
 		}
 
 		ChildArbitraryContext childArbitraryContext = new ChildArbitraryContext(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/CombinableArbitrary.java
@@ -1,0 +1,55 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+/**
+ * An arbitrary instance for combining arbitraries in order to generate an instance of specific class.
+ */
+@API(since = "0.6.0", status = Status.EXPERIMENTAL)
+public interface CombinableArbitrary {
+	/**
+	 * Retrieves a combined arbitrary.
+	 *
+	 * @return a combined arbitrary
+	 */
+	Arbitrary<Object> combined();
+
+	/**
+	 * Retrieves an arbitrary to combine.
+	 * For example, a map whose keys are property names and values are property values.
+	 * Caller determines how the map is converted to an instance of class.
+	 *
+	 * @return an arbitrary to combine
+	 */
+	Arbitrary<Object> rawValue();
+
+	CombinableArbitrary filter(Predicate<Object> predicate);
+
+	CombinableArbitrary map(Function<Object, Object> mapper);
+
+	CombinableArbitrary injectNull(double nullProbability);
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -22,7 +22,6 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
@@ -40,7 +39,7 @@ public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 	}
 
 	@Override
-	public Arbitrary<?> generate(ArbitraryGeneratorContext context) {
+	public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
 		ArbitraryIntrospectorResult result = this.arbitraryIntrospector.introspect(context);
 		if (result.getValue() != null) {
 			double nullInject = context.getArbitraryProperty().getObjectProperty().getNullInject();
@@ -48,6 +47,6 @@ public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 				.injectNull(nullInject);
 		}
 
-		return Arbitraries.just(null);
+		return new FixedCombinableArbitrary(Arbitraries.just(null));
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
@@ -1,0 +1,63 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class FilteredCombinableArbitrary implements CombinableArbitrary {
+	private final CombinableArbitrary combinableArbitrary;
+	private final Predicate<Object> predicate;
+
+	public FilteredCombinableArbitrary(CombinableArbitrary combinableArbitrary, Predicate<Object> predicate) {
+		this.combinableArbitrary = combinableArbitrary;
+		this.predicate = predicate;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return combinableArbitrary.combined().filter(predicate);
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return combinableArbitrary.rawValue();
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FixedCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FixedCombinableArbitrary.java
@@ -1,0 +1,79 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class FixedCombinableArbitrary implements CombinableArbitrary {
+	private final Arbitrary<Object> arbitrary;
+
+	public FixedCombinableArbitrary(Arbitrary<Object> arbitrary) {
+		this.arbitrary = arbitrary;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return arbitrary;
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return arbitrary;
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		FixedCombinableArbitrary that = (FixedCombinableArbitrary)obj;
+		return Objects.equals(arbitrary, that.arbitrary);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(arbitrary);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/LazyCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/LazyCombinableArbitrary.java
@@ -1,0 +1,63 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class LazyCombinableArbitrary implements CombinableArbitrary {
+	private final LazyArbitrary<Arbitrary<Object>> introspected;
+
+	public LazyCombinableArbitrary(LazyArbitrary<Arbitrary<Object>> introspected) {
+		this.introspected = introspected;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return introspected.getValue();
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return introspected.getValue();
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
@@ -1,0 +1,63 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class MappedCombinableArbitrary implements CombinableArbitrary {
+	private final CombinableArbitrary combinableArbitrary;
+	private final Function<Object, Object> mapper;
+
+	public MappedCombinableArbitrary(CombinableArbitrary combinableArbitrary, Function<Object, Object> mapper) {
+		this.combinableArbitrary = combinableArbitrary;
+		this.mapper = mapper;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return combinableArbitrary.combined().map(mapper);
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return combinableArbitrary.rawValue();
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
@@ -1,0 +1,63 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class NullInjectCombinableArbitrary implements CombinableArbitrary {
+	private final CombinableArbitrary combinableArbitrary;
+	private final double nullProbability;
+
+	public NullInjectCombinableArbitrary(CombinableArbitrary combinableArbitrary, double nullProbability) {
+		this.combinableArbitrary = combinableArbitrary;
+		this.nullProbability = nullProbability;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return combinableArbitrary.combined().injectNull(nullProbability);
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return combinableArbitrary.rawValue();
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResult.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResult.java
@@ -25,21 +25,32 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.FixedCombinableArbitrary;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ArbitraryIntrospectorResult {
-	public static final ArbitraryIntrospectorResult EMPTY = new ArbitraryIntrospectorResult(null);
+	public static final ArbitraryIntrospectorResult EMPTY = new ArbitraryIntrospectorResult((Arbitrary<?>)null);
 
-	@Nullable
-	private final Arbitrary<?> value;
+	private final CombinableArbitrary value;
 
+	@SuppressWarnings("unchecked")
 	public ArbitraryIntrospectorResult(@Nullable Arbitrary<?> value) {
+		if (value == null) {
+			this.value = new FixedCombinableArbitrary(Arbitraries.just(null));
+		} else {
+			this.value = new FixedCombinableArbitrary((Arbitrary<Object>)value);
+		}
+	}
+
+	public ArbitraryIntrospectorResult(CombinableArbitrary value) {
 		this.value = value;
 	}
 
-	@Nullable
-	public Arbitrary<?> getValue() {
+	public CombinableArbitrary getValue() {
 		return this.value;
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BooleanIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BooleanIntrospector.java
@@ -38,6 +38,7 @@ public final class BooleanIntrospector implements ArbitraryIntrospector, Matcher
 
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		return new ArbitraryIntrospectorResult(Arbitraries.of(true, false));
+		return new ArbitraryIntrospectorResult(
+			Arbitraries.of(true, false));
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/IteratorIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/IteratorIntrospector.java
@@ -23,9 +23,8 @@ import java.util.Iterator;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitrary;
-
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -47,13 +46,13 @@ public final class IteratorIntrospector implements ArbitraryIntrospector, Matche
 			return result;
 		}
 
-		Arbitrary<?> arbitrary = result.getValue();
-		if (arbitrary == null) {
+		CombinableArbitrary combinableArbitrary = result.getValue();
+		if (combinableArbitrary == null) {
 			return result;
 		}
 
 		return new ArbitraryIntrospectorResult(
-			arbitrary.map(it -> {
+			combinableArbitrary.map(it -> {
 				if (it == null) {
 					return null;
 				}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResultTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResultTest.java
@@ -22,10 +22,12 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import org.junit.jupiter.api.Test;
 
+import net.jqwik.api.Arbitrary;
+
 class ArbitraryIntrospectorResultTest {
 	@Test
 	void equalsEmptyWithNull() {
-		ArbitraryIntrospectorResult sut = new ArbitraryIntrospectorResult(null);
+		ArbitraryIntrospectorResult sut = new ArbitraryIntrospectorResult((Arbitrary<?>)null);
 		then(ArbitraryIntrospectorResult.EMPTY.equals(sut)).isTrue();
 	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/CompositeArbitraryIntrospectorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/introspector/CompositeArbitraryIntrospectorTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
 
 class CompositeArbitraryIntrospectorTest {
 	@Test
@@ -33,7 +34,7 @@ class CompositeArbitraryIntrospectorTest {
 		CompositeArbitraryIntrospector sut = new CompositeArbitraryIntrospector(
 			Arrays.asList(
 				(context) -> ArbitraryIntrospectorResult.EMPTY,
-				(context) -> new ArbitraryIntrospectorResult(null),
+				(context) -> new ArbitraryIntrospectorResult((Arbitrary<?>)null),
 				(context) -> new ArbitraryIntrospectorResult(Arbitraries.strings()),
 				(context) -> new ArbitraryIntrospectorResult(Arbitraries.integers())
 			)
@@ -44,6 +45,6 @@ class CompositeArbitraryIntrospectorTest {
 
 		then(actual).isNotEqualTo(ArbitraryIntrospectorResult.EMPTY);
 		then(actual.getValue()).isNotNull();
-		then(actual.getValue().sample()).isExactlyInstanceOf(String.class);
+		then(actual.getValue().combined().sample()).isExactlyInstanceOf(String.class);
 	}
 }

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCombinableArbitrary.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCombinableArbitrary.java
@@ -1,0 +1,73 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.introspector;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.FilteredCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.MappedCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.NullInjectCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class JacksonCombinableArbitrary implements CombinableArbitrary {
+	private final LazyArbitrary<Arbitrary<Map<String, Object>>> arbitrary;
+	private final Function<Map<String, Object>, Object> deserializer;
+
+	public JacksonCombinableArbitrary(
+		LazyArbitrary<Arbitrary<Map<String, Object>>> arbitrary,
+		Function<Map<String, Object>, Object> deserializer
+	) {
+		this.arbitrary = arbitrary;
+		this.deserializer = deserializer;
+	}
+
+	@Override
+	public Arbitrary<Object> combined() {
+		return arbitrary.getValue().map(deserializer);
+	}
+
+	@Override
+	public Arbitrary<Object> rawValue() {
+		return arbitrary.getValue().asGeneric();
+	}
+
+	@Override
+	public CombinableArbitrary filter(Predicate<Object> predicate) {
+		return new FilteredCombinableArbitrary(this, predicate);
+	}
+
+	@Override
+	public CombinableArbitrary map(Function<Object, Object> mapper) {
+		return new MappedCombinableArbitrary(this, mapper);
+	}
+
+	@Override
+	public CombinableArbitrary injectNull(double nullProbability) {
+		return new NullInjectCombinableArbitrary(this, nullProbability);
+	}
+}

--- a/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyJacksonTest.java
+++ b/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyJacksonTest.java
@@ -58,6 +58,12 @@ class FixtureMonkeyJacksonTest {
 		then(actual.value).isNotNull();
 	}
 
+	@Property
+	void sampleNested() {
+		thenNoException()
+			.isThrownBy(() -> SUT.giveMeOne(NestedStringValue.class));
+	}
+
 	@Value
 	public static class JsonFormatSpec {
 		@JsonFormat(shape = Shape.NUMBER)
@@ -92,5 +98,15 @@ class FixtureMonkeyJacksonTest {
 	@Value
 	public static class JsonNodeWrapperClass {
 		JsonNode value;
+	}
+
+	@Value
+	public static class StringValue {
+		String innerValue;
+	}
+
+	@Value
+	public static class NestedStringValue {
+		StringValue value;
 	}
 }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -47,7 +47,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
             return ArbitraryIntrospectorResult.EMPTY
         }
 
-        val arbitrariesByPropertyName = context.arbitrariesByPropertyName
+        val arbitrariesByPropertyName = context.combinableArbitrariesByPropertyName.mapValues { it.value.combined() }
 
         val kotlinClass = Reflection.createKotlinClass(type) as KClass<*>
         val constructor = CONSTRUCTOR_CACHE.computeIfAbsent(type) {
@@ -56,7 +56,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
 
         var builderCombinator = Builders.withBuilder { mutableMapOf<KParameter, Any?>() }
         for (parameter in constructor.parameters) {
-            val parameterArbitrary = arbitrariesByPropertyName[parameter.name]?.value ?: Arbitraries.just(null)
+            val parameterArbitrary = arbitrariesByPropertyName[parameter.name] ?: Arbitraries.just(null)
             builderCombinator = builderCombinator.use(parameterArbitrary).`in` { map, value ->
                 map.apply {
                     this[parameter] = value
@@ -66,7 +66,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
         return ArbitraryIntrospectorResult(
             builderCombinator.build {
                 constructor.callBy(it)
-            }
+            },
         )
     }
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -344,7 +344,7 @@ class FixtureMonkeyOptionsTest {
 		FixtureMonkey sut = FixtureMonkey.builder()
 			.pushAssignableTypeArbitraryIntrospector(
 				SimpleObject.class,
-				(context) -> new ArbitraryIntrospectorResult(null)
+				(context) -> new ArbitraryIntrospectorResult((Arbitrary<?>)null)
 			)
 			.build();
 
@@ -358,7 +358,7 @@ class FixtureMonkeyOptionsTest {
 		FixtureMonkey sut = FixtureMonkey.builder()
 			.pushExactTypeArbitraryIntrospector(
 				SimpleObjectChild.class,
-				(context) -> new ArbitraryIntrospectorResult(null)
+				(context) -> new ArbitraryIntrospectorResult((Arbitrary<?>)null)
 			)
 			.build();
 
@@ -373,7 +373,7 @@ class FixtureMonkeyOptionsTest {
 			.pushArbitraryIntrospector(
 				MatcherOperator.exactTypeMatchOperator(
 					SimpleObjectChild.class,
-					(context) -> new ArbitraryIntrospectorResult(null)
+					(context) -> new ArbitraryIntrospectorResult((Arbitrary<?>)null)
 				)
 			)
 			.build();


### PR DESCRIPTION
## Summary
Add CombinableArbitrary for adding metadata when generating an object

## (Optional): Description
객체를 생성할 때 메타 데이터가 필요한 경우가 있습니다.
ex. Jackson에서 `@JsonSubTypes`, `@JsonTypeInfo`를 사용해 추상 타입을 추론할 때 필요한 `@type` 필드

생성하고 객체로 바로 변환하지 않고 필드와 메타데이터를 가지고 있는 객체를 반환하고
사용자가 최종적으로 사용할 때 객체로 변환하도록 합니다.