### PR TITLE
Add support for @JsonTypeInfo and @JsonSubTypes

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -81,7 +81,7 @@ public final class ChildArbitraryContext {
 
 	public List<Arbitrary<?>> getArbitraries() {
 		return arbitrariesByChildProperty.values().stream()
-			.map(CombinableArbitrary::combined)
+			.map(CombinableArbitrary::rawValue)
 			.collect(Collectors.toList());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class FilteredCombinableArbitrary implements CombinableArbitrary {
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().filter(predicate);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class MappedCombinableArbitrary implements CombinableArbitrary {
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().map(mapper);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class NullInjectCombinableArbitrary implements CombinableArbitrary 
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().injectNull(nullProbability);
 	}
 
 	@Override

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
@@ -18,12 +18,15 @@
 
 package com.navercorp.fixturemonkey.jackson.plugin;
 
+import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -31,8 +34,11 @@ import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
+import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+import com.navercorp.fixturemonkey.jackson.generator.ElementJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.generator.JsonNodeContainerPropertyGenerator;
+import com.navercorp.fixturemonkey.jackson.generator.PropertyJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.introspector.JsonNodeIntrospector;
 import com.navercorp.fixturemonkey.jackson.property.JacksonPropertyNameResolver;
@@ -79,7 +85,19 @@ public final class JacksonPlugin implements Plugin {
 		if (this.defaultOptions) {
 			optionsBuilder
 				.objectIntrospector(it -> new JacksonArbitraryIntrospector(objectMapper))
-				.defaultPropertyNameResolver(new JacksonPropertyNameResolver());
+				.defaultPropertyNameResolver(new JacksonPropertyNameResolver())
+				.insertFirstArbitraryObjectPropertyGenerator(
+					property -> getJacksonAnnotation(property, JsonSubTypes.class) != null,
+					PropertyJsonSubTypesObjectPropertyGenerator.INSTANCE
+				)
+				.insertFirstArbitraryObjectPropertyGenerator(
+					property -> property instanceof ElementProperty
+						&& getJacksonAnnotation(
+						((ElementProperty)property).getContainerProperty(),
+						JsonSubTypes.class
+					) != null,
+					ElementJsonSubTypesObjectPropertyGenerator.INSTANCE
+				);
 		}
 
 		optionsBuilder

--- a/fixture-monkey-tests/java-tests/build.gradle
+++ b/fixture-monkey-tests/java-tests/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     testImplementation("org.projectlombok:lombok:1.18.24")
+    testImplementation(project(":fixture-monkey-jackson"))
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
@@ -1,0 +1,92 @@
+package com.navercorp.fixturemonkey.tests.java;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Value;
+
+public class JacksonSpecs {
+	@Value
+	public static class JsonTypeInfoIdNameSpec {
+		@JsonTypeInfo(use = Id.NAME)
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		Type type;
+	}
+
+	@Value
+	public static class JsonTypeInfoIdClassSpec {
+		@JsonTypeInfo(use = Id.CLASS)
+		@JsonSubTypes(
+			{
+				@JsonSubTypes.Type(
+					value = TypeA.class,
+					name = "com.navercorp.fixturemonkey.tests.java.JacksonSpecs$TypeA"
+				),
+				@JsonSubTypes.Type(
+					value = TypeB.class,
+					name = "com.navercorp.fixturemonkey.tests.java.JacksonSpecs$TypeB"
+				)
+			}
+		)
+		Type type;
+	}
+
+	@Value
+	public static class JsonTypeInfoListSpec {
+		@JsonTypeInfo(use = Id.NAME)
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		List<Type> types;
+	}
+
+	@Value
+	public static class TypeWithAnnotationsSpec {
+		TypeWithAnnotations type;
+	}
+
+	@Value
+	public static class TypeWithAnnotationsListSpec {
+		List<TypeWithAnnotations> types;
+	}
+
+	public interface Type {
+	}
+
+	@Value
+	public static class TypeA implements Type {
+		String value;
+	}
+
+	@Value
+	@JsonTypeName("typeB")
+	public static class TypeB implements Type {
+		int value;
+	}
+
+	@JsonTypeInfo(use = Id.NAME)
+	@JsonSubTypes({
+		@JsonSubTypes.Type(value = TypeAWithAnnotations.class, name = "TypeAWithAnnotations"),
+		@JsonSubTypes.Type(value = TypeBWithAnnotations.class, name = "TypeBWithAnnotations")
+	})
+	public interface TypeWithAnnotations {
+	}
+
+	@Value
+	public static class TypeAWithAnnotations implements TypeWithAnnotations {
+		String value;
+	}
+
+	@Value
+	public static class TypeBWithAnnotations implements TypeWithAnnotations {
+		int value;
+	}
+}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -1,0 +1,47 @@
+package com.navercorp.fixturemonkey.tests.java;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClassSpec;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdNameSpec;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoListSpec;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsListSpec;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsSpec;
+
+@SuppressWarnings("rawtypes")
+class JacksonTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.plugin(new JacksonPlugin())
+		.defaultNotNull(true)
+		.build();
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfo() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdNameSpec.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeListInfo() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListSpec.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoWithIdClass() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdClassSpec.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeWithoutAnnotations() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsSpec.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeListWithoutAnnotations() {
+		thenNoException().isThrownBy(() -> SUT.giveMeBuilder(TypeWithAnnotationsListSpec.class));
+	}
+}


### PR DESCRIPTION
## Summary
Add support for @JsonTypeInfo and @JsonSubTypes

## (Optional): Description
* `ChildArbitraryContext#getArbitraries` returns rawValue of CombinableArbitrary
* CombinableArbitrary applies filter, map to rawValue

## How Has This Been Tested?
* jsonTypeInfo
* jsonTypeListInfo
* jsonTypeWithoutAnnotations
* jsonTypeListWithoutAnnotations
