### PR TITLE
Remove supporting @JsonTypeInfo, @JsonSubTypes

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -81,7 +81,7 @@ public final class ChildArbitraryContext {
 
 	public List<Arbitrary<?>> getArbitraries() {
 		return arbitrariesByChildProperty.values().stream()
-			.map(CombinableArbitrary::rawValue)
+			.map(CombinableArbitrary::combined)
 			.collect(Collectors.toList());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -21,7 +21,6 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -91,10 +90,6 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 		private final List<Object> array;
 		private final Class<?> componentType;
 		private final int size;
-		/**
-		 * It is used for specifying {@code JacksonCombinableArbitrary} raw value.
-		 */
-		private boolean combined = true;
 
 		public ArrayBuilder(Class<?> componentType, int size) {
 			this.array = new ArrayList<>();
@@ -108,22 +103,13 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 				return this;
 			}
 
-			if (value instanceof Map) {
-				combined = false;
-			}
-
 			array.add(value);
 			return this;
 		}
 
 		// cast to Object for preventing ClassCastException when primitive type
 		Object build() {
-			Object array;
-			if (combined) {
-				array = Array.newInstance(componentType, size);
-			} else {
-				array = Array.newInstance(Object.class, size);
-			}
+			Object array = Array.newInstance(componentType, size);
 
 			for (int i = 0; i < this.array.size(); i++) {
 				Array.set(array, i, this.array.get(i));

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
@@ -18,8 +18,6 @@
 
 package com.navercorp.fixturemonkey.jackson.introspector;
 
-import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
-
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -36,10 +34,6 @@ import net.jqwik.api.Builders;
 import net.jqwik.api.Builders.BuilderCombinator;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
@@ -65,10 +59,9 @@ public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector
 		this.objectMapper = objectMapper;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		Property property = context.getArbitraryProperty().getObjectProperty().getProperty();
+		Property property = context.getResolvedProperty();
 		Class<?> type = Types.getActualType(property.getType());
 
 		List<ArbitraryProperty> childrenProperties = context.getChildren();
@@ -100,22 +93,7 @@ public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector
 											.map(it -> format(value, it))
 											.orElse(value);
 
-										JsonTypeInfo jsonTypeInfo = getJacksonAnnotation(property, JsonTypeInfo.class);
-										if (jsonTypeInfo == null) {
-											map.put(resolvePropertyName, jsonFormatted);
-										} else {
-											if (jsonTypeInfo.include() == As.WRAPPER_OBJECT) {
-												String typeIdentifier = getJsonTypeInfoIdentifier(
-													jsonTypeInfo,
-													property
-												);
-
-												Map<String, Object> typeJson = (Map<String, Object>)
-													map.getOrDefault(typeIdentifier, new HashMap<>());
-												typeJson.put(resolvePropertyName, jsonFormatted);
-												map.put(typeIdentifier, typeJson);
-											}
-										}
+										map.put(resolvePropertyName, jsonFormatted);
 									}
 									return map;
 								});
@@ -129,50 +107,7 @@ public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector
 	}
 
 	private Map<String, Object> initializeMap(Property property) {
-		Map<String, Object> defaultMap = new HashMap<>();
-
-		JsonTypeInfo jsonTypeInfo = getJacksonAnnotation(property, JsonTypeInfo.class);
-		if (jsonTypeInfo == null || jsonTypeInfo.include() == As.WRAPPER_OBJECT) {
-			return defaultMap;
-		}
-
-		String jsonTypeInfoValue = getJsonTypeInfoIdentifier(jsonTypeInfo, property);
-		String jsonTypeInfoPropertyName = getJsonTypeInfoPropertyName(jsonTypeInfo);
-
-		defaultMap.put(jsonTypeInfoPropertyName, jsonTypeInfoValue);
-		return defaultMap;
-	}
-
-	private String getJsonTypeInfoPropertyName(JsonTypeInfo jsonTypeInfo) {
-		return "".equals(jsonTypeInfo.property())
-			? jsonTypeInfo.use().getDefaultPropertyName()
-			: jsonTypeInfo.property();
-	}
-
-	private String getJsonTypeInfoIdentifier(
-		JsonTypeInfo jsonTypeInfo,
-		Property property
-	) {
-		JsonTypeName jsonTypeName = getJacksonAnnotation(property, JsonTypeName.class);
-		Class<?> type = Types.getActualType(property.getType());
-
-		Id id = jsonTypeInfo.use();
-		String jsonTypeInfoValue;
-		switch (id) {
-			case NAME:
-				if (jsonTypeName != null) {
-					jsonTypeInfoValue = jsonTypeName.value();
-				} else {
-					jsonTypeInfoValue = type.getSimpleName();
-				}
-				break;
-			case CLASS:
-				jsonTypeInfoValue = type.getName();
-				break;
-			default:
-				throw new IllegalArgumentException("Unsupported JsonTypeInfo Id : " + id.name());
-		}
-		return jsonTypeInfoValue;
+		return new HashMap<>();
 	}
 
 	private Object format(Object object, JsonFormat jsonFormat) {

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
@@ -18,15 +18,12 @@
 
 package com.navercorp.fixturemonkey.jackson.plugin;
 
-import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -34,11 +31,8 @@ import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
-import com.navercorp.fixturemonkey.api.property.ElementProperty;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
-import com.navercorp.fixturemonkey.jackson.generator.ElementJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.generator.JsonNodeContainerPropertyGenerator;
-import com.navercorp.fixturemonkey.jackson.generator.PropertyJsonSubTypesObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.introspector.JsonNodeIntrospector;
 import com.navercorp.fixturemonkey.jackson.property.JacksonPropertyNameResolver;
@@ -85,19 +79,7 @@ public final class JacksonPlugin implements Plugin {
 		if (this.defaultOptions) {
 			optionsBuilder
 				.objectIntrospector(it -> new JacksonArbitraryIntrospector(objectMapper))
-				.defaultPropertyNameResolver(new JacksonPropertyNameResolver())
-				.insertFirstArbitraryObjectPropertyGenerator(
-					property -> getJacksonAnnotation(property, JsonSubTypes.class) != null,
-					PropertyJsonSubTypesObjectPropertyGenerator.INSTANCE
-				)
-				.insertFirstArbitraryObjectPropertyGenerator(
-					property -> property instanceof ElementProperty
-						&& getJacksonAnnotation(
-						((ElementProperty)property).getContainerProperty(),
-						JsonSubTypes.class
-					) != null,
-					ElementJsonSubTypesObjectPropertyGenerator.INSTANCE
-				);
+				.defaultPropertyNameResolver(new JacksonPropertyNameResolver());
 		}
 
 		optionsBuilder

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -3,6 +3,7 @@ package com.navercorp.fixturemonkey.tests.java;
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
@@ -17,6 +18,7 @@ import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsIn
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsList;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsValue;
 
+@Disabled
 class JacksonTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
 		.plugin(new JacksonPlugin())


### PR DESCRIPTION
## Summary
Remove supporting @JsonTypeInfo, @JsonSubTypes

## (Optional): Description
In order to support `@JsonTypeInfo`, `@JsonSubTypes`, we should consider these situations.

1. generating `List<JsonSuperType>`
    * It should be a `raw` value in `ListIntrospector` 
    * Other introspectors (excluding `JacksonArbitraryIntrospector`) should be `combined` value.
2. Sub-introspector is `JacksonArbitraryIntrospector`, but super-introspector is not `JacksonArbitraryIntrospector`
