### PR TITLE
Upgrade gradle 8.4 version for supporting JDK21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ subprojects {
         JQWIK_VERSION = "1.7.3"
         KOTLIN_VERSION = "1.8.0"
         KOTEST_VERSION = "5.6.2"
+        LOMBOK_VERSION = "1.18.30"
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
         KOTLIN_VERSION = "1.8.0"
         KOTEST_VERSION = "5.6.2"
         LOMBOK_VERSION = "1.18.30"
+        ASSERTJ_VERSION = "3.24.2"
     }
 
     dependencies {

--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -26,10 +26,10 @@ dependencies {
     testImplementation("net.jqwik:jqwik-api:${JQWIK_VERSION}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
     testImplementation("net.jqwik:jqwik-time:${JQWIK_VERSION}")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 configurations.compileOnly {

--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -37,15 +37,15 @@ configurations.compileOnly {
     exclude group: 'org.junit.platform', module: 'junit-platform-commons'
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform()
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -83,8 +83,8 @@ tasks.register("printSpotbugsMain") {
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
 jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+    toolVersion = "0.8.11"
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -93,10 +93,10 @@ jacocoTestReport {
     }
 
     reports {
-        xml.enabled true
+        xml.required = true
         xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
+        csv.required = false
+        html.required = true
         html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/fixture-monkey-api/build.gradle
+++ b/fixture-monkey-api/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("net.jqwik:jqwik-time:${JQWIK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-autoparams/build.gradle
+++ b/fixture-monkey-autoparams/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-autoparams/build.gradle
+++ b/fixture-monkey-autoparams/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-autoparams/build.gradle
+++ b/fixture-monkey-autoparams/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -20,15 +20,15 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform()
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -65,9 +65,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -75,13 +75,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-engine/build.gradle
+++ b/fixture-monkey-engine/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     api("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
 
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-engine/build.gradle
+++ b/fixture-monkey-engine/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     api("net.jqwik:jqwik-engine:${JQWIK_VERSION}")
 
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-engine/build.gradle
+++ b/fixture-monkey-engine/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -17,9 +17,9 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform {
@@ -27,7 +27,7 @@ test {
     }
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -65,8 +65,8 @@ tasks.register("printSpotbugsMain") {
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
 jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+    toolVersion = "0.8.11"
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -75,10 +75,10 @@ jacocoTestReport {
     }
 
     reports {
-        xml.enabled true
+        xml.required = true
         xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
+        csv.required = false
+        html.required = true
         html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/fixture-monkey-jackson/build.gradle
+++ b/fixture-monkey-jackson/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -25,15 +25,15 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform()
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -70,9 +70,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -80,13 +80,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-jackson/build.gradle
+++ b/fixture-monkey-jackson/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-jackson/build.gradle
+++ b/fixture-monkey-jackson/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation(project(":fixture-monkey"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -23,9 +23,9 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform {
@@ -39,7 +39,7 @@ test {
     }
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -76,9 +76,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -86,13 +86,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
-    id "org.gradle.test-retry" version "1.5.2"
 }
 
 dependencies {
@@ -30,12 +29,6 @@ dependencies {
 test {
     useJUnitPlatform {
         includeEngines "jqwik"
-    }
-
-    retry {
-        maxRetries = 2
-        maxFailures = 20
-        failOnPassedAfterRetry = true
     }
 }
 
@@ -76,8 +69,8 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {  
-    toolVersion = "0.8.11"  
+jacoco {
+    toolVersion = "0.8.11"
     reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
@@ -86,13 +79,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {  
-        xml.required = true  
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
-        csv.required = false  
-        html.required = true  
-        html.destination file("${buildDir}/reports/jacoco/html")  
-    } 
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
+        csv.required = false
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-jakarta-validation/build.gradle
+++ b/fixture-monkey-jakarta-validation/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-javax-validation/build.gradle
+++ b/fixture-monkey-javax-validation/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation(project(":fixture-monkey"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey-javax-validation/build.gradle
+++ b/fixture-monkey-javax-validation/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -23,9 +23,9 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform {
@@ -39,7 +39,7 @@ test {
     }
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -76,9 +76,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -86,13 +86,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-javax-validation/build.gradle
+++ b/fixture-monkey-javax-validation/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
-    id "org.gradle.test-retry" version "1.5.2"
 }
 
 dependencies {
@@ -30,12 +29,6 @@ dependencies {
 test {
     useJUnitPlatform {
         includeEngines "jqwik"
-    }
-
-    retry {
-        maxRetries = 2
-        maxFailures = 20
-        failOnPassedAfterRetry = true
     }
 }
 
@@ -76,8 +69,8 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {  
-    toolVersion = "0.8.11"  
+jacoco {
+    toolVersion = "0.8.11"
     reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
@@ -86,13 +79,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {  
-        xml.required = true  
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
-        csv.required = false  
-        html.required = true  
-        html.destination file("${buildDir}/reports/jacoco/html")  
-    } 
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
+        csv.required = false
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-javax-validation/build.gradle
+++ b/fixture-monkey-javax-validation/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-junit-jupiter/build.gradle
+++ b/fixture-monkey-junit-jupiter/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     testImplementation(project(":fixture-monkey-engine"))
     testImplementation(project(":fixture-monkey-javax-validation"))
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 //editorconfig {

--- a/fixture-monkey-junit-jupiter/build.gradle
+++ b/fixture-monkey-junit-jupiter/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//   id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -20,15 +20,15 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+//editorconfig {
+//    excludes = ["build"]
+//}
 
 test {
     useJUnitPlatform()
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -66,8 +66,8 @@ tasks.register("printSpotbugsMain") {
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
 jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+    toolVersion = "0.8.11"
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -76,10 +76,10 @@ jacocoTestReport {
     }
 
     reports {
-        xml.enabled true
+        xml.required = true
         xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
+        csv.required = false
+        html.required = true
         html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/fixture-monkey-junit-jupiter/build.gradle
+++ b/fixture-monkey-junit-jupiter/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation(project(":fixture-monkey-engine"))
     testImplementation(project(":fixture-monkey-javax-validation"))
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")

--- a/fixture-monkey-kotlin/build.gradle
+++ b/fixture-monkey-kotlin/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
 }
 
 test {

--- a/fixture-monkey-mockito/build.gradle
+++ b/fixture-monkey-mockito/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     api("org.mockito:mockito-core:3.9.0")
 
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-mockito/build.gradle
+++ b/fixture-monkey-mockito/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -16,9 +16,9 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform {
@@ -26,7 +26,7 @@ test {
     }
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -63,9 +63,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -73,13 +73,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-mockito/build.gradle
+++ b/fixture-monkey-mockito/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api(project(":fixture-monkey"))
     api("org.mockito:mockito-core:3.9.0")
 
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
@@ -63,8 +63,8 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {  
-    toolVersion = "0.8.11"  
+jacoco {
+    toolVersion = "0.8.11"
     reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
@@ -73,13 +73,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {  
-        xml.required = true  
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
-        csv.required = false  
-        html.required = true  
-        html.destination file("${buildDir}/reports/jacoco/html")  
-    } 
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
+        csv.required = false
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-starter-kotlin/build.gradle
+++ b/fixture-monkey-starter-kotlin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
 }
 
 test {

--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
@@ -65,8 +65,8 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {  
-    toolVersion = "0.8.11"  
+jacoco {
+    toolVersion = "0.8.11"
     reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
@@ -75,13 +75,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {  
-        xml.required = true  
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
-        csv.required = false  
-        html.required = true  
-        html.destination file("${buildDir}/reports/jacoco/html")  
-    } 
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
+        csv.required = false
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-starter/build.gradle
+++ b/fixture-monkey-starter/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -20,15 +20,15 @@ dependencies {
     testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform()
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -65,9 +65,9 @@ tasks.register("printSpotbugsMain") {
 }
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
-jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+jacoco {  
+    toolVersion = "0.8.11"  
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -75,13 +75,13 @@ jacocoTestReport {
         classDirectories.setFrom(file("${buildDir}/classes/java/main"))
     }
 
-    reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
-        html.destination file("${buildDir}/reports/jacoco/html")
-    }
+    reports {  
+        xml.required = true  
+        xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")  
+        csv.required = false  
+        html.required = true  
+        html.destination file("${buildDir}/reports/jacoco/html")  
+    } 
 }
 
 jacocoTestCoverageVerification {

--- a/fixture-monkey-tests/build.gradle
+++ b/fixture-monkey-tests/build.gradle
@@ -16,7 +16,7 @@ subprojects {
         testImplementation(project(":fixture-monkey-tests"))
         testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_JUPITER_VERSION}")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
-        testImplementation("org.assertj:assertj-core:3.22.0")
+        testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     }
 
     test {

--- a/fixture-monkey-tests/java-tests/build.gradle
+++ b/fixture-monkey-tests/java-tests/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     testImplementation(project(":fixture-monkey-javax-validation"))
-    testImplementation("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testImplementation(project(":fixture-monkey-jackson"))
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -6,7 +6,10 @@ plugins {
     id "jacoco"
     id "checkstyle"
     id "me.champeau.jmh" version "0.6.6"
-    id "org.gradle.test-retry" version "1.5.2"
+}
+
+ext {
+    JMH_VERSION = "1.37"
 }
 
 dependencies {
@@ -23,8 +26,8 @@ dependencies {
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 
-    jmhImplementation("org.openjdk.jmh:jmh-core:1.35")
-    jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.35")
+    jmhImplementation("org.openjdk.jmh:jmh-core:${JMH_VERSION}")
+    jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:${JMH_VERSION}")
     jmhImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     jmhImplementation(project(":fixture-monkey-javax-validation"))
     jmhImplementation(project(":fixture-monkey-jackson"))

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
-    id "me.champeau.jmh" version "0.6.6"
+    id "me.champeau.jmh" version "0.7.2"
 }
 
 ext {
@@ -41,12 +41,6 @@ dependencies {
 test {
     useJUnitPlatform {
         includeEngines "jqwik"
-    }
-
-    retry {
-        maxRetries = 2
-        maxFailures = 20
-        failOnPassedAfterRetry = true
     }
 }
 

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id "org.ec4j.editorconfig" version "0.0.3"
+//    id "org.ec4j.editorconfig" version "0.0.3"
     id "com.github.spotbugs" version "4.7.6"
     id "jacoco"
     id "checkstyle"
@@ -31,9 +31,9 @@ dependencies {
     jmhAnnotationProcessor("org.projectlombok:lombok:1.18.24")
 }
 
-editorconfig {
-    excludes = ["build"]
-}
+// editorconfig {
+//    excludes = ["build"]
+// }
 
 test {
     useJUnitPlatform {
@@ -47,7 +47,7 @@ test {
     }
 }
 
-check.dependsOn editorconfigCheck
+// check.dependsOn editorconfigCheck
 
 checkstyle {
     configFile = file("${project.rootDir}/tool/naver-checkstyle-rules.xml")
@@ -85,8 +85,8 @@ tasks.register("printSpotbugsMain") {
 tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
 jacoco {
-    toolVersion = "0.8.7"
-    reportsDir = file("${buildDir}/reports/jacoco")
+    toolVersion = "0.8.11"
+    reportsDirectory.set(file("${buildDir}/reports/jacoco"))
 }
 
 jacocoTestReport {
@@ -95,10 +95,10 @@ jacocoTestReport {
     }
 
     reports {
-        xml.enabled true
+        xml.required = true
         xml.destination file("${buildDir}/reports/jacoco/jacoco.xml")
-        csv.enabled false
-        html.enabled true
+        csv.required = false
+        html.required = true
         html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -20,15 +20,15 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
     testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("org.projectlombok:lombok:1.18.24")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
+    testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 
     jmhImplementation("org.openjdk.jmh:jmh-core:1.35")
     jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.35")
-    jmhImplementation("org.projectlombok:lombok:1.18.24")
+    jmhImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     jmhImplementation(project(":fixture-monkey-javax-validation"))
     jmhImplementation(project(":fixture-monkey-jackson"))
-    jmhAnnotationProcessor("org.projectlombok:lombok:1.18.24")
+    jmhAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 }
 
 // editorconfig {

--- a/fixture-monkey/build.gradle
+++ b/fixture-monkey/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${JUNIT_JUPITER_VERSION}")
     testImplementation("org.junit.platform:junit-platform-engine:${JUNIT_ENGINE_VERSION}")
-    testImplementation("org.assertj:assertj-core:3.22.0")
+    testImplementation("org.assertj:assertj-core:${ASSERTJ_VERSION}")
     testImplementation("org.projectlombok:lombok:${LOMBOK_VERSION}")
     testAnnotationProcessor("org.projectlombok:lombok:${LOMBOK_VERSION}")
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Upgrade gradle 8.4 version for supporting JDK21

## Description
- disable `editorConfig`
- upgrade jacoco  0.8.7 -> 0.8.11
- upgrade lombok 1.8.26 -> 1.8.30
- upgrade jmh 1.35 -> 1.37
- upgrade jmh plugin 0.6.6 -> 0.7.2
- remove retry plugin
- upgrade assertj 3.22.0 -> 3.24.2

## How Has This Been Tested?
* existing tests
