### PR TITLE
Add Generating Objects Section & Plugins Section

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -33,6 +33,18 @@ weight = 50
 identifier = "fixture-monkey-options"
 url = "/docs/fixture-monkey-options/"
 
+[[docs]]
+name = "Plugins"
+weight = 60
+identifier = "plugins"
+url = "/docs/plugins/"
+
+[[docs]]
+name = "IntelliJ Plugin"
+weight = 70
+identifier = "intellij-plugin"
+url = "/docs/intellij-plugin/"
+
 [[main]]
 name = "Release Notes"
 weight = 20

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,6 +8,7 @@ description = ""
 
 ## Documentation
 docsVersion = "0.6.0"
+fixtureMonkeyVersion = "0.6.6"
 
 ## Open Graph
 images = ["doks.png"]

--- a/content/en/docs/customizing-objects/apis.md
+++ b/content/en/docs/customizing-objects/apis.md
@@ -13,7 +13,7 @@ Fixture Monkey offers a range of APIs within the ArbitraryBuilder class that ena
 ### set()
 The `set()` method is used to assign values to one or more properties referenced by the expression.
 
-Different types, including `Supplier`, [`Arbitrary`](../arbitrary), `ArbitraryBuilder`, `NOT_NULL`, or `NULL`, can be used as the value.
+Different types, including `Supplier`, [`Arbitrary`](../arbitrary), `ArbitraryBuilder`, `NOT_NULL`, `NULL`, or `Just` can be used as the value.
 Additionally, a certain instance of an object can also be used as the value.
 
 {{< tabpane persist=false >}}
@@ -31,6 +31,20 @@ fixtureMonkey.giveMeBuilder<Product>()
 {{< /tab >}}
 {{< /tabpane>}}
 
+##### Just
+> Using an instance wrapped by `Just` when using `set()` makes you set the value directly instead of decomposing.
+> Normally, when you `set()` a property in `ArbitraryBuilder` it does not use an instance of the given value, it does a deep copy instead.
+> So, if you need to set with an instance, you can use `Values.just(instance)`
+> This feature can be useful in cases where you need to set a property to a mock instance when using a mocking framework.
+
+> Note that you cannot set a child property after setting with `Just`.
+```java
+Product product = fixture.giveMeBuilder(Product.class)
+	 * 		.set("options", Values.just(List.of("red", "medium", "adult"))
+	 * 		.set("options[0]", "blue")
+	 * 		.sample();
+```
+> For example, the product instance created above, will not have the value "blue" for the first element of options. It will remain the list given with `Just`.
 
 ### size(), minSize(), maxSize()
 The `size()` method lets you specify the size of container properties.

--- a/content/en/docs/customizing-objects/expressions.md
+++ b/content/en/docs/customizing-objects/expressions.md
@@ -13,7 +13,7 @@ Let's consider an example object structure:
 
 ```java
 @Value
-public class Example {
+public class JavaClass {
     String field;
 
     List<String> list;
@@ -21,11 +21,11 @@ public class Example {
     Nested object;
 
     List<Nested> objectList;
-}
 
-@Value
-public class Nested {
-    String nestedField;
+    @Value
+    public static class Nested {
+        String nestedField;
+    }
 }
 ```
 

--- a/content/en/docs/fixture-monkey-options/options.md
+++ b/content/en/docs/fixture-monkey-options/options.md
@@ -1,0 +1,9 @@
+---
+title: "Options"
+images: []
+menu:
+docs:
+parent: "fixture-monkey-options"
+identifier: "options"
+weight: 10
+---

