### PR TITLE
Fix Kotlin PrimaryConstructorArbitraryIntrospector generates concurretly

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -46,15 +46,15 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
             return ArbitraryIntrospectorResult.NOT_INTROSPECTED
         }
 
-        val kotlinClass = Reflection.createKotlinClass(type) as KClass<*>
-        val constructor = CONSTRUCTOR_CACHE.computeIfAbsent(type) {
-            requireNotNull(kotlinClass.primaryConstructor) { "No kotlin primary constructor provided for $kotlinClass" }
-        }
-
         return ArbitraryIntrospectorResult(
             CombinableArbitrary.objectBuilder()
                 .properties(context.combinableArbitrariesByArbitraryProperty)
                 .build {
+                    val kotlinClass = Reflection.createKotlinClass(type) as KClass<*>
+                    val constructor = CONSTRUCTOR_CACHE.computeIfAbsent(type) {
+                        requireNotNull(kotlinClass.primaryConstructor) { "No kotlin primary constructor provided for $kotlinClass" }
+                    }
+
                     val arbitrariesByPropertyName = it.mapKeys { map -> map.key.objectProperty.property.name }
 
                     val map = mutableMapOf<KParameter, Any?>()

--- a/fixture-monkey-tests/kotlin-concurrent-tests/build.gradle
+++ b/fixture-monkey-tests/kotlin-concurrent-tests/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm" version "${KOTLIN_VERSION}"
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:${KOTLIN_VERSION}")
+
+    testImplementation(project(":fixture-monkey-kotlin"))
+}

--- a/fixture-monkey-tests/kotlin-concurrent-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/concurrent/kotlin/ConcurrentTest.kt
+++ b/fixture-monkey-tests/kotlin-concurrent-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/concurrent/kotlin/ConcurrentTest.kt
@@ -1,0 +1,36 @@
+package com.navercorp.fixturemonkey.tests.concurrent.kotlin
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import com.navercorp.fixturemonkey.tests.TestEnvironment
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.RepeatedTest
+
+class ConcurrentTest {
+    @RepeatedTest(TestEnvironment.TEST_COUNT)
+    fun test1() {
+        val actual: KotlinObject = SUT.giveMeOne<KotlinObject>()
+        then(actual).isNotNull()
+    }
+
+    @RepeatedTest(TestEnvironment.TEST_COUNT)
+    fun test2() {
+        val actual: KotlinObject = SUT.giveMeOne<KotlinObject>()
+        then(actual).isNotNull()
+    }
+
+    @RepeatedTest(TestEnvironment.TEST_COUNT)
+    fun test3() {
+        val actual: KotlinObject = SUT.giveMeOne<KotlinObject>()
+        then(actual).isNotNull()
+    }
+
+    data class KotlinObject(val value: String, val map: Map<String, String>)
+
+    companion object {
+        private val SUT = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .build()
+    }
+}

--- a/fixture-monkey-tests/kotlin-concurrent-tests/src/test/resources/junit-platform.properties
+++ b/fixture-monkey-tests/kotlin-concurrent-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=CONCURRENT
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ include(
         "fixture-monkey-tests:java-17-tests",
         "fixture-monkey-tests:kotlin-tests",
         "fixture-monkey-tests:java-tests",
-        "fixture-monkey-tests:java-concurrent-tests"
+        "fixture-monkey-tests:java-concurrent-tests",
+        "fixture-monkey-tests:kotlin-concurrent-tests"
 )
 


### PR DESCRIPTION
## Summary
Fix Kotlin PrimaryConstructorArbitraryIntrospector generates concurretly

## How Has This Been Tested?
* tests in ConcurrentTest
