### PR TITLE
Add Innerspec keys(), values(), entries()

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -23,10 +23,12 @@ import static com.navercorp.fixturemonkey.Constants.DEFAULT_ELEMENT_MIN_SIZE;
 import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALUE;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import javax.annotation.Nullable;
 
@@ -109,6 +111,11 @@ public final class InnerSpec {
 		return this;
 	}
 
+	public InnerSpec keys(Object... keys) {
+		Arrays.stream(keys).forEach(this::key);
+		return this;
+	}
+
 	public InnerSpec key(Consumer<InnerSpec> consumer) {
 		entrySize++;
 		setMapKey(consumer);
@@ -121,6 +128,11 @@ public final class InnerSpec {
 		return this;
 	}
 
+	public InnerSpec values(Object... values) {
+		Arrays.stream(values).forEach(this::value);
+		return this;
+	}
+
 	public InnerSpec value(Consumer<InnerSpec> consumer) {
 		entrySize++;
 		setMapValue(consumer);
@@ -130,6 +142,20 @@ public final class InnerSpec {
 	public InnerSpec entry(Object key, @Nullable Object value) {
 		entrySize++;
 		setMapEntry(key, value);
+		return this;
+	}
+
+	public InnerSpec entries(Object... entries) {
+		if (entries.length % 2 != 0) {
+			throw new IllegalArgumentException("key-value pairs for the Map should be entered");
+		}
+
+		IntStream.range(0, entries.length)
+			.filter(i -> i % 2 == 0)
+			.forEach(i -> {
+				entry(entries[i], entries[i + 1]);
+			});
+
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -24,10 +24,12 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Property;
@@ -52,14 +54,15 @@ class InnerSpecTest {
 	@Property
 	void key() {
 		// when
-		MapObject actual = SUT.giveMeBuilder(MapObject.class)
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
 				new InnerSpec()
 					.property("strMap", m -> m.minSize(1).key("key"))
 			)
-			.sample();
+			.sample()
+			.getStrMap();
 
-		then(actual.getStrMap().containsKey("key")).isTrue();
+		then(actual.keySet()).contains("key");
 	}
 
 	@Property
@@ -79,14 +82,62 @@ class InnerSpecTest {
 	@Property
 	void entry() {
 		// when
-		MapObject actual = SUT.giveMeBuilder(MapObject.class)
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
 			.setInner(
 				new InnerSpec()
 					.property("strMap", m -> m.minSize(1).entry("key", "value"))
 			)
-			.sample();
+			.sample()
+			.getStrMap();
 
-		then(actual.getStrMap().get("key")).isEqualTo("value");
+		then(actual.get("key")).isEqualTo("value");
+	}
+
+	@Property
+	void keys() {
+		// when
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(3).keys("key1", "key2", "key3"))
+			)
+			.sample()
+			.getStrMap();
+
+		then(actual.keySet()).containsAll(
+			Stream.of("key1", "key2", "key3").collect(Collectors.toCollection(HashSet::new))
+		);
+	}
+
+	@Property
+	void values() {
+		// when
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(3).values("value1", "value2", "value3"))
+			)
+			.sample()
+			.getStrMap();
+
+		then(actual.values()).containsAll(
+			Stream.of("value1", "value2", "value3").collect(Collectors.toCollection(HashSet::new))
+		);
+	}
+
+	@Property
+	void entries() {
+		// when
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(2).entries("key1", "value1", "key2", "value2"))
+			)
+			.sample()
+			.getStrMap();
+
+		then(actual.get("key1")).isEqualTo("value1");
+		then(actual.get("key2")).isEqualTo("value2");
 	}
 
 	@Property


### PR DESCRIPTION
## Summary
Resolves #602

Adds keys(), values(), and entries() methods to Innerspec to support setting multiple values at once.

## How Has This Been Tested?
Added related tests to `InnerSpecTest`.