--- a/content/en/docs/generating-objects/fixture-monkey.md
+++ b/content/en/docs/generating-objects/fixture-monkey.md
@@ -1,0 +1,207 @@
+---
+title: "FixtureMonkey"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "fixturemonkey"
+weight: 10
+---
+
+To generate test fixtures, the first step is to create a `FixtureMonkey` instance, which facilitates the creation of test fixtures.
+
+You can use the `create()` method to generate a `FixtureMonkey` instance with default options.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.create();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.create()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+If you want to add some options for creating or customizing the test fixtures, you can add them using the FixtureMonkey builder.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    + options...
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+    + options...
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For information on what options are available, see the [Fixture Monkey Options section](../../fixture-monkey-options/options).
+
+## Generating instances
+
+The `FixtureMonkey` class provides several methods to help create test objects of the required type.
+
+
+### giveMeOne()
+If you need an instance of a certain type, you can use `giveMeOne()`. Pass either a class or a type reference.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = fixtureMonkey.giveMeOne(Product.class);
+
+List<String> strList = fixtureMonkey.giveMeOne(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product: Product = fixtureMonkey.giveMeOne()
+
+val strList: List<String> = fixtureMonkey.giveMeOne()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### giveMe()
+If you need multiple instances of a certain type, you can use the `giveMe()` method.
+You can choose to generate either a stream of instances or a list by specifying the desired size.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Stream<Product> productStream = fixtureMonkey.giveMe(Product.class);
+
+Stream<List<String>> strListStream = fixtureMonkey.giveMe(new TypeReference<List<String>>() {});
+
+List<Product> productList = fixtureMonkey.giveMe(Product.class, 3);
+
+List<List<String>> strListList = fixtureMonkey.giveMe(new TypeReference<List<String>>() {}, 3);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productSequence: Sequence<Product> = fixtureMonkey.giveMe()
+
+val strListSequence: Sequence<List<String>> = fixtureMonkey.giveMe()
+
+val productList: List<Product> = fixtureMonkey.giveMe(3)
+
+val strListList: List<List<String>> = fixtureMonkey.giveMe(3)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeBuilder()
+If you need to further customize the instance to be created, you can use `giveMeBuilder()`. This will return an `ArbitraryBuilder` of the given type.
+An `ArbitraryBuilder` is a class in Fixture Monkey that acts as a builder for an [`Arbitrary`](../arbitrary) object of the given class.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+ArbitraryBuilder<List<String>> strListBuilder = fixtureMonkey.giveMeBuilder(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val strListBuilder: ArbitraryBuilder<List<String>> = fixtureMonkey.giveMeBuilder()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For cases where you already have a generated instance and want to customize it further, you can also use `giveMeBuilder()`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = new Product(1L, "Book", ...);
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(product);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product = Product(1L, "Book", ...)
+
+ArbitraryBuilder<Product> productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder(product)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+The generated `ArbitraryBuilder` can be used for further customization of your fixture. For more information on customization options, see the [section on customization objects](../../customizing-objects/apis).
+
+To obtain an instance from the `ArbitraryBuilder`, you can use the `sample()`, `sampleList()`, `sampleStream()` methods of the `ArbitraryBuilder`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Product product = productBuilder.sample();
+List<Product> productList = productBuilder.sampleList(3);
+Stream<Product> productStream = productBuilder.sampleStream();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val product = productBuilder.sample()
+val productList = productBuilder.sampleList(3)
+val productStream = productBuilder.sampleStream()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+In cases where you need an `Arbitrary` itself rather than an instance, you can simply call the `build()` method.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Arbitrary<Product> productArbitrary = productBuilder.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val productArbitrary = productBuilder.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeArbitrary()
+To get an `Arbitrary` of the specified type, you can use the `giveMeArbitrary()` method.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Arbitrary<Product> productArbitrary = fixtureMonkey.giveMeArbitrary(Product.class);
+
+Arbitrary<List<String>> strListArbitrary = fixtureMonkey.giveMeArbitrary(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productArbitrary: Arbitrary<Product> = fixtureMonkey.giveMeArbitrary()
+
+val strListArbitrary: Arbitrary<List<String>> =fixtureMonkey.giveMeArbitrary()
+
+{{< /tab >}}
+{{< /tabpane>}}
+

--- a/content/en/docs/generating-objects/fixture-monkey.md
+++ b/content/en/docs/generating-objects/fixture-monkey.md
@@ -11,6 +11,7 @@ weight: 10
 To generate test fixtures, the first step is to create a `FixtureMonkey` instance, which facilitates the creation of test fixtures.
 
 You can use the `create()` method to generate a `FixtureMonkey` instance with default options.
+For Kotlin environments, add the Kotlin plugin.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -20,7 +21,9 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.create();
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
-val fixtureMonkey = FixtureMonkey.create()
+val fixtureMonkey = FixtureMonkey
+  .plugin(KotlinPlugin())
+  .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -136,7 +139,7 @@ ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(product);
 
 val product = Product(1L, "Book", ...)
 
-ArbitraryBuilder<Product> productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder(product)
+val productBuilder = fixtureMonkey.giveMeBuilder(product)
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -200,7 +203,7 @@ Arbitrary<List<String>> strListArbitrary = fixtureMonkey.giveMeArbitrary(new Typ
 
 val productArbitrary: Arbitrary<Product> = fixtureMonkey.giveMeArbitrary()
 
-val strListArbitrary: Arbitrary<List<String>> =fixtureMonkey.giveMeArbitrary()
+val strListArbitrary: Arbitrary<List<String>> = fixtureMonkey.giveMeArbitrary()
 
 {{< /tab >}}
 {{< /tabpane>}}

--- a/content/en/docs/generating-objects/introspector.md
+++ b/content/en/docs/generating-objects/introspector.md
@@ -1,0 +1,82 @@
+---
+title: "Introspector"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "introspector"
+weight: 20
+---
+
+There are a number of ways to create an object. For example, you can initialize an instance of an object using its constructor, or you can use its builder.
+Fixture Monkey lets you choose which way you want to create your object by providing different `Introspectors`.
+
+An `Introspector` defines how Fixture Monkey creates objects.
+Each introspector has some kind of restrictions that the class must have in order for the introspector to generate instances of that class.
+
+You can change the introspector you use by using the `objectIntrospector` option of Fixture Monkey.
+
+## BeanArbitraryIntrospector
+The `BeanArbitraryIntrospector` is the default introspector that fixture monkey uses for object creation.
+It creates new instances using reflection and the setter method, so the class it creates must have a no-args constructor and setters.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## ConstructorPropertiesArbitraryIntrospector
+To generate an object with its given constructor, you can use `ConstructorPropertiesArbitraryIntrospector`.
+
+For `ConstructorPropertiesArbitraryIntrospector`, the generated class should have a constructor with `@ConstructorProperties` or the class should be a record type.
+(Or, if you are using Lombok, you can add `lombok.anyConstructor.addConstructorProperties=true` to the lombok.config file.)
+
+When you create a record class and have multiple constructors, the constructor with the `@ConstructorProperties` annotation has priority.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FieldReflectionArbitraryIntrospector
+`FieldReflectionArbitraryIntrospector` creates new instances with reflection and also sets the fields with reflection.
+So the class to be generated must have a no-args constructor and one of the getters or setters.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## BuilderArbitraryIntrospector
+To generate a class using the class's builder, you can use `BuilderArbitraryIntrospector`.
+It requires that the class has a builder.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FailoverArbitraryIntrospector
+Sometimes your production code may contain several classes with different configurations, making it difficult to generate all objects with a single introspector.
+In this case, you can use the `FailoverArbitraryIntrospector`.
+This introspector allows you to use multiple introspectors, and it will continue the introspection even if one of the introspectors fails to generate.
+
+```java
+FixtureMonkey sut = FixtureMonkey.builder()
+    .objectIntrospector(new FailoverIntrospector(
+        Arrays.asList(
+            FieldReflectionArbitraryIntrospector.INSTANCE,
+            ConstructorPropertiesArbitraryIntrospector.INSTANCE
+        )
+    ))
+    .build();
+```
+
+----------------
+
+Additional introspectors have been introduced inside plugins, such as [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector) or
+[`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin)

--- a/content/en/docs/get-started/adding-bean-validation.md
+++ b/content/en/docs/get-started/adding-bean-validation.md
@@ -15,7 +15,7 @@ To enable this feature, you need to add the `fixture-monkey-jakarta-validation` 
 
 ##### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 
 ##### Maven
@@ -23,14 +23,14 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validatio
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-jakarta-validation</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```
 
 Fixture Monkey provides additional features as plugins.
 
-To generate objects based on Bean Validation annotations, you need to add the `JavaxValidationPlugin` (or `JakartaValidationPlugin` if you are using `jakarta.validation.constraints`) option to FixtureMonkey as shown below.
+To generate objects based on Bean Validation annotations, you need to add the `JakartaValidationPlugin` (or `JavaxValidationPlugin` if you are using `javax.validation.constraints`) option to FixtureMonkey as shown below.
 If you've added the fixture-monkey-starter dependency, it's already in place.
 
 ```java

--- a/content/en/docs/get-started/creating-objects-in-kotlin.md
+++ b/content/en/docs/get-started/creating-objects-in-kotlin.md
@@ -15,7 +15,7 @@ Then we can add the Kotlin Plugin, to enable additional features of fixture monk
 
 ```kotlin
 @Test
-void test() {
+fun test() {
   val fixtureMonkey = FixtureMonkey.builder()
       .plugin(KotlinPlugin())
       .build()

--- a/content/en/docs/get-started/creating-objects-in-kotlin.md
+++ b/content/en/docs/get-started/creating-objects-in-kotlin.md
@@ -25,7 +25,7 @@ void test() {
 The Kotlin plugin changes the default `ObjectIntrospector` to `PrimaryConstructorArbitraryIntrospector`,
 which generates Kotlin classes with their primary constructor.
 
-Suppose you have a kotlin class like this:
+Suppose you have a Kotlin class like this:
 
 ```kotlin
 data class Product (

--- a/content/en/docs/get-started/customizing objects.md
+++ b/content/en/docs/get-started/customizing objects.md
@@ -13,15 +13,15 @@ In that case, you can use Fixture Monkey to generate a builder and further custo
 ```java
 @Value
 public class Product {
-    private long id;
+    long id;
 
-    private String productName;
+    String productName;
 
-    private long price;
+    long price;
 
-    private List<String> options;
+    List<String> options;
 
-    private Instant createdAt;
+    Instant createdAt;
 }
 ```
 

--- a/content/en/docs/get-started/requirements.md
+++ b/content/en/docs/get-started/requirements.md
@@ -8,6 +8,8 @@ docs:
 weight: 10
 ---
 
+{{< alert icon="💡" text="Fixture Monkey is designed for test environments. It is not recommended for production use." />}}
+
 ## Prerequisites
 * Java 8 or higher
 * JUnit 5 platform
@@ -23,7 +25,7 @@ weight: 10
 | fixture-monkey-kotlin | Kotlin support |
 | fixture-monkey-starter-kotlin | Starter dependency for fixture monkey kotlin |
 
-**fixture-monkey-starter** is a starter dependency that comes with pre-configured dependencies required to use fixture monkey.
+**fixture-monkey-starter** is a starter dependency that comes with pre-configured dependencies like lombok or fixture-monkey-jakarta-validation to help you get started using Fixture Monkey.
 
 For Kotlin environments, you can use **fixture-monkey-starter-kotlin**
 

--- a/content/en/docs/get-started/requirements.md
+++ b/content/en/docs/get-started/requirements.md
@@ -25,13 +25,13 @@ weight: 10
 | fixture-monkey-kotlin | Kotlin support |
 | fixture-monkey-starter-kotlin | Starter dependency for fixture monkey kotlin |
 
-**fixture-monkey-starter** is a starter dependency that comes with pre-configured dependencies like lombok or fixture-monkey-jakarta-validation to help you get started using Fixture Monkey.
+**fixture-monkey-starter** is a starter dependency that comes with pre-configured dependencies such as fixture-monkey-jakarta-validation to help you get started using Fixture Monkey.
 
 For Kotlin environments, you can use **fixture-monkey-starter-kotlin**
 
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven
@@ -39,7 +39,7 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.2")
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-starter</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/content/en/docs/intellij-plugin/_index.md
+++ b/content/en/docs/intellij-plugin/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Intellij Plugin"
+images: []
+menu:
+docs:
+weight: 70
+---

--- a/content/en/docs/intellij-plugin/fixture-monkey-helper.md
+++ b/content/en/docs/intellij-plugin/fixture-monkey-helper.md
@@ -1,0 +1,31 @@
+---
+title: "Fixture Monkey Helper"
+images: []
+menu:
+docs:
+parent: "intellij-plugin"
+identifier: "fixture-monkey-helper"
+weight: 10
+---
+
+[Fixture Monkey Helper](https://plugins.jetbrains.com/plugin/19589-fixture-monkey-helper) is an IntelliJ plugin that helps to use Fixture Monkey on the IntelliJ IDE.
+
+It provides some features that make using String Expressions and Kotlin DSL Expressions easier, and also add some IntelliJ inspections to detect and fix abnormal code.
+
+### Features
+
+- **Fixture Monkey String Expression support**
+  - Conversion of string expressions to Fixture Monkey Kotlin DSL
+  - Expression validation
+  - Auto completion
+  - Go to target field (reference)
+
+- **FixtureMonkey Kotlin DSL support**
+  - Convert Kotlin DSL to Fixture Monkey string expression
+  - Folding to Fixture Monkey string expression
+  - Generate Kotlin Lambda expression that helps define Fixture specification easily
+  - Convert Lambda to Fixture Monkey Kotlin DSL
+
+- **Inspection**
+  - Change type information passed as method arguments in Fixture Monkey factory methods to generic type arguments
+  - Change generic type arguments to variable types in Fixture Monkey factory methods when possible

--- a/content/en/docs/introduction/overview.md
+++ b/content/en/docs/introduction/overview.md
@@ -46,16 +46,37 @@ This leads to undercovering edge cases that might remain hidden when using stati
 
 ### 4. Versatility
 ```java
+// inheritance
 class Foo {
   String foo;
 }
 
 class Bar extends Foo {
-  String bar;
+    String bar;
 }
 
 Foo foo = FixtureMonkey.create().giveMeOne(Foo.class);
 Bar bar = FixtureMonkey.create().giveMeone(Bar.class);
+
+// circular-reference
+class Foo {
+    String value;
+
+    Foo foo;
+}
+
+Foo foo = FixtureMonkey.create().giveMeOne(Foo.class);
+
+// anonymous objects
+interface Foo {
+    Bar getBar();
+}
+
+class Bar {
+    String value;
+}
+
+Foo foo = FixtureMonkey.create().giveMeOne(Foo.class);
 ```
 
 Fixture Monkey is capable to create any kind of object you can imagine. It supports generating basic objects such as lists, nested collections, enums and generic types.
@@ -64,9 +85,9 @@ It also handles more advanced scenarios, including objects with inheritance rela
 ---------
 
 ## Proven Effectiveness
-Fixture Monkey was originally developed as an in-house library at Naver and played a crucial role in simplifying test object generation for the Plasma project.
+Fixture Monkey was originally developed as an in-house library at [Naver](https://www.navercorp.com/en) and played a crucial role in simplifying test object generation for the Plasma project.
 The Plasma project aimed to revolutionize Naver Pay's architecture, which is the most used mobile payment service in South Korea with a daily active user count of 261,400.
 
-The project required thorough testing of complex business requirements, and with Fixture Monkey's assistance, the team efficiently wrote over 5000 tests, uncovering critical edge cases and ensuring the system's reliability.
+The project required thorough testing of complex business requirements, and with Fixture Monkey's assistance, the team efficiently wrote over 10,000 tests, uncovering critical edge cases and ensuring the system's reliability.
 Now available as an open-source library, developers worldwide can take advantage of Fixture Monkey to simplify their test codes and build robust applications with confidence.
 

--- a/content/en/docs/introduction/overview.md
+++ b/content/en/docs/introduction/overview.md
@@ -45,8 +45,21 @@ Fixture Monkey helps tests become more dynamic by generating test objects with r
 This leads to undercovering edge cases that might remain hidden when using static data.
 
 ### 4. Versatility
+```java
+class Foo {
+  String foo;
+}
+
+class Bar extends Foo {
+  String bar;
+}
+
+Foo foo = FixtureMonkey.create().giveMeOne(Foo.class);
+Bar bar = FixtureMonkey.create().giveMeone(Bar.class);
+```
+
 Fixture Monkey is capable to create any kind of object you can imagine. It supports generating basic objects such as lists, nested collections, enums and generic types.
-It also handles more advanced scenarios, including circular-referenced objects and anonymous objects from interfaces.
+It also handles more advanced scenarios, including objects with inheritance relationships, circular-referenced objects, and anonymous objects that implement interfaces.
 
 ---------
 

--- a/content/en/docs/plugins/_index.md
+++ b/content/en/docs/plugins/_index.md
@@ -3,5 +3,6 @@ title: "Plugins"
 images: []
 menu:
 docs:
+  identifier: "plugins"
 weight: 60
 ---

--- a/content/en/docs/plugins/jackson-plugin/_index.md
+++ b/content/en/docs/plugins/jackson-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Jackson Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "jackson-plugin"
+weight: 40
+---

--- a/content/en/docs/plugins/jackson-plugin/features.md
+++ b/content/en/docs/plugins/jackson-plugin/features.md
@@ -16,7 +16,7 @@ Fixture monkey supports [Jackson](https://github.com/FasterXML/jackson) with the
 ## Dependencies
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jackson:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jackson:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven
@@ -24,7 +24,7 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jackson:0.6.2")
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-jackson</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/content/en/docs/plugins/jackson-plugin/features.md
+++ b/content/en/docs/plugins/jackson-plugin/features.md
@@ -1,0 +1,73 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-plugin-features"
+weight: 10
+---
+
+Fixture monkey supports [Jackson](https://github.com/FasterXML/jackson) with the Fixture Monkey Jackson plugin.
+
+- Supports the use of `JacksonObjectArbitraryIntrospector` as the default introspector to create objects using the Jackson object mapper.
+- Supports Jackson Annotations such as, `@JsonIgnore`, `@JsonProperty`
+
+## Dependencies
+#### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jackson:0.6.2")
+```
+
+#### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-jackson</artifactId>
+  <version>0.6.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+## Plugin
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new JacksonPlugin())
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+    .plugin(JacksonPlugin())
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+Pass the object mapper to the JacksonPlugin constructor if you are using Jackson with a custom object mapper.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+ObjectMapper objectMapper = JsonMapper.builder()
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build()
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new JacksonPlugin(objectMapper))
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+val objectMapper = JsonMapper.builder()
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build()
+
+val fixtureMonkey = FixtureMonkey.builder()
+    .plugin(JacksonPlugin(objectMapper))
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/content/en/docs/plugins/jackson-plugin/jackson-annotations.md
+++ b/content/en/docs/plugins/jackson-plugin/jackson-annotations.md
@@ -22,38 +22,62 @@ The following example shows how @JsonProperty, @JsonIgnore works with Fixture Mo
 ```java
 @Value // lombok getter, setter
 public class Product {
-    private long id;
+    long id;
 
     @JsonProperty("name")
-    private String productName;
+    String productName;
 
-    private long price;
+    long price;
 
     @JsonIgnore
-    private List<String> options;
+    List<String> options;
 
-    private Instant createdAt;
+    Instant createdAt;
 }
 ```
 
-```java
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
 @Test
 void test() {
-// given
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-    .plugin(new JacksonPlugin())
-    .build();
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .plugin(new JacksonPlugin())
+        .build();
 
-// when
-Product actual = fixtureMonkey.giveMeBuilder(Product.class)
-    .set("name", "book")
-    .sample();
+    // when
+    Product actual = fixtureMonkey.giveMeBuilder(Product.class)
+        .set("name", "book")
+        .sample();
 
-// then
-then(actual.getProductName()).isEqualTo("book"); // @JsonProperty
-then(actual.getOptions()).isNull();  // @JsonIgnore
+    // then
+    then(actual.getProductName()).isEqualTo("book"); // @JsonProperty
+    then(actual.getOptions()).isNull(); // @JsonIgnore
 }
-```
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    // given
+    val fixtureMonkey = FixtureMonkey.builder()
+        .plugin(JacksonPlugin())
+        .build()
+
+    // when
+    val actual = fixtureMonkey.giveMeBuilder<Product>()
+        .set("name", "book")
+        .sample()
+
+    // then
+    then(actual.productName).isEqualTo("book") // @JsonProperty
+    then(actual.options).isNull() // @JsonIgnore
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
 
 
 ### @JsonTypeInfo, @JsonSubTypes

--- a/content/en/docs/plugins/jackson-plugin/jackson-annotations.md
+++ b/content/en/docs/plugins/jackson-plugin/jackson-annotations.md
@@ -1,0 +1,62 @@
+---
+title: "Jackson Annotations"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-annotations"
+weight: 30
+---
+
+With the Jackson plugin, some Jackson annotations are also supported.
+
+### @JsonProperty, @JsonIgnore
+
+We can use the property name specified by @JsonProperty when using the String Expression to customize this property.
+
+The property with @JsonIgnore will have a null value when Fixture Monkey generates the object.
+
+The following example shows how @JsonProperty, @JsonIgnore works with Fixture Monkey.
+
+**Example Java Class :**
+```java
+@Value // lombok getter, setter
+public class Product {
+    private long id;
+
+    @JsonProperty("name")
+    private String productName;
+
+    private long price;
+
+    @JsonIgnore
+    private List<String> options;
+
+    private Instant createdAt;
+}
+```
+
+```java
+@Test
+void test() {
+// given
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new JacksonPlugin())
+    .build();
+
+// when
+Product actual = fixtureMonkey.giveMeBuilder(Product.class)
+    .set("name", "book")
+    .sample();
+
+// then
+then(actual.getProductName()).isEqualTo("book"); // @JsonProperty
+then(actual.getOptions()).isNull();  // @JsonIgnore
+}
+```
+
+
+### @JsonTypeInfo, @JsonSubTypes
+Fixture Monkey also supports Jackson's polymorphic type handling annotations `@JsonTypeInfo` and `@JsonSubTypes`.
+
+We can generate an inheritance-implementation relationship object with the help of FixtureMonkey.

--- a/content/en/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
+++ b/content/en/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
@@ -14,17 +14,17 @@ It puts the created properties of the given class into a map and deserializes th
 
 **Example Java Class :**
 ```java
-@Value // lombok getter, setter
+@Value
 public class Product {
-    private long id;
+    long id;
 
-    private String productName;
+    String productName;
 
-    private long price;
+    long price;
 
-    private List<String> options;
+    List<String> options;
 
-    private Instant createdAt;
+    Instant createdAt;
 }
 ```
 
@@ -44,7 +44,7 @@ void test() {
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:{{< fixture-monkey-version >}}")
 testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
 @Test

--- a/content/en/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
+++ b/content/en/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
@@ -1,0 +1,70 @@
+---
+title: "JacksonObjectArbitraryIntrospector"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-object-arbitrary-introspector"
+weight: 20
+---
+
+## JacksonObjectArbitraryIntrospector
+The `JacksonObjectArbitraryIntrospector` becomes the default introspector when the Jackson plugin is added.
+It puts the created properties of the given class into a map and deserializes them using Jackson's object mapper.
+
+**Example Java Class :**
+```java
+@Value // lombok getter, setter
+public class Product {
+    private long id;
+
+    private String productName;
+
+    private long price;
+
+    private List<String> options;
+
+    private Instant createdAt;
+}
+```
+
+**Using JacksonObjectArbitraryIntrospector :**
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .plugin(new JacksonPlugin())
+        .build();
+
+    Product product = fixtureMonkey.giveMeOne(Product.class);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:0.6.2")
+testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+@Test
+fun test() {
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+        .plugin(JacksonPlugin())
+        .build();
+
+    val product: Product = fixtureMonkey.giveMeOne()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+{{< alert icon="💡" text="To generate Kotlin classes with JacksonObjectArbitraryIntrospector, both Kotlin plugin and Jackson plugin need to be added. In addition, fasterxml jackson-module-kotlin should be added to the dependency for serialization/deserialization of Kotlin classes." />}}
+
+It has the advantage of being a general purpose introspector because it relies on the widely used Jackson for object creation.
+If your production code has both Kotlin and Java classes, it is recommended to use `JacksonObjectArbitraryIntrospector`.
+
+However, it does have the disadvantage of potentially not performing as efficiently as other introspectors, as deserialization with Jackson can be more time-consuming.
+
+

--- a/content/en/docs/plugins/jakarta-validation-plugin/_index.md
+++ b/content/en/docs/plugins/jakarta-validation-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Jakarta Validation Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "jakarta-validation-plugin"
+weight: 70
+---

--- a/content/en/docs/plugins/jakarta-validation-plugin/bean-validation.md
+++ b/content/en/docs/plugins/jakarta-validation-plugin/bean-validation.md
@@ -1,0 +1,101 @@
+---
+title: "Bean Validation"
+images: []
+menu:
+docs:
+parent: "jakarta-validation-plugin"
+identifier: "bean-validation"
+weight: 20
+---
+## Generating valid data
+Using the Jakarta Validation plugin, we can generate valid data based on Jakarta Bean validation annotations on properties.
+
+For example, there can be a `Product' class annotated as follows:
+
+```java
+@Value
+public class Product {
+    @Min(1)
+    long id;
+
+    @NotBlank
+    String productName;
+
+    @Max(100000)
+    long price;
+
+    @Size(min = 3)
+    List<@NotBlank String> options;
+
+    @Past
+    Instant createdAt;
+}
+```
+
+An instance of the Product class that is compliant with the annotations can be created in the following manner::
+
+```
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+        .plugin(new JakartaValidationPlugin())
+        .build();
+
+    // when
+    Product actual = fixtureMonkey.giveMeOne(Product.class);
+
+    // then
+    then(actual).isNotNull();
+    then(actual.getId()).isGreaterThan(0);
+    then(actual.getProductName()).isNotBlank();
+    then(actual.getPrice()).isLessThanOrEqualTo(100000);
+    then(actual.getOptions().size()).isGreaterThanOrEqualTo(3);
+    then(actual.getOptions()).allSatisfy(it -> then(it).isNotEmpty());
+    then(actual.getCreatedAt()).isNotNull().isLessThanOrEqualTo(Instant.now());
+}
+```
+
+## Supported Annotations
+
+Every annotation from the `jakarta.validation.constraints` package is supported.
+Different types support different annotation constraints.
+
+### Numeric Type
+Supported Types: `BigDecimal`, `BigInteger`, `byte`, `double`, `float`, `int`, `long`, `short`
+
+- @Digits (fraction is currently not supported)
+- @Max
+- @Min
+- @Negative
+- @NegativeOrZero
+- @DecimalMax
+- @DecimalMin
+- @Positive
+- @PositiveOrZero
+
+### Boolean Type
+- @AssertFalse
+- @AssertTrue
+
+### String Type
+- @Null
+- @NotNull
+- @NotBlank
+- @NotEmpty
+- @Size
+- @Digits
+- @Pattern
+- @Email
+
+### Time Type
+Supported Types: `Calendar`, `Date`, `Instant`, `LocalDate`, `LocalDateTime`, `LocalTime`, `ZonedDateTime`, `Year`, `YearMonth`, `MonthDay`, `OffsetDateTime`, `OffsetTime`
+- @Past
+- @PastOrPresent
+- @Future
+- @FutureOrPresent
+
+### Container Type
+- @Size
+- @NotEmpty

--- a/content/en/docs/plugins/jakarta-validation-plugin/features.md
+++ b/content/en/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture monkey supports generating valid data based on [Jakarta Bean Validation 
 ## Dependencies
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:jakarta-validation-:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven
@@ -23,7 +23,7 @@ testImplementation("com.navercorp.fixturemonkey:jakarta-validation-:0.6.2")
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-jakarta-validation</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/content/en/docs/plugins/jakarta-validation-plugin/features.md
+++ b/content/en/docs/plugins/jakarta-validation-plugin/features.md
@@ -1,0 +1,49 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "jakarta-validation-plugin"
+identifier: "jakarta-validation-plugin-features"
+weight: 10
+---
+
+Fixture monkey supports generating valid data based on [Jakarta Bean Validation 3.0 annotations](https://beanvalidation.org/) with the Fixture Monkey Jakarta Validation Plugin.
+
+{{< alert icon="💡" text="Javax Bean Validation is also supported with the Fixture Monkey Javax Validation Plugin" />}}
+
+## Dependencies
+#### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:jakarta-validation-:0.6.2")
+```
+
+#### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-jakarta-validation</artifactId>
+  <version>0.6.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+The jakarta validation API and the Hibernate validator are already provided as part of the dependency.
+
+## Plugin
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new JakartaValidationPlugin())
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+    .plugin(JakartaValidationPlugin())
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/content/en/docs/plugins/kotlin-plugin/_index.md
+++ b/content/en/docs/plugins/kotlin-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Kotlin Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "kotlin-plugin"
+weight: 10
+---

--- a/content/en/docs/plugins/kotlin-plugin/features.md
+++ b/content/en/docs/plugins/kotlin-plugin/features.md
@@ -17,7 +17,7 @@ To help you take full advantage of the concise, safe, and pragmatic nature of Ko
 ##### fixture-monkey-kotlin
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven
@@ -25,18 +25,18 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:0.6.2")
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-kotlin</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```
 
 ##### fixture-monkey-starter-kotlin
 
-To help you get started using Fixture Monkey in a Kotlin environment, there is also a starter dependency **fixture-monkey-kotlin-starter** that comes with pre-configured dependencies such as lombok or fixture-monkey-jakarta-validation.
+To help you get started using Fixture Monkey in a Kotlin environment, there is also a starter dependency **fixture-monkey-kotlin-starter** that comes with pre-configured dependencies such as **fixture-monkey-starter** or **fixture-monkey-jakarta-validation**.
 
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:0.6.2")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven
@@ -44,25 +44,14 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:0.
 <dependency>
   <groupId>com.navercorp.fixturemonkey</groupId>
   <artifactId>fixture-monkey-starter-kotlin</artifactId>
-  <version>0.6.2</version>
+  <version>{{< fixture-monkey-version >}}</version>
   <scope>test</scope>
 </dependency>
 ```
 
 ## Plugin
-{{< tabpane persist=false >}}
-{{< tab header="Java" lang="java">}}
-
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-    .plugin(new KotlinPlugin())
-    .build();
-
-{{< /tab >}}
-{{< tab header="Kotlin" lang="kotlin">}}
-
+```kotlin
 val fixtureMonkey = FixtureMonkey.builder()
     .plugin(KotlinPlugin())
     .build()
-
-{{< /tab >}}
-{{< /tabpane>}}
+```

--- a/content/en/docs/plugins/kotlin-plugin/features.md
+++ b/content/en/docs/plugins/kotlin-plugin/features.md
@@ -1,0 +1,68 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "kotlin-plugin-features"
+weight: 10
+---
+
+To help you take full advantage of the concise, safe, and pragmatic nature of Kotlin, Fixture Monkey provides a Kotlin plugin.
+- Using `PrimaryConstructorArbitraryIntrospector` as the default introspector to generate Kotlin classes with its primary constructor.
+- Fixture Monkey Extension Functions
+- Kotlin DSL Exp
+
+## Dependencies
+##### fixture-monkey-kotlin
+#### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:0.6.2")
+```
+
+#### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-kotlin</artifactId>
+  <version>0.6.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+##### fixture-monkey-starter-kotlin
+
+To help you get started using Fixture Monkey in a Kotlin environment, there is also a starter dependency **fixture-monkey-kotlin-starter** that comes with pre-configured dependencies such as lombok or fixture-monkey-jakarta-validation.
+
+#### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:0.6.2")
+```
+
+#### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-starter-kotlin</artifactId>
+  <version>0.6.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+## Plugin
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new KotlinPlugin())
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+    .plugin(KotlinPlugin())
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/content/en/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
+++ b/content/en/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
@@ -1,0 +1,43 @@
+---
+title: "Introspectors for Kotlin"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "introspectors-for-kotlin"
+weight: 20
+---
+
+Fixture Monkey provides some additional introspectors that support the generation of Kotlin classes.
+
+## PrimaryConstructorArbitraryIntrospector
+
+The `PrimaryConstructorArbitraryIntrospector` becomes the default introspector when the Kotlin plugin is added.
+It creates a Kotlin class with its primary constructor.
+
+**Example Kotlin Class :**
+```kotlin
+data class Product (
+  val id: Long?,
+
+  val productName: String,
+
+  val price: Long,
+
+  val options: List<String>,
+
+  val createdAt: Instant
+)
+```
+
+**Using PrimaryConstructorArbitraryIntrospector :**
+```kotlin
+@Test
+fun test() {
+  val fixtureMonkey = FixtureMonkey.builder()
+      .plugin(KotlinPlugin())
+      .build()
+
+  val product: Product = fixtureMonkey.giveMeOne()
+}
+```

--- a/content/en/docs/plugins/kotlin-plugin/kotlin-exp.md
+++ b/content/en/docs/plugins/kotlin-plugin/kotlin-exp.md
@@ -1,0 +1,161 @@
+---
+title: "Kotlin DSL Exp"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "kotlin-dsl-exp"
+weight: 30
+---
+
+Fixture Monkey utilizes Kotlin's DSL feature to ensure type-safety with expressions.
+Let's explore how we can employ Kotlin Exp instead of the standard [Java String Expression](../../../customizing-objects/expressions).
+
+### Referencing a property
+
+Suppose we have an object structure similar to the one described earlier, written in both Java and Kotlin:
+
+```java
+@Value
+public class JavaClass {
+    String field;
+
+    List<String> list;
+
+    Nested nestedObject;
+
+    List<Nested> nestedObjectList;
+
+    @Value
+    public static class Nested {
+        String nestedField;
+    }
+}
+```
+
+```kotlin
+data class KotlinClass(
+  val field: String,
+
+  val list: List<String>,
+
+  val nestedObject: Nested,
+
+  val nestedObjectList: List<Nested>
+) {
+  data class Nested(
+    val nestedField: String
+  )
+}
+```
+
+To use Kotlin Exp to reference a property, you need to use the `Exp` or `ExpGetter` suffix to the normal [Fixture Customization APIs]((../../customizing-objects/apis).
+
+Let's look at the example of customizing properties with Kotlin Exp using `setExp()` and `setExpGetter()`.
+
+```kotlin
+@Test
+fun test() {
+    // given
+    val fixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+        .plugin(JacksonPlugin())
+        .build()
+
+    // when
+    val javaClass = fixtureMonkey.giveMeBuilder<JavaClass>()
+        .setExpGetter(JavaClass::getField, "field")
+        .sample()
+
+    val kotlinClass = fixtureMonkey.giveMeBuilder<KotlinClass>()
+        .setExp(KotlinClass::field, "field")
+        .sample()
+
+    // then
+    then(javaClass.field).isEqualTo("field")
+    then(kotlinClass.field).isEqualTo("field")
+}
+```
+
+In the code above, we can see that we are using Kotlin's method reference to select a property.
+
+`setExp()` takes an argument of type `KProperty`, while `setExpGetter()` takes an argument of type `KFunction`.
+
+If the class is defined in Java, the expression (e.g. JavaClass::getField) is of type `KFunction` because it is a reference to a Java getter.
+Therefore you can only use the `setExpGetter()` method.
+
+If it is a Kotlin class, the expression (e.g. KotlinClass::field) is `KProperty`, so you should use `setExp()`.
+
+### Referencing a nested property
+
+To access a nested field, the infix functions `into` and `intoGetter` are used.
+`into` takes a parameter of type `KProperty`, while `intoGetter` takes a parameter of type `KFunction`.
+
+```kotlin
+@Test
+fun test() {
+    // given
+    val fixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+        .plugin(JacksonPlugin())
+        .build()
+
+    // when
+    val javaClass = fixtureMonkey.giveMeBuilder<JavaClass>()
+        .setExp(JavaClass::getNestedObject intoGetter JavaClass.Nested::getNestedField, "nestedField")
+        .sample()
+
+    val kotlinClass = fixtureMonkey.giveMeBuilder<KotlinClass>()
+        .setExp(KotlinClass::nestedObject into KotlinClass.Nested::nestedField, "nestedField")
+        .sample()
+
+    then(javaClass.nestedObject.nestedField).isEqualTo("nestedField")
+    then(kotlinClass.nestedObject.nestedField).isEqualTo("nestedField")
+}
+```
+
+An expression that contains an into or intoGetter operator becomes an `ExpressionGenerator` type in fixture monkey.
+Both `setExp()` and `setExpGetter()`) are defined to take ExpressionGenerator types as arguments, so you can use both.
+
+------------
+
+### Selecting Properties Using Kotlin DSL Expressions
+
+##### Selecting the root object:
+- Currently Not Supported
+
+##### Selecting a specific field:
+```kotlin
+JavaClass::getField // java class
+
+KotlinClass::field // kotlin class
+```
+
+##### Selecting a nested field:
+```kotlin
+JavaClass::getNestedObject intoGetter JavaClass.Nested::getNestedField // java class
+
+KotlinClass::nestedObject into KotlinClass.Nested::nestedField // kotlin class
+```
+
+##### Selecting the n-th element of a collection:
+```kotlin
+JavaClass::getNestedObjectList["0"] // java class
+
+KotlinClass::nestedObjectList["0"] // kotlin class
+```
+
+##### Selecting all elements of a collection:
+```kotlin
+JavaClass::getNestedObjectList["*"] // java class
+
+KotlinClass::nestedObjectList["*"] // kotlin class
+```
+
+##### Combining expressions to select a nested field:
+```java
+JavaClass::getNestedObject intoGetter JavaClass.Nested::getNestedField // java class
+
+KotlinClass::nestedObject into KotlinClass.Nested::nestedField // kotlin class
+```
+

--- a/layouts/shortcodes/fixture-monkey-version.html
+++ b/layouts/shortcodes/fixture-monkey-version.html
@@ -1,0 +1,1 @@
+{{- .Site.Params.fixtureMonkeyVersion -}}


### PR DESCRIPTION
## Summary
Adding Generating Objects Section & Plugins Section for Fixture Monkey documentation version 2.

## (Optional): Description
- Adding generating-objects section
- Adding plugins section (jakarta-validation, kotlin, jackson)
- Adding intellij plugin section

To view the new document in your local environment,
checkout to the branch and run npm install, followed by npm run
