### PR TITLE
Refactor ArbitraryGenerator options

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -35,6 +35,7 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
  */
 @API(since = "0.6.0", status = Status.EXPERIMENTAL)
 public interface CombinableArbitrary {
+	CombinableArbitrary NOT_GENERATED = CombinableArbitrary.from(null);
 	int MAX_TRIES = 1_000;
 
 	/**

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/CompositeArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/CompositeArbitraryGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import static com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary.NOT_GENERATED;
+
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+
+/**
+ * Generates a {@link CombinableArbitrary} by one or more {@link ArbitraryGenerator}.
+ * If a {@link ArbitraryGenerator} returns {@code NOT_GENERATED}, the next {@link ArbitraryGenerator} would be used.
+ */
+@API(since = "0.6.2", status = Status.EXPERIMENTAL)
+public final class CompositeArbitraryGenerator implements ArbitraryGenerator {
+	private final List<ArbitraryGenerator> arbitraryGenerators;
+
+	public CompositeArbitraryGenerator(List<ArbitraryGenerator> arbitraryGenerators) {
+		this.arbitraryGenerators = arbitraryGenerators;
+	}
+
+	@Override
+	public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
+		for (ArbitraryGenerator arbitraryGenerator : arbitraryGenerators) {
+			CombinableArbitrary generated = arbitraryGenerator.generate(context);
+			if (generated != NOT_GENERATED) {
+				return generated;
+			}
+		}
+		return NOT_GENERATED;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultArbitraryGenerator.java
@@ -18,6 +18,8 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
+import static com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary.NOT_GENERATED;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -26,7 +28,12 @@ import com.navercorp.fixturemonkey.api.arbitrary.TraceableCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 
+/**
+ * It is deprecated.
+ * Use {@link IntrospectedArbitraryGenerator} instead.
+ */
 @API(since = "0.4.0", status = Status.MAINTAINED)
+@Deprecated
 public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 	private final ArbitraryIntrospector arbitraryIntrospector;
 
@@ -38,10 +45,18 @@ public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 		return new JavaDefaultArbitraryGeneratorBuilder();
 	}
 
+	/**
+	 * Generates a {@link CombinableArbitrary} by given {@link ArbitraryIntrospector}.
+	 *
+	 * @param context generator context
+	 * @return generated {@link CombinableArbitrary}.
+	 * Returns {@code DefaultArbitraryGenerator.NOT_GENERATED}
+	 * if given {@link ArbitraryGenerator} could not generate a {@link CombinableArbitrary}
+	 */
 	@Override
 	public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
 		ArbitraryIntrospectorResult result = this.arbitraryIntrospector.introspect(context);
-		if (result.getValue() != null) {
+		if (result != ArbitraryIntrospectorResult.EMPTY && result.getValue() != null) {
 			double nullInject = context.getArbitraryProperty().getObjectProperty().getNullInject();
 			return new TraceableCombinableArbitrary(
 				result.getValue()
@@ -50,6 +65,6 @@ public class DefaultArbitraryGenerator implements ArbitraryGenerator {
 			);
 		}
 
-		return CombinableArbitrary.from(null);
+		return NOT_GENERATED;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/IntrospectedArbitraryGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/IntrospectedArbitraryGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.generator;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+
+/**
+ * Generates a {@link CombinableArbitrary} by {@link ArbitraryIntrospector}.
+ */
+@API(since = "0.6.2", status = Status.EXPERIMENTAL)
+public final class IntrospectedArbitraryGenerator extends DefaultArbitraryGenerator {
+	public IntrospectedArbitraryGenerator(ArbitraryIntrospector arbitraryIntrospector) {
+		super(arbitraryIntrospector);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -76,7 +76,7 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 		)
 	);
 	public static final ArbitraryIntrospector DEFAULT_FALLBACK_INTROSPECTOR =
-		(context) -> ArbitraryIntrospectorResult.EMPTY;
+		(context) -> ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 
 	private JavaTypeArbitraryGenerator javaTypeArbitraryGenerator = new JavaTypeArbitraryGenerator() {
 	};
@@ -178,7 +178,7 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 			this.fallbackIntrospector = AnonymousArbitraryIntrospector.INSTANCE;
 		}
 
-		return new DefaultArbitraryGenerator(
+		return new IntrospectedArbitraryGenerator(
 			new CompositeArbitraryIntrospector(
 				Arrays.asList(
 					new JavaArbitraryIntrospector(javaTypeArbitraryGenerator, javaArbitraryResolver),

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResult.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArbitraryIntrospectorResult.java
@@ -32,10 +32,14 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ArbitraryIntrospectorResult {
-	private static final Object LOCK = new Object();
+	@Deprecated
 	public static final ArbitraryIntrospectorResult EMPTY = new ArbitraryIntrospectorResult(
 		CombinableArbitrary.from(new Object())
 	);
+
+	public static final ArbitraryIntrospectorResult NOT_INTROSPECTED = EMPTY;
+
+	private static final Object LOCK = new Object();
 
 	private final CombinableArbitrary value;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -47,7 +47,7 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -48,7 +48,7 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 		Property property = context.getResolvedProperty();
 		Class<?> type = Types.getActualType(property.getType());
 		if (Modifier.isAbstract(type.getModifiers())) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		Map<ArbitraryProperty, CombinableArbitrary> arbitrariesByArbitraryProperty =

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -60,7 +60,7 @@ public final class BuilderArbitraryIntrospector implements ArbitraryIntrospector
 		Property property = context.getResolvedProperty();
 		Class<?> type = Types.getActualType(property.getType());
 		if (Modifier.isAbstract(type.getModifiers())) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<ArbitraryProperty> childrenProperties = context.getChildren();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
@@ -48,7 +48,7 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 		Property property = context.getResolvedProperty();
 		Class<?> type = Types.getActualType(property.getType());
 		if (Modifier.isAbstract(type.getModifiers())) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		Entry<Constructor<?>, String[]> parameterNamesByConstructor = TypeCache.getParameterNamesByConstructor(type);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
@@ -51,7 +51,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 			}
 		}
 		if (results.isEmpty()) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -46,7 +46,7 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 		Property property = context.getResolvedProperty();
 		Class<?> type = Types.getActualType(property.getType());
 		if (Modifier.isAbstract(type.getModifiers())) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<ArbitraryProperty> childrenProperties = context.getChildren();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaArbitraryIntrospector.java
@@ -64,7 +64,7 @@ public final class JavaArbitraryIntrospector implements ArbitraryIntrospector, M
 		Class<?> type = Types.getActualType(context.getResolvedType());
 		return this.introspector.getOrDefault(
 				type,
-				ctx -> ArbitraryIntrospectorResult.EMPTY
+				ctx -> ArbitraryIntrospectorResult.NOT_INTROSPECTED
 			)
 			.apply(context);
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/JavaTimeArbitraryIntrospector.java
@@ -76,9 +76,9 @@ public final class JavaTimeArbitraryIntrospector implements ArbitraryIntrospecto
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		Class<?> type = Types.getActualType(context.getResolvedType());
 		return this.introspector.getOrDefault(
-			type,
-			ctx -> ArbitraryIntrospectorResult.EMPTY
-		)
+				type,
+				ctx -> ArbitraryIntrospectorResult.NOT_INTROSPECTED
+			)
 			.apply(context);
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ListIntrospector.java
@@ -46,7 +46,7 @@ public final class ListIntrospector implements ArbitraryIntrospector, Matcher {
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<CombinableArbitrary> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryElementIntrospector.java
@@ -46,7 +46,7 @@ public final class MapEntryElementIntrospector implements ArbitraryIntrospector,
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<CombinableArbitrary> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapEntryIntrospector.java
@@ -55,7 +55,7 @@ public final class MapEntryIntrospector implements ArbitraryIntrospector, Matche
 		}
 		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		if (containerInfo == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<CombinableArbitrary> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/MapIntrospector.java
@@ -49,7 +49,7 @@ public final class MapIntrospector implements ArbitraryIntrospector, Matcher {
 		ArbitraryProperty arbitraryProperty = context.getArbitraryProperty();
 		ContainerProperty containerProperty = arbitraryProperty.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<CombinableArbitrary> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/OptionalIntrospector.java
@@ -61,7 +61,7 @@ public final class OptionalIntrospector implements ArbitraryIntrospector, Matche
 		ArbitraryContainerInfo containerInfo = containerProperty.getContainerInfo();
 		List<ArbitraryProperty> children = context.getChildren();
 		if (containerInfo == null || children.size() != 1) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		ArbitraryProperty valueProperty = children.get(0);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/QueueIntrospector.java
@@ -46,7 +46,7 @@ public final class QueueIntrospector implements ArbitraryIntrospector, Matcher {
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/SetIntrospector.java
@@ -50,7 +50,7 @@ public final class SetIntrospector implements ArbitraryIntrospector, Matcher {
 		ArbitraryProperty arbitraryProperty = context.getArbitraryProperty();
 		ContainerProperty containerProperty = arbitraryProperty.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		List<CombinableArbitrary> elementArbitraryList = context.getElementCombinableArbitraryList().stream()

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/StreamIntrospector.java
@@ -56,7 +56,7 @@ public final class StreamIntrospector implements ArbitraryIntrospector, Matcher 
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TypedArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TypedArbitraryIntrospector.java
@@ -18,40 +18,32 @@
 
 package com.navercorp.fixturemonkey.api.introspector;
 
-import java.util.List;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
+import com.navercorp.fixturemonkey.api.property.Property;
 
-@API(since = "0.4.0", status = Status.MAINTAINED)
-public class CompositeArbitraryIntrospector implements ArbitraryIntrospector {
-	private final List<ArbitraryIntrospector> introspectors;
+/**
+ * Introspects specific properties matched by {@link Matcher}.
+ */
+@API(since = "0.6.2", status = Status.EXPERIMENTAL)
+public final class TypedArbitraryIntrospector implements ArbitraryIntrospector, Matcher {
+	private final MatcherOperator<ArbitraryIntrospector> arbitraryIntrospector;
 
-	public CompositeArbitraryIntrospector(List<ArbitraryIntrospector> introspectors) {
-		this.introspectors = introspectors;
+	public TypedArbitraryIntrospector(MatcherOperator<ArbitraryIntrospector> arbitraryIntrospector) {
+		this.arbitraryIntrospector = arbitraryIntrospector;
 	}
 
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
-		for (ArbitraryIntrospector introspector : this.introspectors) {
-			if (introspector instanceof Matcher) {
-				if (((Matcher)introspector).match(context.getResolvedProperty())) {
-					ArbitraryIntrospectorResult result = introspector.introspect(context);
-					if (!ArbitraryIntrospectorResult.EMPTY.equals(result)) {
-						return result;
-					}
-				}
-			} else {
-				ArbitraryIntrospectorResult result = introspector.introspect(context);
-				if (!ArbitraryIntrospectorResult.EMPTY.equals(result)) {
-					return result;
-				}
-			}
-		}
+		return arbitraryIntrospector.getOperator().introspect(context);
+	}
 
-		return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
+	@Override
+	public boolean match(Property property) {
+		return arbitraryIntrospector.match(property);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -23,12 +23,14 @@ import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerat
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.DEFAULT_NULL_INJECT;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -41,17 +43,20 @@ import com.navercorp.fixturemonkey.api.container.DefaultDecomposedContainerValue
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.generator.CompositeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.DefaultArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
+import com.navercorp.fixturemonkey.api.generator.IntrospectedArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.JavaDefaultArbitraryGeneratorBuilder;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeArbitraryResolver;
 import com.navercorp.fixturemonkey.api.introspector.JavaTimeTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import com.navercorp.fixturemonkey.api.introspector.TypedArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.Plugin;
@@ -77,11 +82,13 @@ public final class FixtureMonkeyOptionsBuilder {
 	private NullInjectGenerator defaultNullInjectGenerator;
 	private List<MatcherOperator<ArbitraryContainerInfoGenerator>> arbitraryContainerInfoGenerators = new ArrayList<>();
 	private ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator;
+	@Deprecated
 	private List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators = new ArrayList<>();
 	private ArbitraryGenerator defaultArbitraryGenerator;
-
+	private UnaryOperator<ArbitraryGenerator> defaultArbitraryGeneratorOperator = it -> it;
+	private final List<MatcherOperator<ArbitraryIntrospector>> arbitraryIntrospectors = new ArrayList<>();
 	private final JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
-		DefaultArbitraryGenerator.javaBuilder();
+		IntrospectedArbitraryGenerator.javaBuilder();
 	private boolean defaultNotNull = false;
 	private boolean nullableContainer = false;
 	private boolean nullableElement = false;
@@ -327,6 +334,7 @@ public final class FixtureMonkeyOptionsBuilder {
 		return this;
 	}
 
+	@Deprecated
 	public FixtureMonkeyOptionsBuilder arbitraryGenerators(
 		List<MatcherOperator<ArbitraryGenerator>> arbitraryGenerators
 	) {
@@ -334,6 +342,7 @@ public final class FixtureMonkeyOptionsBuilder {
 		return this;
 	}
 
+	@Deprecated
 	public FixtureMonkeyOptionsBuilder insertFirstArbitraryGenerator(
 		MatcherOperator<ArbitraryGenerator> arbitraryGenerator
 	) {
@@ -342,6 +351,7 @@ public final class FixtureMonkeyOptionsBuilder {
 		return this.arbitraryGenerators(result);
 	}
 
+	@Deprecated
 	public FixtureMonkeyOptionsBuilder insertFirstArbitraryGenerator(
 		Matcher matcher,
 		ArbitraryGenerator arbitraryGenerator
@@ -351,6 +361,7 @@ public final class FixtureMonkeyOptionsBuilder {
 		);
 	}
 
+	@Deprecated
 	public FixtureMonkeyOptionsBuilder insertFirstArbitraryGenerator(
 		Class<?> type,
 		ArbitraryGenerator arbitraryGenerator
@@ -363,19 +374,19 @@ public final class FixtureMonkeyOptionsBuilder {
 	public FixtureMonkeyOptionsBuilder insertFirstArbitraryIntrospector(
 		MatcherOperator<ArbitraryIntrospector> arbitraryIntrospector
 	) {
-		return this.insertFirstArbitraryIntrospector(
-			arbitraryIntrospector.getMatcher(),
-			arbitraryIntrospector.getOperator()
-		);
+		this.arbitraryIntrospectors.add(arbitraryIntrospector);
+		return this;
 	}
 
 	public FixtureMonkeyOptionsBuilder insertFirstArbitraryIntrospector(
 		Matcher matcher,
 		ArbitraryIntrospector arbitraryIntrospector
 	) {
-		return this.insertFirstArbitraryGenerator(
-			matcher,
-			new DefaultArbitraryGenerator(arbitraryIntrospector)
+		return this.insertFirstArbitraryIntrospector(
+			new MatcherOperator<>(
+				matcher,
+				arbitraryIntrospector
+			)
 		);
 	}
 
@@ -383,13 +394,20 @@ public final class FixtureMonkeyOptionsBuilder {
 		Class<?> type,
 		ArbitraryIntrospector arbitraryIntrospector
 	) {
-		return this.insertFirstArbitraryGenerator(
-			MatcherOperator.assignableTypeMatchOperator(type, new DefaultArbitraryGenerator(arbitraryIntrospector))
+		return this.insertFirstArbitraryIntrospector(
+			MatcherOperator.assignableTypeMatchOperator(type, arbitraryIntrospector)
 		);
 	}
 
 	public FixtureMonkeyOptionsBuilder defaultArbitraryGenerator(ArbitraryGenerator defaultArbitraryGenerator) {
 		this.defaultArbitraryGenerator = defaultArbitraryGenerator;
+		return this;
+	}
+
+	public FixtureMonkeyOptionsBuilder defaultArbitraryGenerator(
+		UnaryOperator<ArbitraryGenerator> defaultArbitraryGeneratorOperator
+	) {
+		this.defaultArbitraryGeneratorOperator = defaultArbitraryGeneratorOperator;
 		return this;
 	}
 
@@ -522,23 +540,36 @@ public final class FixtureMonkeyOptionsBuilder {
 		ArbitraryGenerator defaultArbitraryGenerator =
 			defaultIfNull(this.defaultArbitraryGenerator, this.javaDefaultArbitraryGeneratorBuilder::build);
 
-		DecomposedContainerValueFactory decomposedContainerValueFactory = new DefaultDecomposedContainerValueFactory(
-				obj -> {
-					Class<?> actualType = obj.getClass();
-					for (
-						Map.Entry<Class<?>, DecomposedContainerValueFactory> entry :
-						this.decomposableContainerFactoryMap.entrySet()
-					) {
-						Class<?> type = entry.getKey();
-						DecomposableJavaContainer decomposedValue = entry.getValue().from(obj);
+		List<ArbitraryIntrospector> typedArbitraryIntrospectors = arbitraryIntrospectors.stream()
+			.map(TypedArbitraryIntrospector::new)
+			.collect(Collectors.toList());
 
-						if (actualType.isAssignableFrom(type)) {
-							return decomposedValue;
-						}
-					}
-					return this.decomposedContainerValueFactory.from(obj);
-				}
+		ArbitraryGenerator introspectedGenerator =
+			new IntrospectedArbitraryGenerator(new CompositeArbitraryIntrospector(typedArbitraryIntrospectors));
+
+		defaultArbitraryGenerator = new CompositeArbitraryGenerator(
+			Arrays.asList(introspectedGenerator, defaultArbitraryGenerator)
 		);
+
+		DecomposedContainerValueFactory decomposedContainerValueFactory = new DefaultDecomposedContainerValueFactory(
+			obj -> {
+				Class<?> actualType = obj.getClass();
+				for (
+					Map.Entry<Class<?>, DecomposedContainerValueFactory> entry :
+					this.decomposableContainerFactoryMap.entrySet()
+				) {
+					Class<?> type = entry.getKey();
+					DecomposableJavaContainer decomposedValue = entry.getValue().from(obj);
+
+					if (actualType.isAssignableFrom(type)) {
+						return decomposedValue;
+					}
+				}
+				return this.decomposedContainerValueFactory.from(obj);
+			}
+		);
+
+		defaultArbitraryGenerator = defaultArbitraryGeneratorOperator.apply(defaultArbitraryGenerator);
 
 		return new FixtureMonkeyOptions(
 			this.propertyGenerators,

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JsonNodeIntrospector.java
@@ -53,7 +53,7 @@ public final class JsonNodeIntrospector implements ArbitraryIntrospector {
 		ArbitraryProperty property = context.getArbitraryProperty();
 		ContainerProperty containerProperty = property.getContainerProperty();
 		if (containerProperty == null || containerProperty.getContainerInfo() == null) {
-			return ArbitraryIntrospectorResult.EMPTY;
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PairIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PairIntrospector.kt
@@ -40,11 +40,11 @@ class PairIntrospector : ArbitraryIntrospector, Matcher {
         val property = context.arbitraryProperty
         val containerProperty = property.containerProperty
             ?: throw IllegalArgumentException(
-                "container property should not null. type: ${property.objectProperty.property.name}"
+                "container property should not null. type: ${property.objectProperty.property.name}",
             )
 
         if (containerProperty.containerInfo == null) {
-            return ArbitraryIntrospectorResult.EMPTY
+            return ArbitraryIntrospectorResult.NOT_INTROSPECTED
         }
 
         val elementCombinableArbitraryList = context.elementCombinableArbitraryList
@@ -56,7 +56,7 @@ class PairIntrospector : ArbitraryIntrospector, Matcher {
         return ArbitraryIntrospectorResult(
             CombinableArbitrary.containerBuilder()
                 .elements(elementCombinableArbitraryList)
-                .build { Pair(it[0], it[1]) }
+                .build { Pair(it[0], it[1]) },
         )
     }
 }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -43,7 +43,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
     override fun introspect(context: ArbitraryGeneratorContext): ArbitraryIntrospectorResult {
         val type = Types.getActualType(context.resolvedType)
         if (Modifier.isAbstract(type.modifiers)) {
-            return ArbitraryIntrospectorResult.EMPTY
+            return ArbitraryIntrospectorResult.NOT_INTROSPECTED
         }
 
         val kotlinClass = Reflection.createKotlinClass(type) as KClass<*>

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/TripleIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/TripleIntrospector.kt
@@ -22,11 +22,11 @@ class TripleIntrospector : ArbitraryIntrospector, Matcher {
         val property = context.arbitraryProperty
         val containerProperty = property.containerProperty
             ?: throw IllegalArgumentException(
-                "container property should not null. type: ${property.objectProperty.property.name}"
+                "container property should not null. type: ${property.objectProperty.property.name}",
             )
 
         if (containerProperty.containerInfo == null) {
-            return ArbitraryIntrospectorResult.EMPTY
+            return ArbitraryIntrospectorResult.NOT_INTROSPECTED
         }
 
         val elementCombinableArbitraryList = context.elementCombinableArbitraryList
@@ -38,7 +38,7 @@ class TripleIntrospector : ArbitraryIntrospector, Matcher {
         return ArbitraryIntrospectorResult(
             CombinableArbitrary.containerBuilder()
                 .elements(elementCombinableArbitraryList)
-                .build { Triple(it[0], it[1], it[2]) }
+                .build { Triple(it[0], it[1], it[2]) },
         )
     }
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -32,6 +33,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.container.DecomposedContainerValueFactory;
 import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
@@ -485,6 +487,13 @@ public class FixtureMonkeyBuilder {
 	public FixtureMonkeyBuilder useExpressionStrictMode() {
 		this.monkeyExpressionFactory = expression ->
 			() -> new ApplyStrictModeResolver(new ArbitraryExpressionFactory().from(expression).toNodeResolver());
+		return this;
+	}
+
+	public FixtureMonkeyBuilder defaultArbitraryGenerator(
+		UnaryOperator<ArbitraryGenerator> arbitraryGeneratorUnaryOperator
+	) {
+		this.fixtureMonkeyOptionsBuilder.defaultArbitraryGenerator(arbitraryGeneratorUnaryOperator);
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsAdditionalTestSpecs.java
@@ -22,7 +22,9 @@ package com.navercorp.fixturemonkey.test;
 import java.beans.ConstructorProperties;
 import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.jqwik.api.Arbitraries;
 
@@ -36,6 +38,7 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.generator.ContainerProperty;
@@ -209,7 +212,7 @@ class FixtureMonkeyOptionsAdditionalTestSpecs {
 			ArbitraryProperty property = context.getArbitraryProperty();
 			ArbitraryContainerInfo containerInfo = property.getContainerProperty().getContainerInfo();
 			if (containerInfo == null) {
-				return ArbitraryIntrospectorResult.EMPTY;
+				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
 
 			List<CombinableArbitrary> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();
@@ -365,5 +368,29 @@ class FixtureMonkeyOptionsAdditionalTestSpecs {
 	@Data
 	public static class GetterInterfaceImplementation2 implements GetterInterface {
 		private String value;
+	}
+
+	public static class UniqueArbitraryGenerator implements ArbitraryGenerator {
+		private static final Set<Object> UNIQUE = new HashSet<>();
+
+		private final ArbitraryGenerator delegate;
+
+		public UniqueArbitraryGenerator(ArbitraryGenerator delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
+			return delegate.generate(context)
+				.filter(
+					obj -> {
+						if (!UNIQUE.contains(obj)) {
+							UNIQUE.add(obj);
+							return true;
+						}
+						return false;
+					}
+				);
+		}
 	}
 }

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.test;
 
+import static com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary.NOT_GENERATED;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.ALWAYS_NULL_INJECT;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
@@ -45,14 +46,17 @@ import net.jqwik.time.api.arbitraries.InstantArbitrary;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.arbitrary.MonkeyStringArbitrary;
 import com.navercorp.fixturemonkey.api.container.DecomposableJavaContainer;
 import com.navercorp.fixturemonkey.api.exception.FilterMissException;
 import com.navercorp.fixturemonkey.api.exception.ValidationFailedException;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.CompositeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator;
 import com.navercorp.fixturemonkey.api.generator.DefaultObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.IntrospectedArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
@@ -95,6 +99,7 @@ import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.SelfRecursiveAbstractValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.SelfRecursiveImplementationValue;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.SimpleObjectChild;
+import com.navercorp.fixturemonkey.test.FixtureMonkeyOptionsAdditionalTestSpecs.UniqueArbitraryGenerator;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.ComplexObject;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.Interface;
 import com.navercorp.fixturemonkey.test.FixtureMonkeyTestSpecs.InterfaceFieldImplementationValue;
@@ -1472,5 +1477,70 @@ class FixtureMonkeyOptionsTest {
 		String actual = sut.giveMeOne(String.class);
 
 		then(actual).isUpperCase();
+	}
+
+	@Property
+	void alterDefaultArbitraryGenerator() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultArbitraryGenerator(generator -> new CompositeArbitraryGenerator(
+				Arrays.asList(
+					new IntrospectedArbitraryGenerator(context ->
+						new ArbitraryIntrospectorResult(CombinableArbitrary.from(null))
+					),
+					generator
+				)
+			))
+			.build();
+
+		String actual = sut.giveMeOne(String.class);
+
+		then(actual).isNull();
+	}
+
+	@Property
+	void skipArbitraryGenerator() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultArbitraryGenerator(generator -> new CompositeArbitraryGenerator(
+				Arrays.asList(
+					context -> NOT_GENERATED,
+					generator
+				)
+			))
+			.defaultNotNull(true)
+			.build();
+
+		String actual = sut.giveMeOne(String.class);
+
+		then(actual).isNotNull();
+	}
+
+	@Property
+	void uniqueArbitraryGenerator() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
+			.build();
+
+		List<String> actual = sut.giveMe(String.class, 100);
+
+		Set<String> expected = new HashSet<>(actual);
+		then(actual).hasSameSizeAs(expected);
+	}
+
+	@Property
+	void allArbitraryGeneratorSkipReturnsNull() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.defaultArbitraryGenerator(generator -> (
+				new CompositeArbitraryGenerator(
+					Arrays.asList(
+						context -> NOT_GENERATED,
+						context -> NOT_GENERATED
+					)
+				)
+			))
+			.build();
+
+		String actual = sut.giveMeOne(String.class);
+
+		then(actual).isNull();
 	}
 }


### PR DESCRIPTION
## Summary
Refactor ArbitraryGenerator options

## (Optional): Description
* Adds `defaultArbitraryGenerator` options in `FixtureMonkeyOptions`
* Deprecate `arbitraryGenerators` options.
* clarifies some magic numbers, such as `EMPTY`

## How Has This Been Tested?
* alterDefaultArbitraryGenerator
* skipArbitraryGenerator
* uniqueArbitraryGenerator
