### PR TITLE
Polish jakarta-validation dependency

### DIFF
--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     api("org.apiguardian:apiguardian-api:1.1.2")
     api("javax.validation:validation-api:2.0.1.Final")
+    api("jakarta.validation:jakarta.validation-api:3.0.2")
     compileOnly("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
     compileOnly("net.jqwik:jqwik-api:${JQWIK_VERSION}")
     compileOnly("net.jqwik:jqwik-time:${JQWIK_VERSION}")

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 dependencies {
     api(project(":fixture-monkey-api"))
-    api("jakarta.validation:jakarta.validation-api:3.0.2")
     api("net.jqwik:jqwik-web:${JQWIK_VERSION}")
     api("net.jqwik:jqwik-time:${JQWIK_VERSION}")
     api("com.github.mifmif:generex:1.0.2")

--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     api(project(":fixture-monkey"))
     api(project(":fixture-monkey-engine"))
     api("ch.qos.logback:logback-classic:1.2.9")
-    api("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    api("org.glassfish:jakarta.el:3.0.4")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -15,15 +15,12 @@ dependencies {
 
     api("net.jqwik:jqwik:${JQWIK_VERSION}")
     api("com.github.mifmif:generex:1.0.2")
-    api("jakarta.validation:jakarta.validation-api:3.0.2")
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
     testImplementation("org.projectlombok:lombok:1.18.24")
-    testImplementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    testImplementation('org.glassfish:jakarta.el:3.0.4')
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 
     jmhImplementation("org.openjdk.jmh:jmh-core:1.35")

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryValue.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryValue.java
@@ -125,7 +125,9 @@ final class ArbitraryValue<T> implements Arbitrary<T> {
 				try {
 					this.validator.validate(fixture);
 					return true;
-				} catch (ConstraintViolationException | jakarta.validation.ConstraintViolationException ex) {
+				} catch (Exception ex) {
+					// It uses Exception for preventing to fail
+					// due to conflict caused by client hibernate-validator version.
 					if (ex instanceof ConstraintViolationException) {
 						((ConstraintViolationException)ex).getConstraintViolations().forEach(violation ->
 							this.violations.put(


### PR DESCRIPTION
## Summary
Polish for jakarta-validation

## (Optional): Description
* remove redundant dependency and useless dependency
* using Exception instead of concrete class `ConstraintViolationException`, `jakarta.validation.ConstraintViolationException`. It may fail if client uses lower version of `hibernate-validator`
