### PR TITLE
Refactor ArbitraryGeneratorContext returns Arbitrary lazily

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -20,27 +20,28 @@ package com.navercorp.fixturemonkey.api.generator;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitrary;
 
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class ChildArbitraryContext {
 	private final Property parentProperty;
-	private final Map<ArbitraryProperty, Arbitrary<?>> arbitrariesByChildProperty;
+	private final Map<ArbitraryProperty, LazyArbitrary<Arbitrary<?>>> arbitrariesByChildProperty;
 
 	public ChildArbitraryContext(
 		Property parentProperty,
-		Map<ArbitraryProperty, Arbitrary<?>> arbitrariesByChildProperty
+		Map<ArbitraryProperty, LazyArbitrary<Arbitrary<?>>> arbitrariesByChildProperty
 	) {
 		this.parentProperty = parentProperty;
 		this.arbitrariesByChildProperty = arbitrariesByChildProperty;
@@ -51,12 +52,12 @@ public final class ChildArbitraryContext {
 	}
 
 	public void replaceArbitrary(Matcher matcher, Arbitrary<?> arbitrary) {
-		for (Entry<ArbitraryProperty, Arbitrary<?>> arbitraryByChildProperty
+		for (Entry<ArbitraryProperty, LazyArbitrary<Arbitrary<?>>> arbitraryByChildProperty
 			: arbitrariesByChildProperty.entrySet()) {
 			ArbitraryProperty arbitraryProperty = arbitraryByChildProperty.getKey();
 			ObjectProperty objectProperty = arbitraryProperty.getObjectProperty();
 			if (matcher.match(objectProperty.getProperty())) {
-				arbitrariesByChildProperty.put(arbitraryProperty, arbitrary);
+				arbitrariesByChildProperty.put(arbitraryProperty, LazyArbitrary.lazy(() -> arbitrary));
 			}
 		}
 	}
@@ -66,17 +67,19 @@ public final class ChildArbitraryContext {
 			.removeIf(it -> matcher.match(it.getKey().getObjectProperty().getProperty()));
 	}
 
-	public Map<String, Arbitrary<?>> getArbitrariesByResolvedName() {
-		return arbitrariesByChildProperty.entrySet().stream()
-			.collect(toMap(it -> it.getKey().getObjectProperty().getResolvedPropertyName(), Entry::getValue));
-	}
-
-	public Map<String, Arbitrary<?>> getArbitrariesByPropertyName() {
+	public Map<String, LazyArbitrary<Arbitrary<?>>> getArbitrariesByPropertyName() {
 		return arbitrariesByChildProperty.entrySet().stream()
 			.collect(toMap(it -> it.getKey().getObjectProperty().getProperty().getName(), Entry::getValue));
 	}
 
+	public Map<String, LazyArbitrary<Arbitrary<?>>> getArbitrariesByResolvedName() {
+		return arbitrariesByChildProperty.entrySet().stream()
+			.collect(toMap(it -> it.getKey().getObjectProperty().getResolvedPropertyName(), Entry::getValue));
+	}
+
 	public List<Arbitrary<?>> getArbitraries() {
-		return new ArrayList<>(arbitrariesByChildProperty.values());
+		return arbitrariesByChildProperty.values().stream()
+			.map(LazyArbitrary::getValue)
+			.collect(Collectors.toList());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -58,7 +58,7 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 		BuilderCombinator<ArrayBuilder> builderCombinator = Builders.withBuilder(() ->
 			new ArrayBuilder(
 				Types.getArrayComponentType(property.getObjectProperty().getProperty().getAnnotatedType()),

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -31,12 +31,14 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Builders;
 import net.jqwik.api.Builders.BuilderCombinator;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 import com.navercorp.fixturemonkey.api.type.Types;
@@ -55,8 +57,7 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 		}
 
 		List<ArbitraryProperty> childrenProperties = context.getChildren();
-		Map<String, Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts()
-			.getArbitrariesByResolvedName();
+		Map<String, LazyArbitrary<Arbitrary<?>>> childrenArbitraries = context.getArbitrariesByResolvedName();
 		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptors(type);
 		BuilderCombinator<?> builderCombinator = Builders.withBuilder(() -> ReflectionUtils.newInstance(type));
 		for (ArbitraryProperty arbitraryProperty : childrenProperties) {
@@ -68,7 +69,11 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 			}
 
 			String resolvePropertyName = arbitraryProperty.getObjectProperty().getResolvedPropertyName();
-			Arbitrary<?> arbitrary = childrenArbitraries.get(resolvePropertyName);
+			Arbitrary<?> arbitrary = childrenArbitraries.getOrDefault(
+					resolvePropertyName,
+					LazyArbitrary.lazy(() -> Arbitraries.just(null))
+				)
+				.getValue();
 			if (arbitrary != null) {
 				builderCombinator = builderCombinator.use(arbitrary).in((b, v) -> {
 					try {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
@@ -56,7 +56,7 @@ public final class EntryIntrospector implements ArbitraryIntrospector, Matcher {
 			);
 		}
 		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
@@ -59,7 +59,7 @@ public final class ListIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 		BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {
 			builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
@@ -61,7 +61,7 @@ public final class MapEntryElementIntrospector implements ArbitraryIntrospector,
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> arbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> arbitraries = context.getArbitraries();
 
 		if (arbitraries.size() != 2) {
 			throw new IllegalArgumentException("Key and Value should be exist for MapEntryElementType.");

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
@@ -60,7 +60,7 @@ public final class MapIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 
 		Arbitrary<?> mapArbitrary = new MonkeyCombineArbitrary(
 			list -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
@@ -72,7 +72,7 @@ public final class OptionalIntrospector implements ArbitraryIntrospector, Matche
 		}
 
 		Class<?> type = Types.getActualType(property.getObjectProperty().getProperty().getType());
-		List<Arbitrary<?>> childArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childArbitraries = context.getArbitraries();
 		Arbitrary<?> elementArbitrary = childArbitraries.get(0)
 			.optional(presenceProbability)
 			.map(it -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
@@ -60,7 +60,7 @@ public final class QueueIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 
 		BuilderCombinator<Queue<Object>> builderCombinator = Builders.withBuilder(LinkedList::new);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
@@ -62,7 +62,7 @@ public final class SetIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries().stream()
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries().stream()
 			.map(arbitrary ->
 				new FilteredMonkeyArbitrary<>(
 					arbitrary,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
@@ -69,7 +69,7 @@ public final class StreamIntrospector implements ArbitraryIntrospector, Matcher 
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 
 		BuilderCombinator<Builder<Object>> builderCombinator = Builders.withBuilder(Stream::builder);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
@@ -39,7 +39,7 @@ public final class TupleLikeElementsIntrospector implements ArbitraryIntrospecto
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 		BuilderCombinator<TupleLikeElementsType> builderCombinator = Builders.withBuilder(TupleLikeElementsType::new);
 		for (Arbitrary<?> child : childrenArbitraries) {
 			builderCombinator = builderCombinator.use(child).in((elements, value) -> {

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
@@ -67,7 +67,7 @@ public final class JsonNodeIntrospector implements ArbitraryIntrospector {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 
 		BuilderCombinator<Map<Object, Object>> builderCombinator = Builders.withBuilder(HashMap::new);
 		for (Arbitrary<?> child : childrenArbitraries) {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -23,6 +23,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult
 import com.navercorp.fixturemonkey.api.type.Types
+import net.jqwik.api.Arbitraries
 import net.jqwik.api.Builders
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.EXPERIMENTAL
@@ -46,7 +47,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
             return ArbitraryIntrospectorResult.EMPTY
         }
 
-        val arbitrariesByPropertyName = context.childrenArbitraryContexts.arbitrariesByPropertyName
+        val arbitrariesByPropertyName = context.arbitrariesByPropertyName
 
         val kotlinClass = Reflection.createKotlinClass(type) as KClass<*>
         val constructor = CONSTRUCTOR_CACHE.computeIfAbsent(type) {
@@ -55,7 +56,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
 
         var builderCombinator = Builders.withBuilder { mutableMapOf<KParameter, Any?>() }
         for (parameter in constructor.parameters) {
-            val parameterArbitrary = arbitrariesByPropertyName[parameter.name]
+            val parameterArbitrary = arbitrariesByPropertyName[parameter.name]?.value ?: Arbitraries.just(null)
             builderCombinator = builderCombinator.use(parameterArbitrary).`in` { map, value ->
                 map.apply {
                     this[parameter] = value

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
@@ -144,7 +144,7 @@ class FixtureMonkeyOptionsAdditionalTestSpecs {
 				return ArbitraryIntrospectorResult.EMPTY;
 			}
 
-			List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+			List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
 			BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
 			for (Arbitrary<?> childArbitrary : childrenArbitraries) {
 				builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {


### PR DESCRIPTION
## Summary
Refactor ArbitraryGeneratorContext returns Arbitrary lazily

## (Optional): Description
Only property in use would be resolved.

Make getter of ChildArbitraryContext private 

## How Has This Been Tested?
* existing tests
