### PR TITLE
Fix FixtureCustomizer in Jackson

### DIFF
--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableJavaTestSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableJavaTestSpecs.java
@@ -109,6 +109,12 @@ class ImmutableJavaTestSpecs {
 		OptionalDouble optionalDouble;
 	}
 
+	@Value
+	@Builder
+	public static class RootJavaTypeObject {
+		JavaTypeObject value;
+	}
+
 	public enum Enum {
 		ONE,
 		TWO,

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -1,13 +1,18 @@
 package com.navercorp.fixturemonkey.tests.java;
 
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
+import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.JavaTypeObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.RootJavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClass;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdName;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoList;
@@ -18,55 +23,91 @@ import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsIn
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsList;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.TypeWithAnnotationsValue;
 
-@Disabled
 class JacksonTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
 		.plugin(new JacksonPlugin())
 		.defaultNotNull(true)
 		.build();
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoName() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdName.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoList() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoList.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoIdClass() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoIdClass.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeWithAnnotations() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsValue.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeWithAnnotationsList() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsList.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoListInSetter() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListInSetter.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoListIncludeWrapperObject() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListIncludeWrapperObject.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeInfoListInSetterIncludeWrapperObject() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(JsonTypeInfoListInSetterIncludeWrapperObject.class));
 	}
 
+	@Disabled
 	@RepeatedTest(TEST_COUNT)
 	void jsonTypeWithAnnotationsIncludeWrapperObjectList() {
 		thenNoException().isThrownBy(() -> SUT.giveMeOne(TypeWithAnnotationsIncludeWrapperObjectList.class));
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void customizedByOption() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.plugin(new JacksonPlugin())
+			.pushAssignableTypeFixtureCustomizer(JavaTypeObject.class, value -> value)
+			.defaultNotNull(true)
+			.build();
+
+		JavaTypeObject actual = sut.giveMeOne(RootJavaTypeObject.class).getValue();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void customized() {
+		JavaTypeObject actual = SUT.giveMeBuilder(RootJavaTypeObject.class)
+			.customize(
+				new MatcherOperator<>(
+					new AssignableTypeMatcher(JavaTypeObject.class),
+					obj -> obj
+				)
+			)
+			.sample()
+			.getValue();
+
+		then(actual).isNotNull();
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -498,7 +498,7 @@ public interface ArbitraryBuilder<T> {
 		Function<List<?>, R> combinator
 	);
 
-	ArbitraryBuilder<T> customize(MatcherOperator<FixtureCustomizer<T>> customizer);
+	ArbitraryBuilder<T> customize(MatcherOperator<FixtureCustomizer<?>> customizer);
 
 	/**
 	 * Build {@link ArbitraryBuilder} into {@link Arbitrary} for using various support methods

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/DefaultArbitraryBuilder.java
@@ -396,7 +396,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T> {
 	}
 
 	@Override
-	public ArbitraryBuilder<T> customize(MatcherOperator<FixtureCustomizer<T>> fixtureCustomizer) {
+	public ArbitraryBuilder<T> customize(MatcherOperator<FixtureCustomizer<?>> fixtureCustomizer) {
 		this.context.addCustomizer(fixtureCustomizer);
 		return this;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -173,13 +173,19 @@ public final class ObjectTree {
 			generated = generated.filter(predicate);
 		}
 
-		return generated.map(
-			object -> ctx.getFixtureCustomizers().stream()
-				.filter(it -> it.match(node.getProperty()))
-				.map(MatcherOperator::getOperator)
-				.findFirst()
-				.map(it -> it.customizeFixture(object))
-				.orElse(object)
-		);
+		FixtureCustomizer customizer = ctx.getFixtureCustomizers().stream()
+			.filter(it -> it.match(node.getProperty()))
+			.map(MatcherOperator::getOperator)
+			.findFirst()
+			.orElse(null);
+
+		CombinableArbitrary arbitrary = generated;
+		if (customizer != null) {
+			arbitrary = new FixedCombinableArbitrary(
+				generated.combined().map(obj -> customizer.customizeFixture(obj))
+			);
+		}
+
+		return arbitrary;
 	}
 }


### PR DESCRIPTION
## Summary
Fix FixtureCustomizer in Jackson

## (Optional): Description
* Interface `ArbitraryBuilder` customize could work in any property types.
* It would be combined when customized