### PR TITLE
Refactor JacksonObjectArbitraryIntrospector using valid properties

### DIFF
--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
@@ -49,7 +49,11 @@ import com.navercorp.fixturemonkey.api.generator.FixedCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.property.CompositeProperty;
+import com.navercorp.fixturemonkey.api.property.ConstructorProperty;
+import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyDescriptorProperty;
 import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
 
@@ -84,6 +88,10 @@ public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntros
 						);
 
 						for (ArbitraryProperty arbitraryProperty : childrenProperties) {
+							if (!isJacksonSerializableProperty(arbitraryProperty.getObjectProperty().getProperty())) {
+								continue;
+							}
+
 							String resolvePropertyName = arbitraryProperty.getObjectProperty()
 								.getResolvedPropertyName();
 							CombinableArbitrary combinableArbitrary = arbitrariesByResolvedName.getOrDefault(
@@ -192,5 +200,17 @@ public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntros
 		} else {
 			return object;
 		}
+	}
+
+	private boolean isJacksonSerializableProperty(Property property) {
+		if (property instanceof CompositeProperty) {
+			CompositeProperty compositeProperty = (CompositeProperty)property;
+			return isJacksonSerializableProperty(compositeProperty.getPrimaryProperty())
+				|| isJacksonSerializableProperty(compositeProperty.getSecondaryProperty());
+		}
+
+		return property instanceof FieldProperty
+			|| property instanceof PropertyDescriptorProperty
+			|| property instanceof ConstructorProperty;
 	}
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
 
@@ -152,5 +153,11 @@ public class JacksonSpecs {
 	@Value
 	public static class TypeWithAnnotationsIncludeWrapperObjectList {
 		List<TypeWithAnnotationsIncludeWrapperObject> types;
+	}
+
+	@AllArgsConstructor
+	public static class ConstructorObject {
+		private final String value1;
+		private final int value2;
 	}
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
@@ -21,6 +20,7 @@ import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.ContainerOb
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.Enum;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.JavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.RootJavaTypeObject;
+import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.ConstructorObject;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClass;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdName;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoList;
@@ -249,5 +249,12 @@ class JacksonTest {
 					.size("$", 2)
 					.sample()
 			);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleConstructorObject() {
+		ConstructorObject actual = SUT.giveMeOne(ConstructorObject.class);
+
+		then(actual).isNotNull();
 	}
 }


### PR DESCRIPTION
## Summary
Refactor JacksonObjectArbitraryIntrospector using valid properties

## (Optional): Description
Jackson only uses `public fields`, `getter/setter`, `constructor` property.
