### PR TITLE
Refactor removing annotatedType dependency in PropertyGenerator interface

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
@@ -36,8 +36,7 @@ public final class DefaultObjectPropertyGenerator implements ObjectPropertyGener
 	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
 		Property property = context.getProperty();
 		PropertyGenerator propertyGenerator = context.getFixtureMonkeyOptions().getPropertyGenerator(property);
-		List<Property> childProperties =
-			propertyGenerator.generateChildProperties(property.getAnnotatedType());
+		List<Property> childProperties = propertyGenerator.generateChildProperties(property.getAnnotatedType());
 		double nullInject = context.getFixtureMonkeyOptions().getNullInjectGenerator(property)
 			.generate(context);
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NoArgumentInterfaceJavaMethodPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/NoArgumentInterfaceJavaMethodPropertyGenerator.java
@@ -22,7 +22,6 @@ import static java.util.stream.Collectors.toMap;
 
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -46,10 +45,8 @@ import com.navercorp.fixturemonkey.api.type.Types;
 @API(since = "0.5.5", status = Status.MAINTAINED)
 public final class NoArgumentInterfaceJavaMethodPropertyGenerator implements PropertyGenerator {
 	@Override
-	public List<Property> generateChildProperties(
-		AnnotatedType annotatedType
-	) {
-		Class<?> actualType = Types.getActualType(annotatedType.getType());
+	public List<Property> generateChildProperties(Property property) {
+		Class<?> actualType = Types.getActualType(property.getType());
 		Map<Method, String> propertyNamesByGetter =
 			TypeCache.getPropertyDescriptorsByPropertyName(actualType).values().stream()
 				.collect(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositePropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositePropertyGenerator.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.property;
 
-import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,11 +50,12 @@ public final class CompositePropertyGenerator implements PropertyGenerator {
 		this.propertyGenerators = propertyGenerators;
 	}
 
-	public List<Property> generateChildProperties(AnnotatedType annotatedType) {
+	public List<Property> generateChildProperties(Property property) {
 		Map<String, List<Property>> propertyListsByPropertyName = new HashMap<>();
 
 		for (PropertyGenerator propertyGenerator : propertyGenerators) {
-			List<Property> generatedProperties = propertyGenerator.generateChildProperties(annotatedType).stream()
+			List<Property> generatedProperties = propertyGenerator.generateChildProperties(property.getAnnotatedType())
+				.stream()
 				.filter(it -> it.getName() != null)
 				.collect(Collectors.toList());
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ConstructorParameterPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ConstructorParameterPropertyGenerator.java
@@ -49,8 +49,8 @@ public final class ConstructorParameterPropertyGenerator implements PropertyGene
 	}
 
 	@Override
-	public List<Property> generateChildProperties(AnnotatedType annotatedType) {
-		Class<?> clazz = Types.getActualType(annotatedType.getType());
+	public List<Property> generateChildProperties(Property property) {
+		Class<?> clazz = Types.getActualType(property.getType());
 
 		Map<String, Property> constructorPropertiesByName = new HashMap<>();
 		Map.Entry<Constructor<?>, String[]> parameterNamesByConstructor =
@@ -71,7 +71,7 @@ public final class ConstructorParameterPropertyGenerator implements PropertyGene
 			Field field = fieldsByName.get(parameterName);
 			Property fieldProperty = field != null
 				? new FieldProperty(
-				Types.resolveWithTypeReferenceGenerics(annotatedType, field.getAnnotatedType()),
+				Types.resolveWithTypeReferenceGenerics(property.getAnnotatedType(), field.getAnnotatedType()),
 				field
 			)
 				: null;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/DefaultPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/DefaultPropertyGenerator.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.property;
 
-import java.lang.reflect.AnnotatedType;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,7 +38,7 @@ public final class DefaultPropertyGenerator implements PropertyGenerator {
 			)
 		);
 
-	public List<Property> generateChildProperties(AnnotatedType annotatedType) {
-		return COMPOSITE_PROPERTY_GENERATOR.generateChildProperties(annotatedType);
+	public List<Property> generateChildProperties(Property property) {
+		return COMPOSITE_PROPERTY_GENERATOR.generateChildProperties(property.getAnnotatedType());
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/FieldPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/FieldPropertyGenerator.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.property;
 
-import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.function.Predicate;
@@ -45,11 +44,11 @@ public final class FieldPropertyGenerator implements PropertyGenerator {
 	}
 
 	@Override
-	public List<Property> generateChildProperties(AnnotatedType annotatedType) {
-		return TypeCache.getFieldsByName(Types.getActualType(annotatedType.getType())).values().stream()
+	public List<Property> generateChildProperties(Property property) {
+		return TypeCache.getFieldsByName(Types.getActualType(property.getType())).values().stream()
 			.filter(fieldPredicate)
 			.map(field -> new FieldProperty(
-				Types.resolveWithTypeReferenceGenerics(annotatedType, field.getAnnotatedType()),
+				Types.resolveWithTypeReferenceGenerics(property.getAnnotatedType(), field.getAnnotatedType()),
 				field
 			))
 			.filter(matcher::match)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/JavaBeansPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/JavaBeansPropertyGenerator.java
@@ -19,7 +19,6 @@
 package com.navercorp.fixturemonkey.api.property;
 
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.AnnotatedType;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -48,8 +47,8 @@ public final class JavaBeansPropertyGenerator implements PropertyGenerator {
 	}
 
 	@Override
-	public List<Property> generateChildProperties(AnnotatedType annotatedType) {
-		return TypeCache.getPropertyDescriptorsByPropertyName(Types.getActualType(annotatedType.getType())).values()
+	public List<Property> generateChildProperties(Property property) {
+		return TypeCache.getPropertyDescriptorsByPropertyName(Types.getActualType(property.getType())).values()
 			.stream()
 			.filter(it -> it.getReadMethod() != null)
 			.filter(propertyDescriptorPredicate)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyGenerator.java
@@ -25,12 +25,17 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 /**
- * It generates child properties of the given {@link java.lang.reflect.AnnotatedType}.
+ * It generates child properties of the given {@link Property}.
  * Property could be field or JavaBeans property or method or constructor parameter.
  * It should generate properties whose name is unique.
  */
 @API(since = "0.5.3", status = Status.MAINTAINED)
 @FunctionalInterface
 public interface PropertyGenerator {
-	List<Property> generateChildProperties(AnnotatedType annotatedType);
+	List<Property> generateChildProperties(Property property);
+
+	@Deprecated
+	default List<Property> generateChildProperties(AnnotatedType annotatedType) {
+		return generateChildProperties(new RootProperty(annotatedType));
+	}
 }

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/generator/ArbitraryPropertyTest.java
@@ -64,7 +64,7 @@ class ArbitraryPropertyTest {
 		};
 
 		Optional<Property> property = DEFAULT_PROPERTY_GENERATOR.generateChildProperties(
-				typeReference.getAnnotatedType()
+				new RootProperty(typeReference.getAnnotatedType())
 			)
 			.stream()
 			.filter(it -> "name".equals(it.getName()))

--- a/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyExpressionGeneratorTest.java
+++ b/fixture-monkey-jackson/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyExpressionGeneratorTest.java
@@ -30,6 +30,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator;
 import com.navercorp.fixturemonkey.api.property.DefaultPropertyGenerator;
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
+import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
 
@@ -47,7 +48,7 @@ public class FixtureMonkeyExpressionGeneratorTest {
 		};
 		ExpressionGenerator expressionGenerator = resolver -> {
 			com.navercorp.fixturemonkey.api.property.Property property =
-				DEFAULT_PROPERTY_GENERATOR.generateChildProperties(typeReference.getAnnotatedType())
+				DEFAULT_PROPERTY_GENERATOR.generateChildProperties(new RootProperty(typeReference.getAnnotatedType()))
 					.stream()
 					.filter(it -> "value".equals(it.getName()))
 					.findFirst()

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/InterfaceKFunctionPropertyGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/InterfaceKFunctionPropertyGenerator.kt
@@ -28,7 +28,6 @@ import com.navercorp.fixturemonkey.kotlin.type.getPropertyName
 import net.jqwik.kotlin.internal.isKotlinClass
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
-import java.lang.reflect.AnnotatedType
 import kotlin.reflect.KParameter.Kind.INSTANCE
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
@@ -41,8 +40,8 @@ import kotlin.reflect.jvm.javaType
  */
 @API(since = "0.5.5", status = Status.MAINTAINED)
 class InterfaceKFunctionPropertyGenerator : PropertyGenerator {
-    override fun generateChildProperties(annotatedType: AnnotatedType): List<Property> {
-        val type = Types.getActualType(annotatedType.type)
+    override fun generateChildProperties(property: Property): List<Property> {
+        val type = Types.getActualType(property.type)
 
         if (type.isKotlinClass()) {
             val methods = type.kotlin.memberFunctions
@@ -70,7 +69,7 @@ class InterfaceKFunctionPropertyGenerator : PropertyGenerator {
             return methods + properties
         }
 
-        return JAVA_METHOD_PROPERTY_GENERATOR.generateChildProperties(annotatedType)
+        return JAVA_METHOD_PROPERTY_GENERATOR.generateChildProperties(property.annotatedType)
     }
 
     companion object {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyCache.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyCache.kt
@@ -23,18 +23,17 @@ import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.type.Types
 import com.navercorp.fixturemonkey.kotlin.type.getAnnotatedType
 import org.apiguardian.api.API
-import java.lang.reflect.AnnotatedType
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.memberProperties
 
 private val KPROPERTY_ANNOTATED_TYPE_MAP = ConcurrentLruCache<Class<*>, Collection<KProperty<*>>>(2048)
 
 @API(since = "0.4.0", status = API.Status.MAINTAINED)
-fun getMemberProperties(annotatedType: AnnotatedType): List<Property> {
-    val actualType = Types.getActualType(annotatedType.type)
+fun getMemberProperties(property: Property): List<Property> {
+    val actualType = Types.getActualType(property.type)
     return getKotlinMemberProperties(actualType)
         .map {
-            val propertyAnnotatedType = getAnnotatedType(annotatedType, it)
+            val propertyAnnotatedType = getAnnotatedType(property.annotatedType, it)
             KPropertyProperty(propertyAnnotatedType, it)
         }
 }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyGenerator.kt
@@ -25,7 +25,6 @@ import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
-import java.lang.reflect.AnnotatedType
 import java.lang.reflect.ParameterizedType
 
 /**
@@ -37,14 +36,14 @@ import java.lang.reflect.ParameterizedType
 class KotlinPropertyGenerator(
     private val javaDelegatePropertyGenerator: PropertyGenerator = DefaultPropertyGenerator(),
 ) : PropertyGenerator {
-    private val objectChildPropertiesCache = ConcurrentLruCache<AnnotatedType, List<Property>>(2048)
+    private val objectChildPropertiesCache = ConcurrentLruCache<Property, List<Property>>(2048)
 
-    override fun generateChildProperties(annotatedType: AnnotatedType): List<Property> =
-        objectChildPropertiesCache.computeIfAbsent(annotatedType) {
-            val javaProperties = javaDelegatePropertyGenerator.generateChildProperties(annotatedType)
+    override fun generateChildProperties(property: Property): List<Property> =
+        objectChildPropertiesCache.computeIfAbsent(property) {
+            val javaProperties = javaDelegatePropertyGenerator.generateChildProperties(property.annotatedType)
                 .filter { it.name != null }
                 .associateBy { it.name!! }
-            val kotlinProperties = getMemberProperties(annotatedType)
+            val kotlinProperties = getMemberProperties(property)
                 .filter { it.type !is ParameterizedType }
                 .filter { it.name != null }
                 .associateBy { it.name!! }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyCacheTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinPropertyCacheTest.kt
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.kotlin.property
 
+import com.navercorp.fixturemonkey.api.property.RootProperty
 import com.navercorp.fixturemonkey.api.type.TypeReference
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
@@ -32,7 +33,7 @@ class KotlinPropertyCacheTest {
         val typeReference = object : TypeReference<SampleValue>() {}
 
         // when
-        val actual = getMemberProperties(typeReference.annotatedType)
+        val actual = getMemberProperties(RootProperty(typeReference.annotatedType))
 
         then(actual).hasSize(1)
         then(actual[0].type).isEqualTo(String::class.java)
@@ -48,7 +49,7 @@ class KotlinPropertyCacheTest {
         val typeReference = object : TypeReference<GenericSample<String>>() {}
 
         // when
-        val actual = getMemberProperties(typeReference.annotatedType)
+        val actual = getMemberProperties(RootProperty(typeReference.annotatedType))
 
         then(actual).hasSize(6)
         val sorted = actual.sortedBy { it.name }
@@ -99,16 +100,16 @@ data class GenericSample<T>(
     val name: T,
     val test: SampleValue,
     val list: List<T>,
-    val samples: List<SampleValue>
+    val samples: List<SampleValue>,
 ) {
     var property: Instant? = null
 }
 
 data class GenericSample2<T>(
-    val name: T
+    val name: T,
 )
 
 data class SampleValue(
     @field:Nullable
-    val name: String?
+    val name: String?,
 )


### PR DESCRIPTION
## Summary
Refactor removing annotatedType dependency in PropertyGenerator interface

## (Optional): Description
Remove direct dependency with `AnnotatedType`
