### PR TITLE
Issue 679: Update InnerSpec and InnerSpecTest

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -24,6 +24,7 @@ import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALU
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -173,6 +174,16 @@ public final class InnerSpec {
 	 */
 	public InnerSpec keys(Object... keys) {
 		Arrays.stream(keys).forEach(this::key);
+		return this;
+	}
+
+	/**
+	 * Sets multiple keys in the currently referred map property from a Collection.
+	 *
+	 * @param keyCollection The collection of keys to set in the map. Can be empty.
+	 */
+	public InnerSpec keys(Collection<? extends Object> keyCollection) {
+		keyCollection.forEach(this::key);
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -22,12 +22,7 @@ import static com.navercorp.fixturemonkey.customizer.Values.NOT_NULL;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -107,6 +102,24 @@ class InnerSpecTest {
 		then(actual.keySet()).containsAll(
 			Stream.of("key1", "key2", "key3").collect(Collectors.toCollection(HashSet::new))
 		);
+	}
+
+	@Property
+	void keysCollection() {
+		// Given
+		List<String> keysList = Arrays.asList("key1", "key2", "key3");
+
+		// when
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner(
+				new InnerSpec()
+					.property("strMap", m -> m.minSize(3).keys(keysList)) // using the keys method with a collection
+			)
+			.sample()
+			.getStrMap();
+
+		// then
+		then(actual.keySet()).containsAll(keysList);
 	}
 
 	@Property


### PR DESCRIPTION
## Summary
This change allows you to pass in a Collection to the keys method of InnerSpec.

This is for issue [679](https://github.com/naver/fixture-monkey/issues/679)

## Description
I've added an overloaded method to the InnerSpec class that takes in a Collection and calls the key method for each. 

## How Has This Been Tested?
I've added a keysCollection() test to InnerSpecTest.

Note: I had to use <? extends Object> because in my testing a List<String> didn't pass because String is a subclass of Object. However, in terms of Java generics, Collection<String> and Collection<Object> are not the same and are not directly interchangeable, even though String is a subclass of Object. This is because generics in Java are invariant.
