### PR TITLE
Replace defaultArbitraryContainerInfo to defaultArbitraryContainerInfoGenerator

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptions.java
@@ -41,7 +41,6 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArrayContainerPropertyGenerator;
@@ -106,8 +105,7 @@ public final class GenerateOptions {
 	private final List<MatcherOperator<NullInjectGenerator>> nullInjectGenerators;
 	private final NullInjectGenerator defaultNullInjectGenerator;
 	private final List<MatcherOperator<ArbitraryContainerInfoGenerator>> arbitraryContainerInfoGenerators;
-	private final int defaultArbitraryContainerSize;
-	private final ArbitraryContainerInfo defaultArbitraryContainerInfo;
+	private final ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator;
 	private final List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators;
 	private final ArbitraryGenerator defaultArbitraryGenerator;
 
@@ -127,7 +125,7 @@ public final class GenerateOptions {
 		List<MatcherOperator<NullInjectGenerator>> nullInjectGenerators,
 		NullInjectGenerator defaultNullInjectGenerator,
 		List<MatcherOperator<ArbitraryContainerInfoGenerator>> arbitraryContainerInfoGenerators,
-		int defaultArbitraryContainerSize, ArbitraryContainerInfo defaultArbitraryContainerInfo,
+		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator,
 		List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators,
 		ArbitraryGenerator defaultArbitraryGenerator,
 		List<MatcherOperator<FixtureCustomizer>> arbitraryCustomizers,
@@ -143,8 +141,7 @@ public final class GenerateOptions {
 		this.nullInjectGenerators = nullInjectGenerators;
 		this.defaultNullInjectGenerator = defaultNullInjectGenerator;
 		this.arbitraryContainerInfoGenerators = arbitraryContainerInfoGenerators;
-		this.defaultArbitraryContainerSize = defaultArbitraryContainerSize;
-		this.defaultArbitraryContainerInfo = defaultArbitraryContainerInfo;
+		this.defaultArbitraryContainerInfoGenerator = defaultArbitraryContainerInfoGenerator;
 		this.arbitraryGenerators = arbitraryGenerators;
 		this.defaultArbitraryGenerator = defaultArbitraryGenerator;
 		this.arbitraryCustomizers = arbitraryCustomizers;
@@ -241,15 +238,11 @@ public final class GenerateOptions {
 			.filter(it -> it.match(property))
 			.map(MatcherOperator::getOperator)
 			.findFirst()
-			.orElse(context -> this.getDefaultArbitraryContainerInfo());
+			.orElse(this.getDefaultArbitraryContainerInfoGenerator());
 	}
 
-	public int getDefaultArbitraryContainerSize() {
-		return this.defaultArbitraryContainerSize;
-	}
-
-	public ArbitraryContainerInfo getDefaultArbitraryContainerInfo() {
-		return this.defaultArbitraryContainerInfo;
+	public ArbitraryContainerInfoGenerator getDefaultArbitraryContainerInfoGenerator() {
+		return this.defaultArbitraryContainerInfoGenerator;
 	}
 
 	public List<MatcherOperator<ArbitraryGenerator>> getArbitraryGenerators() {
@@ -288,8 +281,7 @@ public final class GenerateOptions {
 			.nullInjectGenerators(new ArrayList<>(this.nullInjectGenerators))
 			.defaultNullInjectGenerator(this.defaultNullInjectGenerator)
 			.arbitraryContainerInfoGenerators(new ArrayList<>(this.arbitraryContainerInfoGenerators))
-			.defaultArbitraryContainerMaxSize(this.defaultArbitraryContainerSize)
-			.defaultArbitraryContainerInfo(this.defaultArbitraryContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(this.defaultArbitraryContainerInfoGenerator)
 			.arbitraryGenerators(new ArrayList<>(this.arbitraryGenerators))
 			.defaultArbitraryGenerator(this.defaultArbitraryGenerator)
 			.defaultArbitraryValidator(defaultArbitraryValidator);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -34,7 +34,6 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
@@ -71,8 +70,7 @@ public final class GenerateOptionsBuilder {
 	private List<MatcherOperator<NullInjectGenerator>> nullInjectGenerators = new ArrayList<>();
 	private NullInjectGenerator defaultNullInjectGenerator;
 	private List<MatcherOperator<ArbitraryContainerInfoGenerator>> arbitraryContainerInfoGenerators = new ArrayList<>();
-	private Integer defaultArbitraryContainerMaxSize;
-	private ArbitraryContainerInfo defaultArbitraryContainerInfo;
+	private ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator;
 	private List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators = new ArrayList<>();
 	private ArbitraryGenerator defaultArbitraryGenerator;
 
@@ -311,13 +309,9 @@ public final class GenerateOptionsBuilder {
 		);
 	}
 
-	public GenerateOptionsBuilder defaultArbitraryContainerMaxSize(int defaultArbitraryContainerMaxSize) {
-		this.defaultArbitraryContainerMaxSize = defaultArbitraryContainerMaxSize;
-		return this;
-	}
-
-	public GenerateOptionsBuilder defaultArbitraryContainerInfo(ArbitraryContainerInfo defaultArbitraryContainerInfo) {
-		this.defaultArbitraryContainerInfo = defaultArbitraryContainerInfo;
+	public GenerateOptionsBuilder defaultArbitraryContainerInfoGenerator(
+		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator) {
+		this.defaultArbitraryContainerInfoGenerator = defaultArbitraryContainerInfoGenerator;
 		return this;
 	}
 
@@ -529,15 +523,8 @@ public final class GenerateOptionsBuilder {
 			defaultNullInjectGenerator = defaultNullInjectGeneratorOperator.apply(defaultNullInjectGenerator);
 		}
 
-		int defaultArbitraryContainerMaxSize = defaultIfNull(
-			this.defaultArbitraryContainerMaxSize,
-			() -> GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE
-		);
-		ArbitraryContainerInfo defaultArbitraryContainerInfo =
-			defaultIfNull(
-				this.defaultArbitraryContainerInfo,
-				() -> new ArbitraryContainerInfo(0, defaultArbitraryContainerMaxSize)
-			);
+		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator =
+			this.defaultArbitraryContainerInfoGenerator;
 		ArbitraryGenerator defaultArbitraryGenerator =
 			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);
 
@@ -552,8 +539,7 @@ public final class GenerateOptionsBuilder {
 			this.nullInjectGenerators,
 			defaultNullInjectGenerator,
 			this.arbitraryContainerInfoGenerators,
-			defaultArbitraryContainerMaxSize,
-			defaultArbitraryContainerInfo,
+			defaultArbitraryContainerInfoGenerator,
 			this.arbitraryGenerators,
 			defaultArbitraryGenerator,
 			this.arbitraryCustomizers,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -34,6 +34,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
@@ -523,8 +524,10 @@ public final class GenerateOptionsBuilder {
 			defaultNullInjectGenerator = defaultNullInjectGeneratorOperator.apply(defaultNullInjectGenerator);
 		}
 
-		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator =
-			this.defaultArbitraryContainerInfoGenerator;
+		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator = defaultIfNull(
+			this.defaultArbitraryContainerInfoGenerator,
+			() -> context -> new ArbitraryContainerInfo(0, 3)
+		);
 		ArbitraryGenerator defaultArbitraryGenerator =
 			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/GenerateOptionsBuilder.java
@@ -526,7 +526,7 @@ public final class GenerateOptionsBuilder {
 
 		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator = defaultIfNull(
 			this.defaultArbitraryContainerInfoGenerator,
-			() -> context -> new ArbitraryContainerInfo(0, 3)
+			() -> context -> new ArbitraryContainerInfo(0, GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE)
 		);
 		ArbitraryGenerator defaultArbitraryGenerator =
 			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);

--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/generator/JakartaValidationArbitraryContainerInfoGenerator.java
@@ -33,6 +33,7 @@ import jakarta.validation.constraints.Size;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 
 @API(since = "0.4.10", status = Status.EXPERIMENTAL)
 public final class JakartaValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
@@ -56,9 +57,7 @@ public final class JakartaValidationArbitraryContainerInfoGenerator implements A
 			if (size.max() != Integer.MAX_VALUE) {    // not initialized for preventing OOM
 				max = size.max();
 			} else {
-				int defaultArbitraryContainerSize = context.getGenerateOptions()
-					.getDefaultArbitraryContainerSize();
-				max = min + defaultArbitraryContainerSize;
+				max = min + GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE;
 			}
 		}
 
@@ -75,9 +74,7 @@ public final class JakartaValidationArbitraryContainerInfoGenerator implements A
 		}
 
 		if (max == null) {
-			int defaultArbitraryContainerSize = context.getGenerateOptions()
-				.getDefaultArbitraryContainerSize();
-			max = min + defaultArbitraryContainerSize;
+			max = min + GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE;
 		}
 
 		return new ArbitraryContainerInfo(min, max);

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGenerator.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/generator/JavaxValidationArbitraryContainerInfoGenerator.java
@@ -33,6 +33,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.option.GenerateOptions;
 
 @API(since = "0.4.0", status = Status.EXPERIMENTAL)
 public final class JavaxValidationArbitraryContainerInfoGenerator implements ArbitraryContainerInfoGenerator {
@@ -56,9 +57,7 @@ public final class JavaxValidationArbitraryContainerInfoGenerator implements Arb
 			if (size.max() != Integer.MAX_VALUE) {    // not initialized for preventing OOM
 				max = size.max();
 			} else {
-				int defaultArbitraryContainerSize = context.getGenerateOptions()
-					.getDefaultArbitraryContainerSize();
-				max = min + defaultArbitraryContainerSize;
+				max = min + GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE;
 			}
 		}
 
@@ -75,9 +74,7 @@ public final class JavaxValidationArbitraryContainerInfoGenerator implements Arb
 		}
 
 		if (max == null) {
-			int defaultArbitraryContainerSize = context.getGenerateOptions()
-				.getDefaultArbitraryContainerSize();
-			max = min + defaultArbitraryContainerSize;
+			max = min + GenerateOptions.DEFAULT_ARBITRARY_CONTAINER_MAX_SIZE;
 		}
 
 		return new ArbitraryContainerInfo(min, max);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -33,7 +33,6 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator;
@@ -228,13 +227,9 @@ public class FixtureMonkeyBuilder {
 		return this;
 	}
 
-	public FixtureMonkeyBuilder defaultArbitraryContainerMaxSize(int defaultArbitraryContainerMaxSize) {
-		generateOptionsBuilder.defaultArbitraryContainerMaxSize(defaultArbitraryContainerMaxSize);
-		return this;
-	}
-
-	public FixtureMonkeyBuilder defaultArbitraryContainerInfo(ArbitraryContainerInfo defaultArbitraryContainerInfo) {
-		generateOptionsBuilder.defaultArbitraryContainerInfo(defaultArbitraryContainerInfo);
+	public FixtureMonkeyBuilder defaultArbitraryContainerInfoGenerator(
+		ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator) {
+		generateOptionsBuilder.defaultArbitraryContainerInfoGenerator(defaultArbitraryContainerInfoGenerator);
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -52,6 +52,7 @@ import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ChildArbitraryContext;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
@@ -447,7 +448,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void defaultArbitraryContainerMaxSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerMaxSize(1)
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		List<SimpleObject> actual = sut.giveMeOne(ComplexObject.class)
@@ -459,7 +460,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void defaultArbitraryContainerInfo() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(3, 3))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		List<SimpleObject> actual = sut.giveMeOne(ComplexObject.class)
@@ -1218,7 +1219,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMaxSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerMaxSize(5)
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
@@ -1230,7 +1231,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMinSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(3, 5))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
@@ -1242,7 +1243,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumSetWithEnumSizeIsLessThanContainerInfoMinSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(3, 5))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		Set<TwoEnum> values = sut.giveMeOne(new TypeReference<Set<TwoEnum>>() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -52,7 +52,6 @@ import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ChildArbitraryContext;
-import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
@@ -448,7 +447,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void defaultArbitraryContainerMaxSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(0, 1))
 			.build();
 
 		List<SimpleObject> actual = sut.giveMeOne(ComplexObject.class)
@@ -460,7 +459,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void defaultArbitraryContainerInfo() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 3))
 			.build();
 
 		List<SimpleObject> actual = sut.giveMeOne(ComplexObject.class)
@@ -1219,7 +1218,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMaxSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(0, 5))
 			.build();
 
 		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
@@ -1231,7 +1230,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumMapWithEnumSizeIsLessThanContainerInfoMinSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 5))
 			.build();
 
 		Map<TwoEnum, String> values = sut.giveMeOne(new TypeReference<Map<TwoEnum, String>>() {
@@ -1243,7 +1242,7 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void sampleEnumSetWithEnumSizeIsLessThanContainerInfoMinSize() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 5))
 			.build();
 
 		Set<TwoEnum> values = sut.giveMeOne(new TypeReference<Set<TwoEnum>>() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -34,7 +34,7 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.ComplexObject;
@@ -136,7 +136,7 @@ class InnerSpecTest {
 	@Property
 	void keyInKey() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(1, 3))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
@@ -154,7 +154,7 @@ class InnerSpecTest {
 	@Property
 	void valueInKey() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(1, 3))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
@@ -271,7 +271,7 @@ class InnerSpecTest {
 	void entryInEntryKey() {
 		// given
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfo(new ArbitraryContainerInfo(1, 3))
+			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
 			.build();
 
 		// when

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -34,7 +34,7 @@ import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.customizer.InnerSpec;
 import com.navercorp.fixturemonkey.test.InnerSpecTestSpecs.ComplexObject;
@@ -136,7 +136,7 @@ class InnerSpecTest {
 	@Property
 	void keyInKey() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(1, 3))
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
@@ -154,7 +154,7 @@ class InnerSpecTest {
 	@Property
 	void valueInKey() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(1, 3))
 			.build();
 
 		NestedKeyMapObject actual = sut.giveMeBuilder(NestedKeyMapObject.class)
@@ -271,7 +271,7 @@ class InnerSpecTest {
 	void entryInEntryKey() {
 		// given
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.defaultArbitraryContainerInfoGenerator(ContainerPropertyGeneratorContext::getContainerInfo)
+			.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(1, 3))
 			.build();
 
 		// when


### PR DESCRIPTION
## Summary
Fix #569 

## (Optional): Description
Replace `defaultArbitraryContainerInfo` to `defaultArbitraryContainerInfoGenerator`

## How Has This Been Tested?
None

## Additional info
The maintainers [provided guidelines](https://github.com/naver/fixture-monkey/issues/569#issuecomment-1428916871) for doing this.
Unfortunately, I don't think I understood this properly. I worked on it first, but I'm honestly not sure if my work went in the right direction 😞 

Regarding this bug, I don't think it's good for a discovered bug to remain for a long time.
So it would be nice to proceed with fixing the bug at the maintainer's discretion.