### PR TITLE
Fix KPropertyProperty getValue

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
@@ -33,8 +33,6 @@ data class KPropertyProperty(
     private val annotatedType: AnnotatedType,
     val kProperty: KProperty<*>,
 ) : Property {
-    private val LOGGER = LoggerFactory.getLogger(KPropertyProperty::class.java)
-
     override fun getType(): Type = this.annotatedType.type
 
     override fun getAnnotatedType(): AnnotatedType = this.annotatedType
@@ -61,4 +59,8 @@ data class KPropertyProperty(
     }
 
     override fun isNullable(): Boolean = this.kProperty.returnType.isMarkedNullable
+
+    companion object {
+        private val LOGGER = LoggerFactory.getLogger(KPropertyProperty::class.java)
+    }
 }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
@@ -44,16 +44,19 @@ data class KPropertyProperty(
     override fun getAnnotations(): List<Annotation> = this.annotatedType.annotations.toList()
 
     override fun getValue(instance: Any): Any? {
-        val getter = this.kProperty.getter
-        if (getter.javaMethod != null && Modifier.isPublic(getter.javaMethod!!.modifiers)) {
+        val javaMethod = this.kProperty.getter.javaMethod
+
+        if (javaMethod != null && Modifier.isPublic(javaMethod.modifiers)) {
             return this.kProperty.getter.call(instance)
-        } else if (this.kProperty.javaField != null) {
-            val javaField = this.kProperty.javaField!!
+        }
+
+        val javaField = this.kProperty.javaField
+        if (javaField != null) {
             javaField.isAccessible = true
             return javaField.get(instance)
-        } else {
-            LOGGER.warn("Failed to get value of property {} in instance {}.", this.kProperty.name, instance);
         }
+
+        LOGGER.warn("Failed to get value of property {} in instance {}.", this.kProperty.name, instance)
         return null
     }
 

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyPropertyTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyPropertyTest.kt
@@ -62,6 +62,21 @@ class KPropertyPropertyTest {
         then(actual["instant"]!!.annotations).hasSize(1)
         then(actual["instant"]!!.annotations[0].annotationClass).isEqualTo(PastOrPresent::class)
     }
+
+    @Test
+    fun getValueOfPropertyWithoutBackingField() {
+        // given
+        val typeReference = object : TypeReference<PropertyWithoutBackingFieldClass>() {}
+        val property = PropertyWithoutBackingFieldClass::class.memberProperties.first()
+        val kPropertyProperty = KPropertyProperty(getAnnotatedType(typeReference.annotatedType, property), property)
+        val propertyWithoutBackingFieldClass = PropertyWithoutBackingFieldClass()
+
+        // when
+        val actual = kPropertyProperty.getValue(propertyWithoutBackingFieldClass)
+
+        // then
+        then(actual).isEqualTo("test")
+    }
 }
 
 data class PropertySample(
@@ -79,4 +94,9 @@ data class PropertySample(
 ) {
     @PastOrPresent
     val instant: Instant = Instant.now()
+}
+
+class PropertyWithoutBackingFieldClass {
+    val str: String
+        get() = "test"
 }


### PR DESCRIPTION
## Summary
The original implementation of the `getValue()` function of `KPropertyProperty` gives a NPE when a kotlin property does not have a backing field.

## (Optional): Description
The refactored implementation replaces the check for `kProperty.isAccessible` with a check for the accessibility of the getter javaMethod.

## How Has This Been Tested?
`getValueOfPropertyWithoutBackingField()` test added.
