### PR TITLE
Add a Plugin to extend interfaces

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -26,7 +26,6 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet;
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet;
-import com.navercorp.fixturemonkey.api.introspector.AnonymousArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.ArrayIntrospector;
@@ -151,10 +150,6 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 	}
 
 	public IntrospectedArbitraryGenerator build() {
-		if (this.fallbackIntrospector == DEFAULT_FALLBACK_INTROSPECTOR) {
-			this.fallbackIntrospector = AnonymousArbitraryIntrospector.INSTANCE;
-		}
-
 		return new IntrospectedArbitraryGenerator(
 			new MatchArbitraryIntrospector(
 				Arrays.asList(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/InterfacePlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/InterfacePlugin.java
@@ -1,0 +1,129 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.plugin;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.introspector.AnonymousArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.MatchArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
+import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptionsBuilder;
+
+/**
+ * This plugin is used to extend an interface.
+ */
+@API(since = "1.0.6", status = Status.EXPERIMENTAL)
+public final class InterfacePlugin implements Plugin {
+	private final List<MatcherOperator<ObjectPropertyGenerator>> objectPropertyGenerators = new ArrayList<>();
+	private boolean useAnonymousArbitraryIntrospector = true;
+
+	/**
+	 * Registers an interface implementation with a specified matcher.
+	 * This method facilitates adding custom implementations for interfaces using a matcher.
+	 *
+	 * @param <T> the type parameter of the interface
+	 * @param matcher the matcher to be used for matching interfaces
+	 * @param implementations a list of classes implementing the interface
+	 * @return the InterfacePlugin instance for fluent chaining
+	 */
+	public <T> InterfacePlugin interfaceImplements(
+		Matcher matcher,
+		List<Class<? extends T>> implementations
+	) {
+		return interfaceImplements(
+			new MatcherOperator<>(
+				matcher,
+				new InterfaceObjectPropertyGenerator<>(implementations))
+		);
+	}
+
+	/**
+	 * Registers implementations for a given interface.
+	 * This method validates that the provided class is an interface.
+	 * It throws an IllegalArgumentException if the validation fails.
+	 *
+	 * @param <T> the type parameter of the interface
+	 * @param interfaceClass the interface class to be implemented
+	 * @param implementations a list of classes implementing the interface
+	 * @return the InterfacePlugin instance for fluent chaining
+	 * @throws IllegalArgumentException if the first parameter is not an interface
+	 */
+	public <T> InterfacePlugin interfaceImplements(
+		Class<T> interfaceClass,
+		List<Class<? extends T>> implementations
+	) {
+		if (!Modifier.isInterface(interfaceClass.getModifiers())) {
+			throw new IllegalArgumentException(
+				"interfaceImplements option first parameter should be interface. "
+					+ interfaceClass.getTypeName()
+			);
+		}
+
+		return interfaceImplements(new ExactTypeMatcher(interfaceClass), implementations);
+	}
+
+	/**
+	 * Registers an interface implementation with a specified matcher.
+	 * This method facilitates adding custom implementations for interfaces using a matcher.
+	 *
+	 * @param objectPropertyGenerator the object property generator to add
+	 * @return the InterfacePlugin instance for fluent chaining
+	 */
+	public InterfacePlugin interfaceImplements(MatcherOperator<ObjectPropertyGenerator> objectPropertyGenerator) {
+		this.objectPropertyGenerators.add(objectPropertyGenerator);
+		return this;
+	}
+
+	/**
+	 * Configures the use of an anonymous arbitrary introspector.
+	 * By default, this option is enabled (default value is true).
+	 * When enabled, it uses an instance of {@link AnonymousArbitraryIntrospector} as the fallback introspector.
+	 *
+	 * @param useAnonymousArbitraryIntrospector a boolean flag to enable (true) or disable (false)
+	 *        the anonymous arbitrary introspector. Default value is true.
+	 * @return the InterfacePlugin instance for fluent chaining
+	 */
+	public InterfacePlugin useAnonymousArbitraryIntrospector(boolean useAnonymousArbitraryIntrospector) {
+		this.useAnonymousArbitraryIntrospector = useAnonymousArbitraryIntrospector;
+		return this;
+	}
+
+	@Override
+	public void accept(FixtureMonkeyOptionsBuilder optionsBuilder) {
+		for (MatcherOperator<ObjectPropertyGenerator> objectPropertyGenerator : objectPropertyGenerators) {
+			optionsBuilder.insertFirstArbitraryObjectPropertyGenerator(objectPropertyGenerator);
+		}
+
+		if (useAnonymousArbitraryIntrospector) {
+			optionsBuilder.fallbackIntrospector(it ->
+				new MatchArbitraryIntrospector(Arrays.asList(it, AnonymousArbitraryIntrospector.INSTANCE))
+			);
+		}
+	}
+}

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/OptionTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/OptionTest.kt
@@ -22,6 +22,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import com.navercorp.fixturemonkey.api.constraint.JavaDateTimeConstraint
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
+import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
@@ -108,5 +109,37 @@ class OptionTest {
         // then
         val nextYearInstant = nextYear.toInstant(offset)
         then(actual).isBetween(thisYearInstant, nextYearInstant)
+    }
+
+    interface Interface {
+        fun string(): String
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun anonymousArbitraryIntrospector() {
+        // given
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .build()
+
+        // when
+        val actual = sut.giveMeOne<Interface>().string()
+
+        // then
+        then(actual).isNotNull()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun notUseAnonymousArbitraryIntrospector() {
+        // given
+        val sut = FixtureMonkey.builder()
+            .plugin(InterfacePlugin().useAnonymousArbitraryIntrospector(false))
+            .build()
+
+        // when
+        val actual: Interface = sut.giveMeOne()
+
+        // then
+        then(actual).isNull()
     }
 }


### PR DESCRIPTION
## Summary
Add a Plugin to extend interfaces

## (Optional): Description
All interface related options are separated into `InterfacePlugin`.

## How Has This Been Tested?
* anonymousArbitraryIntrospector
* notUseAnonymousArbitraryIntrospector
