### PR TITLE
Add support for @JsonTypeInfo and @JsonSubTypes

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -81,7 +81,7 @@ public final class ChildArbitraryContext {
 
 	public List<Arbitrary<?>> getArbitraries() {
 		return arbitrariesByChildProperty.values().stream()
-			.map(CombinableArbitrary::combined)
+			.map(CombinableArbitrary::rawValue)
 			.collect(Collectors.toList());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FilteredCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class FilteredCombinableArbitrary implements CombinableArbitrary {
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().filter(predicate);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/MappedCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class MappedCombinableArbitrary implements CombinableArbitrary {
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().map(mapper);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NullInjectCombinableArbitrary.java
@@ -43,7 +43,7 @@ public final class NullInjectCombinableArbitrary implements CombinableArbitrary 
 
 	@Override
 	public Arbitrary<Object> rawValue() {
-		return combinableArbitrary.rawValue();
+		return combinableArbitrary.rawValue().injectNull(nullProbability);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -90,6 +91,10 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 		private final List<Object> array;
 		private final Class<?> componentType;
 		private final int size;
+		/**
+		 * It is used for specifying {@code JacksonCombinableArbitrary} raw value.
+		 */
+		private boolean combined = true;
 
 		public ArrayBuilder(Class<?> componentType, int size) {
 			this.array = new ArrayList<>();
@@ -103,13 +108,23 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 				return this;
 			}
 
+			if (value instanceof Map) {
+				combined = false;
+			}
+
 			array.add(value);
 			return this;
 		}
 
 		// cast to Object for preventing ClassCastException when primitive type
 		Object build() {
-			Object array = Array.newInstance(componentType, size);
+			Object array;
+			if (combined) {
+				array = Array.newInstance(componentType, size);
+			} else {
+				array = Array.newInstance(Object.class, size);
+			}
+
 			for (int i = 0; i < this.array.size(); i++) {
 				Array.set(array, i, this.array.get(i));
 			}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyDescriptorProperty.java
@@ -25,7 +25,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,7 +64,14 @@ public final class PropertyDescriptorProperty implements Property {
 	public PropertyDescriptorProperty(AnnotatedType annotatedType, PropertyDescriptor propertyDescriptor) {
 		this.annotatedType = annotatedType;
 		this.propertyDescriptor = propertyDescriptor;
-		this.annotations = Arrays.asList(propertyDescriptor.getReadMethod().getAnnotations());
+		List<Annotation> concatAnnotations = new ArrayList<>();
+		if (propertyDescriptor.getWriteMethod() != null) {
+			concatAnnotations.addAll(Arrays.asList(propertyDescriptor.getWriteMethod().getAnnotations()));
+		}
+		if (propertyDescriptor.getReadMethod() != null) {
+			concatAnnotations.addAll(Arrays.asList(propertyDescriptor.getReadMethod().getAnnotations()));
+		}
+		this.annotations = Collections.unmodifiableList(concatAnnotations);
 		this.annotationsMap = this.annotations.stream()
 			.collect(toMap(Annotation::annotationType, Function.identity(), (a1, a2) -> a1));
 	}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
@@ -18,12 +18,15 @@
 
 package com.navercorp.fixturemonkey.jackson.plugin;
 
+import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -31,8 +34,11 @@ import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
+import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+import com.navercorp.fixturemonkey.jackson.generator.ElementJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.generator.JsonNodeContainerPropertyGenerator;
+import com.navercorp.fixturemonkey.jackson.generator.PropertyJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.introspector.JsonNodeIntrospector;
 import com.navercorp.fixturemonkey.jackson.property.JacksonPropertyNameResolver;
@@ -79,7 +85,19 @@ public final class JacksonPlugin implements Plugin {
 		if (this.defaultOptions) {
 			optionsBuilder
 				.objectIntrospector(it -> new JacksonArbitraryIntrospector(objectMapper))
-				.defaultPropertyNameResolver(new JacksonPropertyNameResolver());
+				.defaultPropertyNameResolver(new JacksonPropertyNameResolver())
+				.insertFirstArbitraryObjectPropertyGenerator(
+					property -> getJacksonAnnotation(property, JsonSubTypes.class) != null,
+					PropertyJsonSubTypesObjectPropertyGenerator.INSTANCE
+				)
+				.insertFirstArbitraryObjectPropertyGenerator(
+					property -> property instanceof ElementProperty
+						&& getJacksonAnnotation(
+						((ElementProperty)property).getContainerProperty(),
+						JsonSubTypes.class
+					) != null,
+					ElementJsonSubTypesObjectPropertyGenerator.INSTANCE
+				);
 		}
 
 		optionsBuilder

--- a/fixture-monkey-tests/java-tests/build.gradle
+++ b/fixture-monkey-tests/java-tests/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     testImplementation("org.projectlombok:lombok:1.18.24")
+    testImplementation(project(":fixture-monkey-jackson"))
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
@@ -1,0 +1,156 @@
+package com.navercorp.fixturemonkey.tests.java;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Getter;
+import lombok.Value;
+
+@SuppressWarnings("unused")
+public class JacksonSpecs {
+	@Value
+	public static class JsonTypeInfoIdName {
+		@JsonTypeInfo(use = Id.NAME)
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		Type type;
+	}
+
+	@Value
+	public static class JsonTypeInfoIdClass {
+		@JsonTypeInfo(use = Id.CLASS)
+		@JsonSubTypes(
+			{
+				@JsonSubTypes.Type(
+					value = TypeA.class,
+					name = "com.navercorp.fixturemonkey.tests.java.JacksonSpecs$TypeA"
+				),
+				@JsonSubTypes.Type(
+					value = TypeB.class,
+					name = "com.navercorp.fixturemonkey.tests.java.JacksonSpecs$TypeB"
+				)
+			}
+		)
+		Type type;
+	}
+
+	@Value
+	public static class JsonTypeInfoList {
+		@JsonTypeInfo(use = Id.NAME)
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		List<Type> types;
+	}
+
+	@Value
+	public static class JsonTypeInfoListIncludeWrapperObject {
+		@JsonTypeInfo(use = Id.NAME, include = As.WRAPPER_OBJECT)
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		List<Type> types;
+	}
+
+	@Getter
+	public static class JsonTypeInfoListInSetter {
+		@JsonTypeInfo(use = Id.NAME)
+		List<Type> types;
+
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		public void setTypes(List<Type> types) {
+			this.types = types;
+		}
+	}
+
+	@Getter
+	public static class JsonTypeInfoListInSetterIncludeWrapperObject {
+		@JsonTypeInfo(use = Id.NAME, include = As.WRAPPER_OBJECT)
+		List<Type> types;
+
+		@JsonSubTypes({
+			@JsonSubTypes.Type(value = TypeA.class, name = "TypeA"),
+			@JsonSubTypes.Type(value = TypeB.class, name = "typeB")
+		})
+		public void setTypes(List<Type> types) {
+			this.types = types;
+		}
+	}
+
+	@Value
+	public static class TypeWithAnnotationsValue {
+		TypeWithAnnotations type;
+	}
+
+	@Value
+	public static class TypeWithAnnotationsList {
+		List<TypeWithAnnotations> types;
+	}
+
+	public interface Type {
+	}
+
+	@Value
+	public static class TypeA implements Type {
+		String value;
+	}
+
+	@Value
+	@JsonTypeName("typeB")
+	public static class TypeB implements Type {
+		int value;
+	}
+
+	@JsonTypeInfo(use = Id.NAME)
+	@JsonSubTypes({
+		@JsonSubTypes.Type(value = TypeAWithAnnotations.class, name = "TypeAWithAnnotations"),
+		@JsonSubTypes.Type(value = TypeBWithAnnotations.class, name = "TypeBWithAnnotations")
+	})
+	public interface TypeWithAnnotations {
+	}
+
+	@Value
+	public static class TypeAWithAnnotations implements TypeWithAnnotations {
+		String value;
+	}
+
+	@Value
+	public static class TypeBWithAnnotations implements TypeWithAnnotations {
+		int value;
+	}
+
+	@JsonTypeInfo(use = Id.NAME, include = As.WRAPPER_OBJECT)
+	@JsonSubTypes({
+		@JsonSubTypes.Type(value = TypeAWithAnnotationsIncludeWrapperObject.class, name = "TypeAWithAnnotationsIncludeWrapperObject"),
+		@JsonSubTypes.Type(value = TypeBWithAnnotationsIncludeWrapperObject.class, name = "TypeBWithAnnotationsIncludeWrapperObject")
+	})
+	public interface TypeWithAnnotationsIncludeWrapperObject {
+	}
+
+	@Value
+	public static class TypeAWithAnnotationsIncludeWrapperObject implements TypeWithAnnotationsIncludeWrapperObject {
+		String value;
+	}
+
+	@Value
+	public static class TypeBWithAnnotationsIncludeWrapperObject implements TypeWithAnnotationsIncludeWrapperObject {
+		int value;
+	}
+
+	@Value
+	public static class TypeWithAnnotationsIncludeWrapperObjectList {
+		List<TypeWithAnnotationsIncludeWrapperObject> types;
+	}
+}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -1,0 +1,70 @@
+package com.navercorp.fixturemonkey.tests.java;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClass;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdName;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoList;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoListInSetter;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoListInSetterIncludeWrapperObject;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoListIncludeWrapperObject;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsIncludeWrapperObjectList;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsList;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsValue;
+
+class JacksonTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.plugin(new JacksonPlugin())
+		.defaultNotNull(true)
+		.build();
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoName() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdName.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoList() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoList.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoIdClass() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdClass.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeWithAnnotations() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsValue.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeWithAnnotationsList() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsList.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoListInSetter() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListInSetter.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoListIncludeWrapperObject() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListIncludeWrapperObject.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeInfoListInSetterIncludeWrapperObject() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListInSetterIncludeWrapperObject.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void jsonTypeWithAnnotationsIncludeWrapperObjectList() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsIncludeWrapperObjectList.class));
+	}
+}


### PR DESCRIPTION
## Summary
Add support for @JsonTypeInfo and @JsonSubTypes

## (Optional): Description
* `ChildArbitraryContext#getArbitraries` returns rawValue of CombinableArbitrary
* CombinableArbitrary applies filter, map to rawValue

## How Has This Been Tested?
* jsonTypeInfoName
* jsonTypeInfoList
* jsonTypeInfoIdClass
* jsonTypeWithAnnotations
* jsonTypeWithAnnotationsList
* jsonTypeInfoListInSetter
* jsonTypeInfoListIncludeWrapperObject
* jsonTypeInfoListInSetterIncludeWrapperObject
* jsonTypeWithAnnotationsIncludeWrapperObjectList