### PR TITLE
Improve ArbitraryBuilderCandidateListExtensions

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/resolver/ArbitraryBuilderCandidateListExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/resolver/ArbitraryBuilderCandidateListExtensions.kt
@@ -18,9 +18,23 @@
 
 package com.navercorp.fixturemonkey.kotlin.resolver
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.api.type.TypeReference
 import com.navercorp.fixturemonkey.resolver.ArbitraryBuilderCandidateFactory
+import com.navercorp.fixturemonkey.resolver.ArbitraryBuilderCandidateList
 
-inline fun <reified T : Any?> ArbitraryBuilderCandidateFactory.of():
-    ArbitraryBuilderCandidateFactory.CandidateBuilder<T> =
-    ArbitraryBuilderCandidateFactory.of(object : TypeReference<T>() {})
+inline fun <reified T : Any?> ArbitraryBuilderCandidateList.add(
+    noinline builder: (ArbitraryBuilder<T>) -> ArbitraryBuilder<T>
+): ArbitraryBuilderCandidateList =
+    this.add(
+        ArbitraryBuilderCandidateFactory.of(object : TypeReference<T>() {})
+            .builder(builder)
+    )
+
+inline fun <reified T : Any?> ArbitraryBuilderCandidateList.add(
+    value: T
+): ArbitraryBuilderCandidateList =
+    this.add(
+        ArbitraryBuilderCandidateFactory.of(object : TypeReference<T>() {})
+            .value(value)
+    )


### PR DESCRIPTION
## Summary

related #628

Change the target class of extension methods. (ArbitraryBuilderCandidateFactory -> ArbitraryBuilderCandidateList)

## (Optional): Description

- `ArbitraryBuilderCandidateFactory` 는 static method 여서 extension 의 의미가 없습니다
- `ArbitraryBuilderCandidateList` 에 대한 extension 을 추가합니다
