### PR TITLE
Fix flatten node resolvers when distinct

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/CompositeNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/CompositeNodeResolver.java
@@ -83,7 +83,7 @@ public final class CompositeNodeResolver implements NodeResolver {
 			NodeResolver resolver = resolvers.get(i);
 			if (resolver instanceof CompositeNodeResolver) {
 				CompositeNodeResolver compositeNodeResolver = (CompositeNodeResolver)resolver;
-				List<NodeResolver> componentNodeResolvers = compositeNodeResolver.nodeResolvers.stream()
+				List<NodeResolver> componentNodeResolvers = compositeNodeResolver.flatten().stream()
 					.filter(it -> !(it instanceof IdentityNodeResolver))
 					.collect(Collectors.toList());
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTest.java
@@ -81,6 +81,7 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.SimpleObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.StaticFieldObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.StringAndInt;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.StringPair;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.ThirdNestedListStringObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.TwoEnum;
 
 class FixtureMonkeyTest {
@@ -1680,5 +1681,21 @@ class FixtureMonkeyTest {
 		thenNoException()
 			.isThrownBy(() -> SUT.giveMeOne(new TypeReference<GenericSimpleObject>() {
 			}));
+	}
+
+	@Property
+	void sizeThirdNestedNested() {
+		List<String> actual = SUT.giveMeBuilder(ThirdNestedListStringObject.class)
+			.size("values", 1)
+			.size("values[0].values", 1)
+			.size("values[0].values[0].values", 1)
+			.sample()
+			.getValues()
+			.get(0)
+			.getValues()
+			.get(0)
+			.getValues();
+
+		then(actual).hasSize(1);
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyTestSpecs.java
@@ -283,4 +283,16 @@ class FixtureMonkeyTestSpecs {
 	public static class GenericSimpleObject extends GenericValue<SimpleObject> {
 		String childValue;
 	}
+
+	@Setter
+	@Getter
+	public static class NestedListStringObject {
+		List<ListStringObject> values;
+	}
+
+	@Setter
+	@Getter
+	public static class ThirdNestedListStringObject {
+		List<NestedListStringObject> values;
+	}
 }


### PR DESCRIPTION
## Summary
Fix flatten node resolvers when distinct

## (Optional): Description
표현식에서 Exp 객체 두개가 있을 때, 두 개를 합치면  `IdentityNodeResolver`를 포함하는 문제를 해결합니다.

## How Has This Been Tested?
* sizeThirdNestedNested
