### PR TITLE
Fix generating nested generic type in Jackson

### DIFF
--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArrayArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonArrayArbitraryIntrospector.java
@@ -18,9 +18,12 @@
 
 package com.navercorp.fixturemonkey.jackson.introspector;
 
+import java.lang.reflect.Type;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.ArrayType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -33,6 +36,7 @@ import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+import com.navercorp.fixturemonkey.jackson.type.JacksonTypeReference;
 
 @API(since = "0.5.5", status = Status.MAINTAINED)
 public final class JacksonArrayArbitraryIntrospector implements ArbitraryIntrospector, Matcher {
@@ -52,11 +56,16 @@ public final class JacksonArrayArbitraryIntrospector implements ArbitraryIntrosp
 		return Types.getActualType(property.getType()).isArray();
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		Property property = context.getResolvedProperty();
-		Class<?> elementType = Types.getArrayComponentType(property.getAnnotatedType());
+		TypeFactory typeFactory = TypeFactory.defaultInstance();
+		JavaType elementType = typeFactory.constructType(new JacksonTypeReference<Object>() {
+			@Override
+			public Type getType() {
+				return Types.getArrayComponentAnnotatedType(property.getAnnotatedType()).getType();
+			}
+		});
 
 		ArrayType arrayType = TypeFactory.defaultInstance()
 			.constructArrayType(elementType);

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.jackson.introspector;
 
 import static com.navercorp.fixturemonkey.jackson.property.JacksonAnnotations.getJacksonAnnotation;
 
+import java.lang.reflect.Type;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -36,7 +37,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
@@ -50,6 +53,7 @@ import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyDescriptorProperty;
 import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
+import com.navercorp.fixturemonkey.jackson.type.JacksonTypeReference;
 
 @API(since = "0.5.5", status = Status.MAINTAINED)
 public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntrospector {
@@ -66,7 +70,13 @@ public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntros
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		Property property = context.getResolvedProperty();
-		Class<?> type = Types.getActualType(property.getType());
+		TypeFactory typeFactory = TypeFactory.defaultInstance();
+		JavaType type = typeFactory.constructType(new JacksonTypeReference<Object>() {
+			@Override
+			public Type getType() {
+				return property.getType();
+			}
+		});
 
 		return new ArbitraryIntrospectorResult(
 			new JacksonCombinableArbitrary<>(

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/type/JacksonTypeReference.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/type/JacksonTypeReference.java
@@ -1,0 +1,57 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.jackson.type;
+
+import static com.navercorp.fixturemonkey.api.type.Types.generateAnnotatedTypeWithoutAnnotation;
+
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Type;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.type.Types;
+
+@SuppressWarnings("unused")
+@API(since = "0.6.3", status = Status.MAINTAINED)
+public abstract class JacksonTypeReference<T> extends com.fasterxml.jackson.core.type.TypeReference<T> {
+	private final AnnotatedType annotatedType;
+
+	protected JacksonTypeReference() {
+		AnnotatedType annotatedType = getClass().getAnnotatedSuperclass();
+		this.annotatedType = ((AnnotatedParameterizedType)annotatedType).getAnnotatedActualTypeArguments()[0];
+	}
+
+	protected JacksonTypeReference(Class<T> type) {
+		this.annotatedType = generateAnnotatedTypeWithoutAnnotation(type);
+	}
+
+	public Type getType() {
+		return this.annotatedType.getType();
+	}
+
+	public AnnotatedType getAnnotatedType() {
+		return this.annotatedType;
+	}
+
+	public boolean isGenericType() {
+		return !Types.getGenericsTypes(annotatedType).isEmpty();
+	}
+}


### PR DESCRIPTION
## Summary
Fix generating nested generic type in Jackson

## How Has This Been Tested?
* sampleGenericObject
* sampleListNestedElement
* sampleMapNestedListValue
* sampleGenericArray
