### PR TITLE
Refactor ArbitraryNode not unique

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryNode.java
@@ -20,7 +20,6 @@ package com.navercorp.fixturemonkey.resolver;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -125,32 +124,5 @@ final class ArbitraryNode {
 
 	public void setManipulated(boolean manipulated) {
 		this.manipulated = manipulated;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
-		ArbitraryNode that = (ArbitraryNode)obj;
-		return Objects.equals(resolvedParentProperty, that.resolvedParentProperty)
-			&& arbitraryProperty.equals(that.arbitraryProperty)
-			&& children.equals(that.children)
-			&& Objects.equals(arbitrary, that.arbitrary)
-			&& arbitraryFilters.equals(that.arbitraryFilters);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(
-			resolvedParentProperty,
-			arbitraryProperty,
-			children,
-			arbitrary,
-			arbitraryFilters
-		);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryTraverser.java
@@ -20,11 +20,9 @@ package com.navercorp.fixturemonkey.resolver;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -125,7 +123,7 @@ public final class ArbitraryTraverser {
 		@Nullable Property resolvedParentProperty,
 		TraverseContext context
 	) {
-		Set<ArbitraryNode> children = new LinkedHashSet<>();
+		List<ArbitraryNode> children = new ArrayList<>();
 		ObjectProperty objectProperty = arbitraryProperty.getObjectProperty();
 		ContainerProperty containerProperty = arbitraryProperty.getContainerProperty();
 		boolean container = containerProperty != null;
@@ -171,7 +169,7 @@ public final class ArbitraryTraverser {
 			resolvedParentProperty,
 			resolvedProperty,
 			arbitraryProperty,
-			new ArrayList<>(children)
+			children
 		);
 	}
 
@@ -181,7 +179,7 @@ public final class ArbitraryTraverser {
 		Property resolvedParentProperty,
 		TraverseContext context
 	) {
-		Set<ArbitraryNode> children = new LinkedHashSet<>();
+		List<ArbitraryNode> children = new ArrayList<>();
 		List<ContainerInfoManipulator> containerInfoManipulators = context.getContainerInfoManipulators();
 		boolean container = parentArbitraryProperty.getContainerProperty() != null;
 
@@ -259,6 +257,6 @@ public final class ArbitraryTraverser {
 			}
 			children.add(childNode);
 		}
-		return new ArrayList<>(children);
+		return children;
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
@@ -300,4 +300,18 @@ class FixtureMonkeyOptionsAdditionalTestSpecs {
 			this.value = value;
 		}
 	}
+
+	public interface GetterInterface {
+		String getValue();
+	}
+
+	@Data
+	public static class GetterInterfaceImplementation implements GetterInterface {
+		private String value;
+	}
+
+	@Data
+	public static class GetterInterfaceImplementation2 implements GetterInterface {
+		private String value;
+	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import java.lang.reflect.AnnotatedType;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -87,6 +88,9 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetIntegerFixedValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetIntegerFixedValueChild;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetStringFixedValue;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetterInterface;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetterInterfaceImplementation;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.GetterInterfaceImplementation2;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.NestedListStringObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.Pair;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.PairContainerPropertyGenerator;
@@ -1483,5 +1487,25 @@ class FixtureMonkeyOptionsTest {
 			.getValues();
 
 		then(actual).allMatch(it -> it.getValues().size() >= 3 && it.getValues().size() <= 5);
+	}
+
+	@Property
+	void samePropertyDiffImplementations() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.interfaceImplements(
+				GetterInterface.class,
+				Arrays.asList(
+					GetterInterfaceImplementation.class,
+					GetterInterfaceImplementation2.class
+				)
+			)
+			.build();
+
+		String actual = sut.giveMeBuilder(GetterInterface.class)
+			.set("value", "expected")
+			.sample()
+			.getValue();
+
+		then(actual).isEqualTo("expected");
 	}
 }


### PR DESCRIPTION
## Summary
Refactor ArbitraryNode not unique

## (Optional): Description
It leads to performance issue if ArbitraryNode is unique.
It could be many `ArbitraryNodes` with same property name.

## How Has This Been Tested?
* samePropertyDiffImplementations
