### PR TITLE
Add setInner method takes InnerSpec consumer

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ArbitraryBuilderExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ArbitraryBuilderExtensions.kt
@@ -1,0 +1,30 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder
+import com.navercorp.fixturemonkey.customizer.InnerSpec
+
+/**
+ * Apply manipulation to [InnerSpec][com.navercorp.fixturemonkey.customizer.InnerSpec]
+ * and pass it to [setInner][com.navercorp.fixturemonkey.ArbitraryBuilder.setInner].
+ */
+fun <T> ArbitraryBuilder<T>.setInner(innerSpecConfigurer: ((InnerSpec) -> Unit)): ArbitraryBuilder<T> {
+    return this.setInner(InnerSpec().apply(innerSpecConfigurer))
+}

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InnerSpecTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InnerSpecTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.kotlin
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.setInner
+import com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.RepeatedTest
+
+class InnerSpecTest {
+
+    @RepeatedTest(TEST_COUNT)
+    fun setInnerSpecByTrailingLambda() {
+        val actual = SUT.giveMeBuilder<Map<String, String>>()
+            .setInner {
+                it.keys("key1", "key2")
+                    .minSize(3)
+            }
+            .sample()
+
+        then(actual).containsKeys("key1", "key2")
+    }
+
+    companion object {
+        private val SUT: FixtureMonkey = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .build()
+    }
+}


### PR DESCRIPTION
## Summary

I want to use like this (in kotlin).

```kotlin
val actual = SUT.giveMeBuilder<Map<String, String>>()
    .setInner {
        it.keys("key1", "key2")
            .minSize(3)
    }
    .sample()
```

## How Has This Been Tested?

InnerSpecTest#innerConsumer