### PR TITLE
Add a condition to not include control characters when creating String values (#553)

### DIFF
--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationJavaArbitraryResolver.java
@@ -50,7 +50,6 @@ import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 
 @API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationJavaArbitraryResolver implements JavaArbitraryResolver {
-	private static final String CONTROL_BLOCK = "\u0000-\u001f\u007f";
 	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
 
 	private final JakartaValidationConstraintGenerator constraintGenerator;
@@ -117,15 +116,29 @@ public final class JakartaValidationJavaArbitraryResolver implements JavaArbitra
 		return arbitrary
 			.filter(it -> {
 				if (!notBlank) {
-					return true;
+					if (it == null) {
+						return true;
+					} else {
+						return !containsControlCharacters(it);
+					}
 				}
 
-				if (it == null || it.trim().length() == 0) {
+				if (it == null || it.trim().isEmpty()) {
 					return false;
 				}
 
-				return !CONTROL_BLOCK.equals(it.trim());
+				return !containsControlCharacters(it);
 			});
+	}
+
+	private static boolean containsControlCharacters(String value) {
+		for (char c : value.toCharArray()) {
+			if (Character.isISOControl(c)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
@@ -227,10 +227,6 @@ class JakartaValidationFixtureMonkeyTest {
 		then(actual.getEmail()).containsOnlyOnce("@");
 		Pattern controlCharacters = Pattern.compile("[\u0000-\u001f\u007f]");
 		then(actual.getStr()).doesNotMatch(controlCharacters);
-		then(actual.getNotEmpty()).doesNotMatch(controlCharacters);
-		then(actual.getSize()).doesNotMatch(controlCharacters);
-		then(actual.getDigits()).doesNotMatch(controlCharacters);
-		then(actual.getEmail()).doesNotMatch(controlCharacters);
 	}
 
 	@Property(tries = 100)

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
@@ -225,6 +225,12 @@ class JakartaValidationFixtureMonkeyTest {
 			then(ch).isBetween('e', 'o');
 		}
 		then(actual.getEmail()).containsOnlyOnce("@");
+		Pattern controlCharacters = Pattern.compile("[\u0000-\u001f\u007f]");
+		then(actual.getStr()).doesNotMatch(controlCharacters);
+		then(actual.getNotEmpty()).doesNotMatch(controlCharacters);
+		then(actual.getSize()).doesNotMatch(controlCharacters);
+		then(actual.getDigits()).doesNotMatch(controlCharacters);
+		then(actual.getEmail()).doesNotMatch(controlCharacters);
 	}
 
 	@Property(tries = 100)

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationJavaArbitraryResolver.java
@@ -50,7 +50,6 @@ import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationJavaArbitraryResolver implements JavaArbitraryResolver {
-	private static final String CONTROL_BLOCK = "\u0000-\u001f\u007f";
 	private static final RegexGenerator REGEX_GENERATOR = new RegexGenerator();
 
 	private final JavaxValidationConstraintGenerator constraintGenerator;
@@ -117,15 +116,29 @@ public final class JavaxValidationJavaArbitraryResolver implements JavaArbitrary
 		return arbitrary
 			.filter(it -> {
 				if (!notBlank) {
-					return true;
+					if (it == null) {
+						return true;
+					} else {
+						return !containsControlCharacters(it);
+					}
 				}
 
-				if (it == null || it.trim().length() == 0) {
+				if (it == null || it.trim().isEmpty()) {
 					return false;
 				}
 
-				return !CONTROL_BLOCK.equals(it.trim());
+				return !containsControlCharacters(it);
 			});
+	}
+
+	private static boolean containsControlCharacters(String value) {
+		for (char c : value.toCharArray()) {
+			if (Character.isISOControl(c)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
@@ -225,6 +225,12 @@ class JavaxValidationFixtureMonkeyTest {
 			then(ch).isBetween('e', 'o');
 		}
 		then(actual.getEmail()).containsOnlyOnce("@");
+		Pattern controlCharacters = Pattern.compile("[\u0000-\u001f\u007f]");
+		then(actual.getStr()).doesNotMatch(controlCharacters);
+		then(actual.getNotEmpty()).doesNotMatch(controlCharacters);
+		then(actual.getSize()).doesNotMatch(controlCharacters);
+		then(actual.getDigits()).doesNotMatch(controlCharacters);
+		then(actual.getEmail()).doesNotMatch(controlCharacters);
 	}
 
 	@Property(tries = 100)

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
@@ -227,10 +227,6 @@ class JavaxValidationFixtureMonkeyTest {
 		then(actual.getEmail()).containsOnlyOnce("@");
 		Pattern controlCharacters = Pattern.compile("[\u0000-\u001f\u007f]");
 		then(actual.getStr()).doesNotMatch(controlCharacters);
-		then(actual.getNotEmpty()).doesNotMatch(controlCharacters);
-		then(actual.getSize()).doesNotMatch(controlCharacters);
-		then(actual.getDigits()).doesNotMatch(controlCharacters);
-		then(actual.getEmail()).doesNotMatch(controlCharacters);
 	}
 
 	@Property(tries = 100)


### PR DESCRIPTION
## Summary
Fix #553 

## (Optional): Description
Add a condition to not include [control characters](https://en.wikipedia.org/wiki/Control_character) when creating String values through `XXXValidationJavaArbitraryResolver`.

## How Has This Been Tested?
Add additional assertions to existing test code