### PR TITLE
Refactor ContainerInfoManipulator

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -41,10 +41,11 @@ import com.navercorp.fixturemonkey.resolver.CompositeNodeResolver;
 import com.navercorp.fixturemonkey.resolver.ContainerElementPredicate;
 import com.navercorp.fixturemonkey.resolver.DefaultNodeResolver;
 import com.navercorp.fixturemonkey.resolver.IdentityNodeResolver;
-import com.navercorp.fixturemonkey.resolver.NodeAllEntryPredicate;
-import com.navercorp.fixturemonkey.resolver.NodeEntryPredicate;
-import com.navercorp.fixturemonkey.resolver.NodeKeyValuePredicate;
+import com.navercorp.fixturemonkey.resolver.NodeAllElementPredicate;
+import com.navercorp.fixturemonkey.resolver.NodeElementPredicate;
+import com.navercorp.fixturemonkey.resolver.NodeKeyPredicate;
 import com.navercorp.fixturemonkey.resolver.NodeResolver;
+import com.navercorp.fixturemonkey.resolver.NodeValuePredicate;
 import com.navercorp.fixturemonkey.resolver.PropertyNameNodePredicate;
 
 @SuppressWarnings("UnusedReturnValue")
@@ -256,8 +257,8 @@ public final class InnerSpec {
 
 		NodeResolver nextKeyNodeResolver = new CompositeNodeResolver(
 			this.treePathResolver,
-			new DefaultNodeResolver(new NodeEntryPredicate(entrySize - 1)),
-			new DefaultNodeResolver(new NodeKeyValuePredicate(true))
+			new DefaultNodeResolver(new NodeElementPredicate(entrySize - 1)),
+			new DefaultNodeResolver(new NodeKeyPredicate())
 		);
 
 		setValue(nextKeyNodeResolver, mapKey);
@@ -272,8 +273,8 @@ public final class InnerSpec {
 
 		NodeResolver nextKeyNodeResolver = new CompositeNodeResolver(
 			this.treePathResolver,
-			new DefaultNodeResolver(new NodeAllEntryPredicate()),
-			new DefaultNodeResolver(new NodeKeyValuePredicate(true))
+			new DefaultNodeResolver(new NodeAllElementPredicate()),
+			new DefaultNodeResolver(new NodeKeyPredicate())
 		);
 
 		setValue(nextKeyNodeResolver, mapKey);
@@ -282,8 +283,8 @@ public final class InnerSpec {
 	private void setMapValue(@Nullable Object mapValue) {
 		NodeResolver nextValueNodeResolver = new CompositeNodeResolver(
 			this.treePathResolver,
-			new DefaultNodeResolver(new NodeEntryPredicate(entrySize - 1)),
-			new DefaultNodeResolver(new NodeKeyValuePredicate(false))
+			new DefaultNodeResolver(new NodeElementPredicate(entrySize - 1)),
+			new DefaultNodeResolver(new NodeValuePredicate())
 		);
 
 		setValue(nextValueNodeResolver, mapValue);
@@ -292,8 +293,8 @@ public final class InnerSpec {
 	private void setMapAllValue(@Nullable Object mapValue) {
 		NodeResolver nextValueNodeResolver = new CompositeNodeResolver(
 			this.treePathResolver,
-			new DefaultNodeResolver(new NodeAllEntryPredicate()),
-			new DefaultNodeResolver(new NodeKeyValuePredicate(false))
+			new DefaultNodeResolver(new NodeAllElementPredicate()),
+			new DefaultNodeResolver(new NodeValuePredicate())
 		);
 
 		setValue(nextValueNodeResolver, mapValue);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -83,7 +84,7 @@ public final class ArbitraryTraverser {
 		ContainerProperty containerProperty = null;
 		if (container) {
 			ArbitraryContainerInfo containerInfo = containerInfoManipulators.stream()
-				.filter(it -> it.isMatch(Collections.emptyList(), objectProperty))
+				.filter(it -> it.isMatch(Collections.singletonList(objectProperty)))
 				.findFirst()
 				.map(ContainerInfoManipulator::getContainerInfo)
 				.orElse(null);
@@ -208,12 +209,14 @@ public final class ArbitraryTraverser {
 
 			ContainerProperty childContainerProperty = null;
 			if (childContainer) {
+				List<ObjectProperty> objectProperties =
+					context.getArbitraryProperties().stream()
+						.map(ArbitraryProperty::getObjectProperty).collect(Collectors.toList());
+				objectProperties.add(childObjectProperty);
+
 				ArbitraryContainerInfo containerInfo = null;
 				for (ContainerInfoManipulator containerInfoManipulator : containerInfoManipulators) {
-					if (containerInfoManipulator.isMatch(
-						context.getArbitraryProperties(),
-						childObjectProperty
-					)) {
+					if (containerInfoManipulator.isMatch(objectProperties)) {
 						containerInfo = containerInfoManipulator.getContainerInfo();
 					}
 				}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementPredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerElementPredicate.java
@@ -20,13 +20,9 @@ package com.navercorp.fixturemonkey.resolver;
 
 import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALUE;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -40,11 +36,7 @@ public final class ContainerElementPredicate implements NextNodePredicate {
 	}
 
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
+	public boolean test(ObjectProperty currentObjectProperty) {
 		Property property = currentObjectProperty.getProperty();
 		if (!(property instanceof ElementProperty)) {
 			throw new IllegalArgumentException("Resolved node is not element type. : " + property);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerInfoManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ContainerInfoManipulator.java
@@ -26,7 +26,6 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
@@ -49,7 +48,7 @@ public final class ContainerInfoManipulator {
 
 	ContainerInfoManipulator withPrependNextNodePredicate(NextNodePredicate nextNodePredicate) {
 		List<NextNodePredicate> nodePredicatesWithoutRoot = this.nextNodePredicates.stream()
-			.filter(it -> !(it instanceof RootPredicate))
+			.filter(it -> !(it instanceof StartNodePredicate))
 			.collect(Collectors.toList());
 
 		List<NextNodePredicate> newNextNodePredicates = new ArrayList<>();
@@ -72,45 +71,23 @@ public final class ContainerInfoManipulator {
 		);
 	}
 
-	public boolean isMatch(
-		List<ArbitraryProperty> parentArbitraryProperties,
-		ObjectProperty currentObjectProperty
-	) {
-		int parentArbitraryPropertySize = parentArbitraryProperties.size();
+	public boolean isMatch(List<ObjectProperty> objectProperties) {
+		int objectPropertiesSize = objectProperties.size();
 		int nextNodePredicateSize = nextNodePredicates.size();
 
 		boolean registered = nextNodePredicates.get(0) instanceof PropertyPredicate;
-		if (!registered && nextNodePredicateSize != parentArbitraryPropertySize + 1) {
+		if (!registered && nextNodePredicateSize != objectPropertiesSize) {
 			return false;
 		}
 
 		for (int i = 0; i < nextNodePredicateSize; i++) {
 			int reversedNextNodePredicateIndex = nextNodePredicateSize - 1 - i;
-			int reversedCurrentArbitraryPropertyIndex = parentArbitraryPropertySize - i;
+			int reversedCurrentObjectPropertyIndex = objectPropertiesSize - 1 - i;
 			NextNodePredicate nextNodePredicate = nextNodePredicates.get(reversedNextNodePredicateIndex);
-			ArbitraryProperty parentArbitraryProperty = reversedCurrentArbitraryPropertyIndex == 0
-				? null
-				: parentArbitraryProperties.get(reversedCurrentArbitraryPropertyIndex - 1);
+			ObjectProperty objectProperty = objectProperties.get(reversedCurrentObjectPropertyIndex);
 
-			if (reversedCurrentArbitraryPropertyIndex == parentArbitraryPropertySize) {
-				if (!nextNodePredicate.test(
-					parentArbitraryProperty,
-					currentObjectProperty,
-					null
-				)) {
-					return false;
-				}
-			} else {
-				ArbitraryProperty currentArbitraryProperty =
-					parentArbitraryProperties.get(reversedCurrentArbitraryPropertyIndex);
-
-				if (!nextNodePredicate.test(
-					parentArbitraryProperty,
-					currentArbitraryProperty.getObjectProperty(),
-					currentArbitraryProperty.getContainerProperty()
-				)) {
-					return false;
-				}
+			if (!nextNodePredicate.test(objectProperty)) {
+				return false;
 			}
 		}
 		return true;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultNodeResolver.java
@@ -38,11 +38,7 @@ public class DefaultNodeResolver implements NodeResolver {
 	@Override
 	public List<ArbitraryNode> resolve(ArbitraryNode arbitraryNode) {
 		List<ArbitraryNode> resolved = arbitraryNode.getChildren().stream()
-			.filter(it -> nextNodePredicate.test(
-				arbitraryNode.getArbitraryProperty(),
-				it.getArbitraryProperty().getObjectProperty(),
-				it.getArbitraryProperty().getContainerProperty()
-			))
+			.filter(it -> nextNodePredicate.test(it.getArbitraryProperty().getObjectProperty()))
 			.collect(Collectors.toList());
 
 		arbitraryNode.setManipulated(true);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/IdentityNodeResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/IdentityNodeResolver.java
@@ -42,6 +42,6 @@ public final class IdentityNodeResolver implements NodeResolver {
 
 	@Override
 	public List<NextNodePredicate> toNextNodePredicate() {
-		return Collections.singletonList(RootPredicate.INSTANCE);
+		return Collections.singletonList(StartNodePredicate.INSTANCE);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NextNodePredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NextNodePredicate.java
@@ -17,21 +17,13 @@
  */
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 @FunctionalInterface
 public interface NextNodePredicate {
-	boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	);
+	boolean test(ObjectProperty currentObjectProperty);
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeAllElementPredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeAllElementPredicate.java
@@ -18,40 +18,24 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class NodeEntryPredicate implements NextNodePredicate {
-	private final int index;
-
-	public NodeEntryPredicate(int index) {
-		this.index = index;
-	}
+public final class NodeAllElementPredicate implements NextNodePredicate {
 
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
-		if (parentArbitraryProperty == null
-			|| parentArbitraryProperty.getContainerProperty() == null
-			|| currentObjectProperty.getElementIndex() == null) {
+	public boolean test(ObjectProperty currentObjectProperty) {
+		if (currentObjectProperty.getElementIndex() == null) {
 			throw new IllegalArgumentException(
-				"Only Map.Entry could be selected. now type : " + currentObjectProperty.getProperty()
+				"It is not an element property. now type : " + currentObjectProperty.getProperty()
 					.getType()
 					.getTypeName()
 			);
 		}
 
-		int elementIndex = currentObjectProperty.getElementIndex();
-		return elementIndex == index;
+		return true;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeElementPredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeElementPredicate.java
@@ -18,34 +18,30 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class NodeAllEntryPredicate implements NextNodePredicate {
+public final class NodeElementPredicate implements NextNodePredicate {
+	private final int index;
+
+	public NodeElementPredicate(int index) {
+		this.index = index;
+	}
 
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
-		if (parentArbitraryProperty == null
-			|| parentArbitraryProperty.getContainerProperty() == null
-			|| currentObjectProperty.getElementIndex() == null) {
+	public boolean test(ObjectProperty currentObjectProperty) {
+		if (currentObjectProperty.getElementIndex() == null) {
 			throw new IllegalArgumentException(
-				"Only Map.Entry could be selected. now type : " + currentObjectProperty.getProperty()
+				"It is not an element property. now type : " + currentObjectProperty.getProperty()
 					.getType()
 					.getTypeName()
 			);
 		}
 
-		return true;
+		int elementIndex = currentObjectProperty.getElementIndex();
+		return elementIndex == index;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyPredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeKeyPredicate.java
@@ -18,25 +18,19 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
+import com.navercorp.fixturemonkey.api.property.MapKeyElementProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class RootPredicate implements NextNodePredicate {
-	public static final RootPredicate INSTANCE = new RootPredicate();
-
+public final class NodeKeyPredicate implements NextNodePredicate {
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
-		return parentArbitraryProperty == null;
+	public boolean test(ObjectProperty currentObjectProperty) {
+		Property property = currentObjectProperty.getProperty();
+
+		return property instanceof MapKeyElementProperty;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeValuePredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/NodeValuePredicate.java
@@ -18,35 +18,18 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
-import com.navercorp.fixturemonkey.api.property.MapKeyElementProperty;
 import com.navercorp.fixturemonkey.api.property.MapValueElementProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
 
-@API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class NodeKeyValuePredicate implements NextNodePredicate {
-	private final boolean key;
-
-	public NodeKeyValuePredicate(boolean key) {
-		this.key = key;
-	}
-
+@API(since = "0.5.0", status = Status.EXPERIMENTAL)
+public final class NodeValuePredicate implements NextNodePredicate {
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
-		if (key) {
-			return currentObjectProperty.getProperty() instanceof MapKeyElementProperty;
-		} else {
-			return currentObjectProperty.getProperty() instanceof MapValueElementProperty;
-		}
+	public boolean test(ObjectProperty currentObjectProperty) {
+		Property property = currentObjectProperty.getProperty();
+		return property instanceof MapValueElementProperty;
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyPredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/PropertyPredicate.java
@@ -18,13 +18,9 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import javax.annotation.Nullable;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 
@@ -37,11 +33,7 @@ public final class PropertyPredicate implements NextNodePredicate {
 	}
 
 	@Override
-	public boolean test(
-		@Nullable ArbitraryProperty parentArbitraryProperty,
-		ObjectProperty currentObjectProperty,
-		@Nullable ContainerProperty currentContainerProperty
-	) {
+	public boolean test(ObjectProperty currentObjectProperty) {
 		return property.equals(currentObjectProperty.getProperty());
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/StartNodePredicate.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/StartNodePredicate.java
@@ -18,43 +18,23 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
-import static com.navercorp.fixturemonkey.Constants.ALL_INDEX_STRING;
-
-import java.util.Objects;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ObjectProperty;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
-public final class PropertyNameNodePredicate implements NextNodePredicate {
-	private final String propertyName;
+public final class StartNodePredicate implements NextNodePredicate {
+	public static final StartNodePredicate INSTANCE = new StartNodePredicate();
 
-	public PropertyNameNodePredicate(String propertyName) {
-		this.propertyName = propertyName;
-	}
-
+	/**
+	 * It determines if given objectProperty is a first node.
+	 *
+	 * @param currentObjectProperty property to determines
+	 * @return true
+	 */
 	@Override
 	public boolean test(ObjectProperty currentObjectProperty) {
-		String nodePropertyName = currentObjectProperty.getResolvedPropertyName();
-		return ALL_INDEX_STRING.equals(propertyName) || propertyName.equals(nodePropertyName);
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
-		PropertyNameNodePredicate that = (PropertyNameNodePredicate)obj;
-		return propertyName.equals(that.propertyName);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(propertyName);
+		return true; // always returns true since the first node has no constraint
 	}
 }


### PR DESCRIPTION
## Summary
Refactor ContainerInfoManipulator removing useless dependencies

## (Optional): Description
Remove useless dependencies in a `NextNodePredicate` interface.
It only depends on `ObjectProperty`

## How Has This Been Tested?
* Existing tests
