### PR TITLE
Add document update check to PR update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,7 @@
 
 ## How Has This Been Tested?
 *Please describe the tests that you ran to verify your changes.*
+
+## Is the Document updated?
+*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
+*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*


### PR DESCRIPTION
## Summary
Specify to update the corresponding document page within the PR in the PR template.

This will ensure the documentation stays up-to-date.