### PR TITLE
Add instantiate DSL factory method for root type

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/instantiator/KotlinInstantiatorDsl.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/instantiator/KotlinInstantiatorDsl.kt
@@ -61,6 +61,27 @@ class InstantiatorDslSpec<T>(
         return this
     }
 
+    @JvmName("rootFactory")
+    fun factory(factoryMethodName: String): InstantiatorDslSpec<T> {
+        KotlinFactoryMethodInstantiator<T>(factoryMethodName)
+            .also {
+                instantiators[rootTypeReference] = it
+            }
+        return this
+    }
+
+    @JvmName("rootFactory")
+    fun factory(
+        factoryMethodName: String,
+        dsl: KotlinFactoryMethodInstantiator<T>.() -> KotlinFactoryMethodInstantiator<T>,
+    ): InstantiatorDslSpec<T> {
+        dsl(KotlinFactoryMethodInstantiator(factoryMethodName))
+            .also {
+                instantiators[rootTypeReference] = it
+            }
+        return this
+    }
+
     inline fun <reified U> factory(factoryMethodName: String): InstantiatorDslSpec<T> {
         KotlinFactoryMethodInstantiator<U>(factoryMethodName)
             .also {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
@@ -160,10 +160,36 @@ class InstantiatorTest {
     }
 
     @RepeatedTest(TEST_COUNT)
+    fun instantiateByCompanionObjectFactoryMethodWithoutType() {
+        val actual = SUT.giveMeBuilder<Foo>()
+            .instantiateBy {
+                factory("build")
+            }
+            .sample()
+            .foo
+
+        then(actual).isEqualTo("factory")
+    }
+
+    @RepeatedTest(TEST_COUNT)
     fun instantiateByCompanionObjectFactoryMethod() {
         val actual = SUT.giveMeBuilder<Foo>()
             .instantiateBy {
                 factory<Foo>("build")
+            }
+            .sample()
+            .foo
+
+        then(actual).isEqualTo("factory")
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun instantiateByCompanionObjectFactoryMethodWithoutTypeWithParameter() {
+        val actual = SUT.giveMeBuilder<Foo>()
+            .instantiateBy {
+                factory("build") {
+                    parameter<Int>()
+                }
             }
             .sample()
             .foo


### PR DESCRIPTION
## Summary
Add instantiate DSL factory method for root type

## How Has This Been Tested?
* instantiateByCompanionObjectFactoryMethodWithoutType
* instantiateByCompanionObjectFactoryMethodWithoutTypeWithParameter
