### PR TITLE
Upgrade Jackson version 2.14.2

### DIFF
--- a/fixture-monkey-jackson/build.gradle
+++ b/fixture-monkey-jackson/build.gradle
@@ -7,11 +7,15 @@ plugins {
     id "checkstyle"
 }
 
+ext {
+    JACKSON_VERSION = "2.14.2"
+}
+
 dependencies {
     api(project(":fixture-monkey"))
-    api('com.fasterxml.jackson.core:jackson-databind:2.14.1')
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.1")
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.1")
+    api("com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION}")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${JACKSON_VERSION}")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${JACKSON_VERSION}")
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")


### PR DESCRIPTION
## Summary
Upgrade Jackson version 2.14.2

## (Optional): Description
Upgrade due to security vulnerability

https://ossindex.sonatype.org/vulnerability/sonatype-2022-6438?component-type=maven&component-name=com.fasterxml.jackson.core%2Fjackson-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0

## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*
