### PR TITLE
kotlin private primary constructor access

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -32,6 +32,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
 
 @API(since = "0.4.0", status = MAINTAINED)
 class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
@@ -54,6 +55,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
                     val constructor = CONSTRUCTOR_CACHE.computeIfAbsent(type) {
                         requireNotNull(kotlinClass.primaryConstructor) { "No kotlin primary constructor provided for $kotlinClass" }
                     }
+                    constructor.isAccessible = true
 
                     val arbitrariesByPropertyName = it.mapKeys { map -> map.key.objectProperty.property.name }
 

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
@@ -447,6 +447,17 @@ class InstantiatorTest {
     }
 
     @RepeatedTest(TEST_COUNT)
+    fun instantiatePrivateConstructorWithoutInstantiate() {
+        class PrivateConstructorObject private constructor(val value: String)
+
+        val actual = SUT.giveMeBuilder<PrivateConstructorObject>()
+            .sample()
+            .value
+
+        then(actual).isNotNull()
+    }
+
+    @RepeatedTest(TEST_COUNT)
     fun instantiateDefaultArgumentConstructor() {
         class ConstructorObject(val value: String = "default")
 

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/InstantiatorTest.kt
@@ -5,6 +5,7 @@ import com.navercorp.fixturemonkey.api.instantiator.Instantiator
 import com.navercorp.fixturemonkey.api.instantiator.Instantiator.constructor
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.navercorp.fixturemonkey.kotlin.instantiator.instantiateBy
 import com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT
 import org.assertj.core.api.BDDAssertions.then
@@ -450,8 +451,7 @@ class InstantiatorTest {
     fun instantiatePrivateConstructorWithoutInstantiate() {
         class PrivateConstructorObject private constructor(val value: String)
 
-        val actual = SUT.giveMeBuilder<PrivateConstructorObject>()
-            .sample()
+        val actual = SUT.giveMeOne<PrivateConstructorObject>()
             .value
 
         then(actual).isNotNull()


### PR DESCRIPTION
## Summary

This is a pr regarding the issue at

https://github.com/naver/fixture-monkey/issues/847

i have made modification to`PrimaryConstructorArbitraryIntrospector` to include that handles private access.

additionaly added a corresponding test case.

## How Has This Been Tested?

check through test case