### PR TITLE
Refactor improving generation of properties

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ConstructorParameterPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ConstructorParameterPropertyGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.lang.reflect.AnnotatedType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
+
+@API(since = "0.5.3", status = Status.EXPERIMENTAL)
+public final class ConstructorParameterPropertyGenerator implements PropertyGenerator {
+	private final Matcher matcher;
+
+	public ConstructorParameterPropertyGenerator(Matcher matcher) {
+		this.matcher = matcher;
+	}
+
+	@Override
+	public List<Property> generateProperties(AnnotatedType annotatedType) {
+		return PropertyCache.getConstructorParameterPropertiesByParameterName(annotatedType).values().stream()
+			.filter(matcher::match)
+			.collect(Collectors.toList());
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FieldPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FieldPropertyGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.FieldProperty;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
+
+@API(since = "0.5.3", status = Status.EXPERIMENTAL)
+public final class FieldPropertyGenerator implements PropertyGenerator {
+	private final Predicate<Field> fieldPredicate;
+	private final Matcher matcher;
+
+	public FieldPropertyGenerator(Predicate<Field> fieldPredicate, Matcher matcher) {
+		this.fieldPredicate = fieldPredicate;
+		this.matcher = matcher;
+	}
+
+	@Override
+	public List<Property> generateProperties(AnnotatedType annotatedType) {
+		return PropertyCache.getFieldsByName(annotatedType).values().stream()
+			.filter(fieldPredicate)
+			.map(FieldProperty::new)
+			.filter(matcher::match)
+			.collect(Collectors.toList());
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaBeansPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaBeansPropertyGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.AnnotatedType;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyCache;
+import com.navercorp.fixturemonkey.api.property.PropertyDescriptorProperty;
+
+@API(since = "0.5.3", status = Status.EXPERIMENTAL)
+public final class JavaBeansPropertyGenerator implements PropertyGenerator {
+	private final Predicate<PropertyDescriptor> propertyDescriptorPredicate;
+	private final Matcher matcher;
+
+	public JavaBeansPropertyGenerator(
+		Predicate<PropertyDescriptor> propertyDescriptorPredicate,
+		Matcher matcher
+	) {
+		this.propertyDescriptorPredicate = propertyDescriptorPredicate;
+		this.matcher = matcher;
+	}
+
+	@Override
+	public List<Property> generateProperties(AnnotatedType annotatedType) {
+		return PropertyCache.getPropertyDescriptorsByPropertyName(annotatedType).values().stream()
+			.filter(propertyDescriptorPredicate)
+			.map(PropertyDescriptorProperty::new)
+			.filter(matcher::match)
+			.collect(Collectors.toList());
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -60,7 +60,9 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 		List<ArbitraryProperty> childrenProperties = context.getChildren();
 		Map<String, CombinableArbitrary> arbitrariesByResolvedName =
 			context.getCombinableArbitrariesByResolvedName();
-		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptors(type);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			property.getAnnotatedType()
+		);
 
 		LazyArbitrary<Arbitrary<Object>> generateArbitrary = LazyArbitrary.lazy(() -> {
 			BuilderCombinator<Object> builderCombinator = Builders.withBuilder(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -57,7 +57,7 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 		List<ArbitraryProperty> childrenProperties = context.getChildren();
 		Map<String, CombinableArbitrary> arbitrariesByResolvedName
 			= context.getCombinableArbitrariesByResolvedName();
-		Map<String, Field> fields = PropertyCache.getFields(type);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(property.getAnnotatedType());
 
 		LazyArbitrary<Arbitrary<Object>> generateArbitrary = LazyArbitrary.lazy(
 			() -> {

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyCacheTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/property/PropertyCacheTest.java
@@ -32,7 +32,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import com.navercorp.fixturemonkey.api.type.TypeReference;
+import com.navercorp.fixturemonkey.api.type.Types;
 
+@SuppressWarnings("unused")
 class PropertyCacheTest {
 
 	@Test
@@ -156,7 +158,9 @@ class PropertyCacheTest {
 
 	@Test
 	void getFields() {
-		Map<String, Field> actual = PropertyCache.getFields(PropertyValue.class);
+		Map<String, Field> actual = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(PropertyValue.class)
+		);
 		then(actual).hasSize(1);
 		then(actual.get("name")).isNotNull();
 		then(actual.get("name").getName()).isEqualTo("name");
@@ -164,7 +168,9 @@ class PropertyCacheTest {
 
 	@Test
 	void getPropertyDescriptors() {
-		Map<String, PropertyDescriptor> actual = PropertyCache.getPropertyDescriptors(PropertyValue.class);
+		Map<String, PropertyDescriptor> actual = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(PropertyValue.class)
+		);
 		then(actual).hasSize(1);
 
 		then(actual.get("name")).isNotNull();

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypesTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/type/TypesTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import com.navercorp.fixturemonkey.api.property.PropertyCache;
 
+@SuppressWarnings({"rawtypes", "unused"})
 class TypesTest {
 
 	@Test
@@ -236,7 +237,9 @@ class TypesTest {
 		TypeReference<GenericSample<String>> typeReference = new TypeReference<GenericSample<String>>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class)
+		);
 		Field field = fields.get("name");
 
 		// when
@@ -251,7 +254,8 @@ class TypesTest {
 		TypeReference<GenericSample<String>> typeReference = new TypeReference<GenericSample<String>>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		Field field = fields.get("sample2");
 
 		// when
@@ -272,7 +276,8 @@ class TypesTest {
 		TypeReference<GenericSample<String>> typeReference = new TypeReference<GenericSample<String>>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		Field field = fields.get("list");
 
 		// when
@@ -293,7 +298,8 @@ class TypesTest {
 		TypeReference<GenericSample<String>> typeReference = new TypeReference<GenericSample<String>>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		Field field = fields.get("samples");
 
 		// when
@@ -314,7 +320,9 @@ class TypesTest {
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(Sample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(Sample.class)
+		);
 		Field field = fields.get("name");
 
 		// when
@@ -329,7 +337,8 @@ class TypesTest {
 		TypeReference<GenericSample<?>> typeReference = new TypeReference<GenericSample<?>>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		Field field = fields.get("name");
 
 		// when
@@ -346,7 +355,8 @@ class TypesTest {
 		TypeReference<GenericSample> typeReference = new TypeReference<GenericSample>() {
 		};
 
-		Map<String, Field> fields = PropertyCache.getFields(GenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		Field field = fields.get("name");
 
 		// when
@@ -362,7 +372,9 @@ class TypesTest {
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, Field> fields = PropertyCache.getFields(BiGenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		Field field = fields.get("name");
 
 		// when
@@ -378,7 +390,9 @@ class TypesTest {
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, Field> fields = PropertyCache.getFields(BiGenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		Field field = fields.get("address");
 
 		// when
@@ -394,7 +408,9 @@ class TypesTest {
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, Field> fields = PropertyCache.getFields(BiGenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		Field field = fields.get("sample2");
 
 		// when
@@ -417,7 +433,9 @@ class TypesTest {
 			new TypeReference<BiGenericSample<GenericSample<Integer>, BiGenericSample<Integer, String>>>() {
 			};
 
-		Map<String, Field> fields = PropertyCache.getFields(BiGenericSample.class);
+		Map<String, Field> fields = PropertyCache.getFieldsByName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		Field field = fields.get("sample2");
 
 		// when
@@ -454,7 +472,9 @@ class TypesTest {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class)
+			);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("name");
 
 		// when
@@ -471,7 +491,9 @@ class TypesTest {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class)
+			);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("sample2");
 
 		// when
@@ -494,7 +516,8 @@ class TypesTest {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("list");
 
 		// when
@@ -517,7 +540,8 @@ class TypesTest {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("samples");
 
 		// when
@@ -534,13 +558,14 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsSimplePropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsSimplePropertyDescriptor() {
 		// given
 		TypeReference<Sample> typeReference = new TypeReference<Sample>() {
 		};
 
-		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(Sample.class);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(Sample.class)
+		);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("name");
 
 		// when
@@ -551,13 +576,14 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsWildCardPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsWildCardPropertyDescriptor() {
 		// given
 		TypeReference<GenericSample<?>> typeReference = new TypeReference<GenericSample<?>>() {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class));
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("name");
 
 		// when
@@ -570,13 +596,15 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsNoGenericsPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsNoGenericsPropertyDescriptor() {
 		// given
 		TypeReference<GenericSample> typeReference = new TypeReference<GenericSample>() {
 		};
 
 		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(GenericSample.class);
+			PropertyCache.getPropertyDescriptorsByPropertyName(
+				Types.generateAnnotatedTypeWithoutAnnotation(GenericSample.class)
+			);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("name");
 
 		// when
@@ -587,14 +615,15 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsBiGenericsFirstPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsBiGenericsFirstPropertyDescriptor() {
 		// given
 		TypeReference<BiGenericSample<Integer, String>> typeReference =
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(BiGenericSample.class);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("name");
 
 		// when
@@ -605,14 +634,15 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsBiGenericsSecondPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsBiGenericsSecondPropertyDescriptor() {
 		// given
 		TypeReference<BiGenericSample<Integer, String>> typeReference =
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(BiGenericSample.class);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("address");
 
 		// when
@@ -623,14 +653,15 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsBiGenericsNestedPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsBiGenericsNestedPropertyDescriptor() {
 		// given
 		TypeReference<BiGenericSample<Integer, String>> typeReference =
 			new TypeReference<BiGenericSample<Integer, String>>() {
 			};
 
-		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(BiGenericSample.class);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("sample2");
 
 		// when
@@ -648,14 +679,15 @@ class TypesTest {
 	}
 
 	@Test
-	void resolveWithTypeReferenceGenericsBiGenericsComplexPropertyDescriptor() throws NoSuchMethodException {
+	void resolveWithTypeReferenceGenericsBiGenericsComplexPropertyDescriptor() {
 		// given
 		TypeReference<BiGenericSample<GenericSample<Integer>, BiGenericSample<Integer, String>>> typeReference =
 			new TypeReference<BiGenericSample<GenericSample<Integer>, BiGenericSample<Integer, String>>>() {
 			};
 
-		Map<String, PropertyDescriptor> propertyDescriptors =
-			PropertyCache.getPropertyDescriptors(BiGenericSample.class);
+		Map<String, PropertyDescriptor> propertyDescriptors = PropertyCache.getPropertyDescriptorsByPropertyName(
+			Types.generateAnnotatedTypeWithoutAnnotation(BiGenericSample.class)
+		);
 		PropertyDescriptor propertyDescriptor = propertyDescriptors.get("sample2");
 
 		// when


### PR DESCRIPTION
## Summary
Refactor improving generation of properties

## (Optional): Description
### Add more PropertyGenerator
* FieldPropertyGenerator
* JavaBeansPropertyGenerator
* ConstructorParameterPropertyGenerator

### Rename methods to be clearer
* `getPropertyDescriptors` to `getPropertyDescriptorsByPropertyName`
* `getFields` to `getFieldsByName`
* `getConstructorProperties` to `getConstructorParameterPropertiesByParameterName`
