### PR TITLE
Use setup-java action to cache dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
+          cache: 'gradle'
       - name: Execute check without tests
         uses: gradle/gradle-build-action@v2.2.1
         with:
@@ -32,10 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.Java }}
+          cache: 'gradle'
       - name: Execute tests
         uses: gradle/gradle-build-action@v2.2.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Restore gradle.properties


### PR DESCRIPTION
## Summary

Updated workflows to cache dependencies using [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies). `setup-java@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Java projects can run faster on GitHub Actions by enabling dependency caching on the [setup-java](https://github.com/actions/setup-java) action. `setup-java` supports caching for both Gradle and Maven projects.

**AS-IS**

```yaml
- name: Set up JDK
  uses: actions/setup-java@v2
  with:
    distribution: 'temurin'
    java-version: 8
```

**TO-BE**

```yaml
- name: Set up JDK
  uses: actions/setup-java@v3
  with:
    distribution: 'temurin'
    java-version: 8
    cache: 'gradle'
```

> It’s literally a one line change to pass the `cache: 'gradle'` input parameter.

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)