### PR TITLE
Add JacksonContainerIntrospector

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -35,8 +35,6 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitrary;
-
 import com.navercorp.fixturemonkey.api.context.MonkeyGeneratorContext;
 import com.navercorp.fixturemonkey.api.customizer.FixtureCustomizer;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
@@ -117,8 +115,8 @@ public final class ArbitraryGeneratorContext {
 		return childArbitraryContext.getValue().getCombinableArbitraryByPropertyName();
 	}
 
-	public List<Arbitrary<?>> getArbitraries() {
-		return childArbitraryContext.getValue().getArbitraries();
+	public List<CombinableArbitrary> getElementArbitraries() {
+		return childArbitraryContext.getValue().getElementArbitraries();
 	}
 
 	@Nullable

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ChildArbitraryContext.java
@@ -20,10 +20,10 @@ package com.navercorp.fixturemonkey.api.generator;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -79,9 +79,7 @@ public final class ChildArbitraryContext {
 			.collect(toMap(it -> it.getKey().getObjectProperty().getProperty().getName(), Entry::getValue));
 	}
 
-	public List<Arbitrary<?>> getArbitraries() {
-		return arbitrariesByChildProperty.values().stream()
-			.map(CombinableArbitrary::combined)
-			.collect(Collectors.toList());
+	public List<CombinableArbitrary> getElementArbitraries() {
+		return new ArrayList<>(arbitrariesByChildProperty.values());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -32,6 +33,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.LazyCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
@@ -64,7 +66,9 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 			new LazyCombinableArbitrary(
 				LazyArbitrary.lazy(
 					() -> {
-						List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+						List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+							.map(CombinableArbitrary::combined)
+							.collect(Collectors.toList());
 						BuilderCombinator<ArrayBuilder> builderCombinator = Builders.withBuilder(() ->
 							new ArrayBuilder(
 								Types.getArrayComponentType(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/EntryIntrospector.java
@@ -22,6 +22,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -31,6 +32,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -57,7 +59,9 @@ public final class EntryIntrospector implements ArbitraryIntrospector, Matcher {
 			);
 		}
 		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -31,6 +32,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -59,7 +61,9 @@ public final class ListIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 		BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {
 			builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -30,6 +31,7 @@ import net.jqwik.api.Builders;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
@@ -61,7 +63,9 @@ public final class MapEntryElementIntrospector implements ArbitraryIntrospector,
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> arbitraries = context.getArbitraries();
+		List<Arbitrary<?>> arbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		if (arbitraries.size() != 2) {
 			throw new IllegalArgumentException("Key and Value should be exist for MapEntryElementType.");

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryIntrospector.java
@@ -22,6 +22,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -31,6 +32,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -56,7 +58,9 @@ public final class MapEntryIntrospector implements ArbitraryIntrospector, Matche
 			);
 		}
 		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		if (containerInfo == null) {
 			return ArbitraryIntrospectorResult.EMPTY;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -30,6 +31,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -60,7 +62,9 @@ public final class MapIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		Arbitrary<?> mapArbitrary = new MonkeyCombineArbitrary(
 			list -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -32,6 +33,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -72,7 +74,9 @@ public final class OptionalIntrospector implements ArbitraryIntrospector, Matche
 		}
 
 		Class<?> type = Types.getActualType(property.getObjectProperty().getProperty().getType());
-		List<Arbitrary<?>> childArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 		Arbitrary<?> elementArbitrary = childArbitraries.get(0)
 			.optional(presenceProbability)
 			.map(it -> {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -32,6 +33,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -60,7 +62,9 @@ public final class QueueIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		BuilderCombinator<Queue<Object>> builderCombinator = Builders.withBuilder(LinkedList::new);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
@@ -31,6 +31,7 @@ import net.jqwik.api.Arbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -62,7 +63,8 @@ public final class SetIntrospector implements ArbitraryIntrospector, Matcher {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries().stream()
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
 			.map(arbitrary ->
 				new FilteredMonkeyArbitrary<>(
 					arbitrary,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -36,6 +37,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -69,7 +71,9 @@ public final class StreamIntrospector implements ArbitraryIntrospector, Matcher 
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 
 		BuilderCombinator<Builder<Object>> builderCombinator = Builders.withBuilder(Stream::builder);
 		for (Arbitrary<?> childArbitrary : childrenArbitraries) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TupleLikeElementsIntrospector.java
@@ -1,6 +1,7 @@
 package com.navercorp.fixturemonkey.api.introspector;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -12,6 +13,7 @@ import net.jqwik.api.Builders.BuilderCombinator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -39,7 +41,9 @@ public final class TupleLikeElementsIntrospector implements ArbitraryIntrospecto
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+			.map(CombinableArbitrary::combined)
+			.collect(Collectors.toList());
 		BuilderCombinator<TupleLikeElementsType> builderCombinator = Builders.withBuilder(TupleLikeElementsType::new);
 		for (Arbitrary<?> child : childrenArbitraries) {
 			builderCombinator = builderCombinator.use(child).in((elements, value) -> {

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArbitraryIntrospector.java
@@ -18,114 +18,38 @@
 
 package com.navercorp.fixturemonkey.jackson.introspector;
 
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Builders;
-import net.jqwik.api.Builders.BuilderCombinator;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
-import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
-import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
-import com.navercorp.fixturemonkey.api.generator.FixedCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
-import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
-import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
 
-@API(since = "0.4.0", status = Status.MAINTAINED)
+/**
+ * It is deprecated since 0.5.4.
+ * Use {@link JacksonObjectArbitraryIntrospector} instead.
+ *
+ * @see JacksonObjectArbitraryIntrospector
+ */
+@Deprecated
+@API(since = "0.4.0", status = Status.DEPRECATED)
 public final class JacksonArbitraryIntrospector implements ArbitraryIntrospector {
+
 	public static final JacksonArbitraryIntrospector INSTANCE = new JacksonArbitraryIntrospector(
 		FixtureMonkeyJackson.defaultObjectMapper()
 	);
 
-	private final ObjectMapper objectMapper;
+	private final JacksonObjectArbitraryIntrospector delegate;
 
 	public JacksonArbitraryIntrospector(ObjectMapper objectMapper) {
-		this.objectMapper = objectMapper;
+		this.delegate = new JacksonObjectArbitraryIntrospector(objectMapper);
 	}
 
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		Property property = context.getResolvedProperty();
-		Class<?> type = Types.getActualType(property.getType());
-
-		List<ArbitraryProperty> childrenProperties = context.getChildren();
-		Map<String, CombinableArbitrary> arbitrariesByResolvedName =
-			context.getCombinableArbitrariesByResolvedName();
-
-		return new ArbitraryIntrospectorResult(
-			new JacksonCombinableArbitrary(
-				LazyArbitrary.lazy(
-					() -> {
-						BuilderCombinator<Map<String, Object>> builderCombinator = Builders.withBuilder(
-							() -> initializeMap(property)
-						);
-
-						for (ArbitraryProperty arbitraryProperty : childrenProperties) {
-							String resolvePropertyName = arbitraryProperty.getObjectProperty()
-								.getResolvedPropertyName();
-							CombinableArbitrary combinableArbitrary = arbitrariesByResolvedName.getOrDefault(
-								resolvePropertyName,
-								new FixedCombinableArbitrary(Arbitraries.just(null)
-								)
-							);
-							builderCombinator = builderCombinator.use(combinableArbitrary.rawValue())
-								.in((map, value) -> {
-									if (value != null) {
-										Object jsonFormatted = arbitraryProperty.getObjectProperty()
-											.getProperty()
-											.getAnnotation(JsonFormat.class)
-											.map(it -> format(value, it))
-											.orElse(value);
-
-										map.put(resolvePropertyName, jsonFormatted);
-									}
-									return map;
-								});
-						}
-						return builderCombinator.build();
-					}
-				),
-				map -> objectMapper.convertValue(map, type)
-			)
-		);
-	}
-
-	private Map<String, Object> initializeMap(Property property) {
-		return new HashMap<>();
-	}
-
-	private Object format(Object object, JsonFormat jsonFormat) {
-		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(jsonFormat.pattern())
-			.withZone(ZoneId.systemDefault());
-
-		if (object instanceof TemporalAccessor) {
-			TemporalAccessor temporalAccessor = (TemporalAccessor)object;
-			return dateTimeFormatter.format(temporalAccessor);
-		} else if (object instanceof Date) {
-			TemporalAccessor dateTemporalAccessor = ((Date)object).toInstant()
-				.atZone(ZoneId.systemDefault())
-				.toLocalDate();
-			return dateTimeFormatter.format(dateTemporalAccessor);
-		} else if (object instanceof Enum && jsonFormat.shape().isNumeric()) {
-			return ((Enum<?>)object).ordinal();
-		} else {
-			return object;
-		}
+		return delegate.introspect(context);
 	}
 }

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArrayArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArrayArbitraryIntrospector.java
@@ -1,0 +1,83 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.introspector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.ArrayType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
+import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+
+@API(since = "0.5.5", status = Status.EXPERIMENTAL)
+public final class JacksonArrayArbitraryIntrospector implements ArbitraryIntrospector, Matcher {
+	public static final JacksonArrayArbitraryIntrospector INSTANCE = new JacksonArrayArbitraryIntrospector(
+		FixtureMonkeyJackson.defaultObjectMapper()
+	);
+
+	private final ObjectMapper objectMapper;
+
+	public JacksonArrayArbitraryIntrospector(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public boolean match(Property property) {
+		return Types.getActualType(property.getType()).isArray();
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		Property property = context.getResolvedProperty();
+		Class<?> elementType = Types.getArrayComponentType(property.getAnnotatedType());
+
+		ArrayType arrayType = TypeFactory.defaultInstance()
+			.constructArrayType(elementType);
+
+		return new ArbitraryIntrospectorResult(
+			new JacksonCombinableArbitrary<>(
+				LazyArbitrary.lazy(() -> {
+					List<Arbitrary<Object>> arbitraries = context.getElementArbitraries().stream()
+						.map(CombinableArbitrary::rawValue)
+						.collect(Collectors.toList());
+
+					return Combinators.combine(arbitraries).as(ArrayList::new);
+				}),
+				list -> objectMapper.convertValue(list, arrayType)
+			)
+		);
+	}
+}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCollectionArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCollectionArbitraryIntrospector.java
@@ -1,0 +1,86 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.introspector;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
+import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+
+@API(since = "0.5.5", status = Status.EXPERIMENTAL)
+public final class JacksonCollectionArbitraryIntrospector implements ArbitraryIntrospector, Matcher {
+	public static final JacksonCollectionArbitraryIntrospector INSTANCE = new JacksonCollectionArbitraryIntrospector(
+		FixtureMonkeyJackson.defaultObjectMapper()
+	);
+
+	private final ObjectMapper objectMapper;
+
+	public JacksonCollectionArbitraryIntrospector(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public boolean match(Property property) {
+		return Collection.class.isAssignableFrom(Types.getActualType(property.getType()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		Property property = context.getResolvedProperty();
+		Class<?> containerType = Types.getActualType(property.getType());
+		Class<?> elementType = Types.getActualType(Types.getGenericsTypes(property.getAnnotatedType()).get(0));
+
+		CollectionType collectionType = TypeFactory.defaultInstance()
+			.constructCollectionType((Class<? extends Collection<?>>)containerType, elementType);
+
+		return new ArbitraryIntrospectorResult(
+			new JacksonCombinableArbitrary<>(
+				LazyArbitrary.lazy(() -> {
+					List<Arbitrary<Object>> arbitraries = context.getElementArbitraries().stream()
+						.map(CombinableArbitrary::rawValue)
+						.collect(Collectors.toList());
+
+					return Combinators.combine(arbitraries).as(ArrayList::new);
+				}),
+				list -> objectMapper.convertValue(list, collectionType)
+			)
+		);
+	}
+}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCombinableArbitrary.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonCombinableArbitrary.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.jackson.introspector;
 
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,13 +33,13 @@ import com.navercorp.fixturemonkey.api.generator.NullInjectCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 
 @API(since = "0.5.0", status = Status.EXPERIMENTAL)
-public final class JacksonCombinableArbitrary implements CombinableArbitrary {
-	private final LazyArbitrary<Arbitrary<Map<String, Object>>> arbitrary;
-	private final Function<Map<String, Object>, Object> deserializer;
+public final class JacksonCombinableArbitrary<C> implements CombinableArbitrary {
+	private final LazyArbitrary<Arbitrary<C>> arbitrary;
+	private final Function<C, Object> deserializer;
 
 	public JacksonCombinableArbitrary(
-		LazyArbitrary<Arbitrary<Map<String, Object>>> arbitrary,
-		Function<Map<String, Object>, Object> deserializer
+		LazyArbitrary<Arbitrary<C>> arbitrary,
+		Function<C, Object> deserializer
 	) {
 		this.arbitrary = arbitrary;
 		this.deserializer = deserializer;

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonMapArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonMapArbitraryIntrospector.java
@@ -1,0 +1,103 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.introspector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty.MapEntryElementType;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
+import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+
+@API(since = "0.5.5", status = Status.EXPERIMENTAL)
+public final class JacksonMapArbitraryIntrospector implements ArbitraryIntrospector, Matcher {
+	public static final JacksonMapArbitraryIntrospector INSTANCE = new JacksonMapArbitraryIntrospector(
+		FixtureMonkeyJackson.defaultObjectMapper()
+	);
+
+	private final ObjectMapper objectMapper;
+
+	public JacksonMapArbitraryIntrospector(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public boolean match(Property property) {
+		return Map.class.isAssignableFrom(Types.getActualType(property.getType()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		Property property = context.getResolvedProperty();
+		Class<? extends Map<?, ?>> containerType = (Class<? extends Map<?, ?>>)Types.getActualType(property.getType());
+		Class<?> keyType = Types.getActualType(Types.getGenericsTypes(property.getAnnotatedType()).get(0));
+		Class<?> valueType = Types.getActualType(Types.getGenericsTypes(property.getAnnotatedType()).get(1));
+
+		MapLikeType mapType = TypeFactory.defaultInstance()
+			.constructMapType(containerType, keyType, valueType);
+
+		return new ArbitraryIntrospectorResult(
+			new JacksonCombinableArbitrary<>(
+				LazyArbitrary.lazy(() -> {
+					List<Arbitrary<Object>> arbitraries = context.getElementArbitraries().stream()
+						.map(CombinableArbitrary::rawValue)
+						.collect(Collectors.toList());
+
+					return Combinators.combine(arbitraries).as(
+						list -> {
+							Map<Object, Object> map = new HashMap<>();
+							for (Object obj : list) {
+								MapEntryElementType mapEntryElement = (MapEntryElementType)obj;
+								if (mapEntryElement.getKey() == null) {
+									throw new IllegalArgumentException("Map key cannot be null.");
+								}
+								map.put(
+									mapEntryElement.getKey(),
+									mapEntryElement.getValue()
+								);
+							}
+							return map;
+						}
+					);
+				}),
+				list -> objectMapper.convertValue(list, mapType)
+			)
+		);
+	}
+}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
@@ -1,0 +1,131 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.introspector;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Builders;
+import net.jqwik.api.Builders.BuilderCombinator;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.FixedCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
+import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.type.Types;
+import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+
+@API(since = "0.5.5", status = Status.EXPERIMENTAL)
+public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntrospector {
+	public static final JacksonObjectArbitraryIntrospector INSTANCE = new JacksonObjectArbitraryIntrospector(
+		FixtureMonkeyJackson.defaultObjectMapper()
+	);
+
+	private final ObjectMapper objectMapper;
+
+	public JacksonObjectArbitraryIntrospector(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		Property property = context.getResolvedProperty();
+		Class<?> type = Types.getActualType(property.getType());
+
+		List<ArbitraryProperty> childrenProperties = context.getChildren();
+		Map<String, CombinableArbitrary> arbitrariesByResolvedName =
+			context.getCombinableArbitrariesByResolvedName();
+
+		return new ArbitraryIntrospectorResult(
+			new JacksonCombinableArbitrary<>(
+				LazyArbitrary.lazy(
+					() -> {
+						BuilderCombinator<Map<String, Object>> builderCombinator = Builders.withBuilder(
+							() -> initializeMap(property)
+						);
+
+						for (ArbitraryProperty arbitraryProperty : childrenProperties) {
+							String resolvePropertyName = arbitraryProperty.getObjectProperty()
+								.getResolvedPropertyName();
+							CombinableArbitrary combinableArbitrary = arbitrariesByResolvedName.getOrDefault(
+								resolvePropertyName,
+								new FixedCombinableArbitrary(Arbitraries.just(null)
+								)
+							);
+							builderCombinator = builderCombinator.use(combinableArbitrary.rawValue())
+								.in((map, value) -> {
+									if (value != null) {
+										Object jsonFormatted = arbitraryProperty.getObjectProperty()
+											.getProperty()
+											.getAnnotation(JsonFormat.class)
+											.map(it -> format(value, it))
+											.orElse(value);
+
+										map.put(resolvePropertyName, jsonFormatted);
+									}
+									return map;
+								});
+						}
+						return builderCombinator.build();
+					}
+				),
+				map -> objectMapper.convertValue(map, type)
+			)
+		);
+	}
+
+	private Map<String, Object> initializeMap(Property property) {
+		return new HashMap<>();
+	}
+
+	private Object format(Object object, JsonFormat jsonFormat) {
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(jsonFormat.pattern())
+			.withZone(ZoneId.systemDefault());
+
+		if (object instanceof TemporalAccessor) {
+			TemporalAccessor temporalAccessor = (TemporalAccessor)object;
+			return dateTimeFormatter.format(temporalAccessor);
+		} else if (object instanceof Date) {
+			TemporalAccessor dateTemporalAccessor = ((Date)object).toInstant()
+				.atZone(ZoneId.systemDefault())
+				.toLocalDate();
+			return dateTimeFormatter.format(dateTemporalAccessor);
+		} else if (object instanceof Enum && jsonFormat.shape().isNumeric()) {
+			return ((Enum<?>)object).ordinal();
+		} else {
+			return object;
+		}
+	}
+}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.jackson.introspector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -35,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
@@ -67,7 +69,9 @@ public final class JsonNodeIntrospector implements ArbitraryIntrospector {
 			return ArbitraryIntrospectorResult.EMPTY;
 		}
 
-		List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+		List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+				.map(CombinableArbitrary::combined)
+				.collect(Collectors.toList());
 
 		BuilderCombinator<Map<Object, Object>> builderCombinator = Builders.withBuilder(HashMap::new);
 		for (Arbitrary<?> child : childrenArbitraries) {

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/plugin/JacksonPlugin.java
@@ -19,6 +19,7 @@
 package com.navercorp.fixturemonkey.jackson.plugin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -27,13 +28,17 @@ import org.apiguardian.api.API.Status;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.option.GenerateOptionsBuilder;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
 import com.navercorp.fixturemonkey.jackson.generator.JsonNodeContainerPropertyGenerator;
-import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jackson.introspector.JacksonArrayArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jackson.introspector.JacksonCollectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jackson.introspector.JacksonMapArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jackson.introspector.JacksonObjectArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.introspector.JsonNodeIntrospector;
 import com.navercorp.fixturemonkey.jackson.property.JacksonPropertyNameResolver;
 
@@ -72,14 +77,22 @@ public final class JacksonPlugin implements Plugin {
 			Matcher matcher = property -> matchers.stream().anyMatch(it -> it.match(property));
 
 			optionsBuilder
-				.insertFirstArbitraryIntrospector(matcher, new JacksonArbitraryIntrospector(objectMapper))
+				.insertFirstArbitraryIntrospector(matcher, new JacksonObjectArbitraryIntrospector(objectMapper))
 				.insertFirstPropertyNameResolver(matcher, new JacksonPropertyNameResolver());
 		}
 
 		if (this.defaultOptions) {
 			optionsBuilder
-				.objectIntrospector(it -> new JacksonArbitraryIntrospector(objectMapper))
-				.defaultPropertyNameResolver(new JacksonPropertyNameResolver());
+				.objectIntrospector(it -> new JacksonObjectArbitraryIntrospector(objectMapper))
+				.defaultPropertyNameResolver(new JacksonPropertyNameResolver())
+				.containerIntrospector(container -> new CompositeArbitraryIntrospector(
+					Arrays.asList(
+						new JacksonCollectionArbitraryIntrospector(objectMapper),
+						new JacksonArrayArbitraryIntrospector(objectMapper),
+						new JacksonMapArbitraryIntrospector(objectMapper),
+						container
+					)
+				));
 		}
 
 		optionsBuilder

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
@@ -24,14 +24,14 @@ import static org.assertj.core.api.BDDAssertions.then;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.jackson.introspector.JacksonArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jackson.introspector.JacksonObjectArbitraryIntrospector;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.ContainerRecord;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.DateTimeRecord;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.JavaTypeRecord;
 
 class JacksonRecordTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
-		.objectIntrospector(JacksonArbitraryIntrospector.INSTANCE)
+		.objectIntrospector(JacksonObjectArbitraryIntrospector.INSTANCE)
 		.build();
 
 	@RepeatedTest(TEST_COUNT)

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -4,13 +4,20 @@ import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
+import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
+import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.ContainerObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.JavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.RootJavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClass;
@@ -107,6 +114,137 @@ class JacksonTest {
 			)
 			.sample()
 			.getValue();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleContainerType() {
+		ContainerObject actual = SUT.giveMeOne(ContainerObject.class);
+
+		then(actual.getPrimitiveArray()).isNotNull();
+		then(actual.getArray()).isNotNull();
+		then(actual.getComplexArray()).isNotNull();
+		then(actual.getList()).isNotNull();
+		then(actual.getComplexList()).isNotNull();
+		then(actual.getSet()).isNotNull();
+		then(actual.getComplexSet()).isNotNull();
+		then(actual.getMap()).isNotNull();
+		then(actual.getComplexMap()).isNotNull();
+		then(actual.getMapEntry()).isNotNull();
+		then(actual.getComplexMapEntry()).isNotNull();
+		then(actual.getOptional()).isNotNull();
+		then(actual.getOptionalInt()).isNotNull();
+		then(actual.getOptionalLong()).isNotNull();
+		then(actual.getOptionalDouble()).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleListType() {
+		List<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<List<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedListType() {
+		List<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<List<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSetType() {
+		Set<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Set<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedSetType() {
+		Set<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Set<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleArrayType() {
+		JavaTypeObject[] actual = SUT.giveMeOne(new TypeReference<JavaTypeObject[]>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedArrayType() {
+		JavaTypeObject[] actual = SUT.giveMeBuilder(new TypeReference<JavaTypeObject[]>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleOptionalType() {
+		Optional<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Optional<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedOptionalType() {
+		Optional<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Optional<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleMapType() {
+		Map<String, JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Map<String, JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedMapType() {
+		Map<String, JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Map<String, JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleMapEntryType() {
+		Map.Entry<String, JavaTypeObject> actual = SUT.giveMeOne(
+			new TypeReference<Map.Entry<String, JavaTypeObject>>() {
+			});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedMapEntryType() {
+		Map.Entry<String, JavaTypeObject> actual = SUT.giveMeBuilder(
+				new TypeReference<Map.Entry<String, JavaTypeObject>>() {
+				})
+			.fixed()
+			.sample();
 
 		then(actual).isNotNull();
 	}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -21,6 +21,11 @@ package com.navercorp.fixturemonkey.tests.java;
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
@@ -29,6 +34,8 @@ import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericImplementationObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.TwoGenericImplementationObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.ContainerObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.JavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableRecursiveTypeSpecs.SelfRecursiveListObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableRecursiveTypeSpecs.SelfRecursiveObject;
 
@@ -187,5 +194,136 @@ class JavaTest {
 
 		then(actual.getValue()).isNotNull();
 		then(actual.getSelfRecursiveListObjects()).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleContainerType() {
+		ContainerObject actual = SUT.giveMeOne(ContainerObject.class);
+
+		then(actual.getPrimitiveArray()).isNotNull();
+		then(actual.getArray()).isNotNull();
+		then(actual.getComplexArray()).isNotNull();
+		then(actual.getList()).isNotNull();
+		then(actual.getComplexList()).isNotNull();
+		then(actual.getSet()).isNotNull();
+		then(actual.getComplexSet()).isNotNull();
+		then(actual.getMap()).isNotNull();
+		then(actual.getComplexMap()).isNotNull();
+		then(actual.getMapEntry()).isNotNull();
+		then(actual.getComplexMapEntry()).isNotNull();
+		then(actual.getOptional()).isNotNull();
+		then(actual.getOptionalInt()).isNotNull();
+		then(actual.getOptionalLong()).isNotNull();
+		then(actual.getOptionalDouble()).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleListType() {
+		List<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<List<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedListType() {
+		List<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<List<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSetType() {
+		Set<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Set<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedSetType() {
+		Set<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Set<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleArrayType() {
+		JavaTypeObject[] actual = SUT.giveMeOne(new TypeReference<JavaTypeObject[]>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedArrayType() {
+		JavaTypeObject[] actual = SUT.giveMeBuilder(new TypeReference<JavaTypeObject[]>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleOptionalType() {
+		Optional<JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Optional<JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedOptionalType() {
+		Optional<JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Optional<JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleMapType() {
+		Map<String, JavaTypeObject> actual = SUT.giveMeOne(new TypeReference<Map<String, JavaTypeObject>>() {
+		});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedMapType() {
+		Map<String, JavaTypeObject> actual = SUT.giveMeBuilder(new TypeReference<Map<String, JavaTypeObject>>() {
+			})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleMapEntryType() {
+		Map.Entry<String, JavaTypeObject> actual = SUT.giveMeOne(
+			new TypeReference<Map.Entry<String, JavaTypeObject>>() {
+			});
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedMapEntryType() {
+		Map.Entry<String, JavaTypeObject> actual = SUT.giveMeBuilder(
+				new TypeReference<Map.Entry<String, JavaTypeObject>>() {
+				})
+			.fixed()
+			.sample();
+
+		then(actual).isNotNull();
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
@@ -23,6 +23,7 @@ import java.beans.ConstructorProperties;
 import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Builders;
@@ -39,6 +40,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.generator.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGeneratorContext;
@@ -144,7 +146,9 @@ class FixtureMonkeyOptionsAdditionalTestSpecs {
 				return ArbitraryIntrospectorResult.EMPTY;
 			}
 
-			List<Arbitrary<?>> childrenArbitraries = context.getArbitraries();
+			List<Arbitrary<?>> childrenArbitraries = context.getElementArbitraries().stream()
+				.map(CombinableArbitrary::combined)
+				.collect(Collectors.toList());
 			BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
 			for (Arbitrary<?> childArbitrary : childrenArbitraries) {
 				builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {


### PR DESCRIPTION
## Summary
Add JacksonContainerIntrospector

## (Optional): Description
Jackson deserializes `Container type` by its own way.
Add `JacksonCollectionArbitraryIntrospector`, `JacksonArrayArbitraryIntrospector`, `JacksonMapArbitraryIntrospector`

## How Has This Been Tested?
* sampleContainerType
* sampleListType
* fixedListType
* sampleSetType
* fixedSetType
* sampleArrayType
* fixedArrayType
* sampleOptionalType
* fixedOptionalType
* sampleMapType
* fixedMapType
* sampleMapEntryType
* fixedMapEntryType
