### PR TITLE
Fix addExceptGenerateClass option to not be affected by specific ArbitraryIntrospector

### DIFF
--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -5,6 +5,11 @@ menu:
 docs:
 weight: 100
 ---
+### v1.0.9
+Fix addExceptGenerateClass option affected by specific ArbitraryIntrospector
+
+----------
+
 ### v1.0.8
 Add more detailed message if generation fails.
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/NullArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/NullArbitraryIntrospector.java
@@ -16,25 +16,20 @@
  * limitations under the License.
  */
 
-package com.navercorp.fixturemonkey.api.generator;
-
-import java.util.Collections;
+package com.navercorp.fixturemonkey.api.introspector;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-@API(since = "0.4.0", status = Status.MAINTAINED)
-public final class NullObjectPropertyGenerator implements ObjectPropertyGenerator {
-	public static final NullObjectPropertyGenerator INSTANCE = new NullObjectPropertyGenerator();
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+
+@API(since = "1.0.9", status = Status.EXPERIMENTAL)
+public final class NullArbitraryIntrospector implements ArbitraryIntrospector {
+	public static final NullArbitraryIntrospector INSTANCE = new NullArbitraryIntrospector();
 
 	@Override
-	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
-		return new ObjectProperty(
-			context.getProperty(),
-			context.getPropertyNameResolver(),
-			1.0d,
-			null,
-			Collections.singletonMap(context.getProperty(), Collections.emptyList())
-		);
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		return new ArbitraryIntrospectorResult(CombinableArbitrary.from((Object)null));
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
@@ -55,13 +55,14 @@ import com.navercorp.fixturemonkey.api.generator.MapContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.MapEntryElementContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NoArgumentInterfaceJavaMethodPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
-import com.navercorp.fixturemonkey.api.generator.NullObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.OptionalContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.SetContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.SingleValueObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.StreamContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.instantiator.InstantiatorProcessor;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.NullArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.DoubleGenericTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
@@ -82,6 +83,10 @@ public final class FixtureMonkeyOptions {
 		getDefaultObjectPropertyGenerators();
 	public static final List<MatcherOperator<ContainerPropertyGenerator>> DEFAULT_CONTAINER_PROPERTY_GENERATORS =
 		getDefaultContainerPropertyGenerators();
+	public static final List<MatcherOperator<ArbitraryIntrospector>> DEFAULT_ARBITRARY_INTROSPECTORS =
+		Collections.singletonList(
+			MatcherOperator.exactTypeMatchOperator(UnidentifiableType.class, NullArbitraryIntrospector.INSTANCE)
+		);
 	public static final ObjectPropertyGenerator DEFAULT_OBJECT_PROPERTY_GENERATOR =
 		DefaultObjectPropertyGenerator.INSTANCE;
 	public static final PropertyNameResolver DEFAULT_PROPERTY_NAME_RESOLVER = PropertyNameResolver.IDENTITY;
@@ -332,11 +337,7 @@ public final class FixtureMonkeyOptions {
 				},
 				SingleValueObjectPropertyGenerator.INSTANCE
 			),
-			new MatcherOperator<>(Matchers.ENUM_TYPE_MATCHER, SingleValueObjectPropertyGenerator.INSTANCE),
-			MatcherOperator.exactTypeMatchOperator(
-				UnidentifiableType.class,
-				NullObjectPropertyGenerator.INSTANCE
-			)
+			new MatcherOperator<>(Matchers.ENUM_TYPE_MATCHER, SingleValueObjectPropertyGenerator.INSTANCE)
 		);
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -22,6 +22,7 @@ import static com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.DEFAULT_NOTNULL_ANNOTATION_TYPES;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.DEFAULT_NULLABLE_ANNOTATION_TYPES;
 import static com.navercorp.fixturemonkey.api.generator.DefaultNullInjectGenerator.DEFAULT_NULL_INJECT;
+import static com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions.DEFAULT_ARBITRARY_INTROSPECTORS;
 import static com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions.DEFAULT_MAX_UNIQUE_GENERATION_COUNT;
 
 import java.util.ArrayList;
@@ -97,7 +98,8 @@ public final class FixtureMonkeyOptionsBuilder {
 	private ArbitraryContainerInfoGenerator defaultArbitraryContainerInfoGenerator;
 	private ArbitraryGenerator defaultArbitraryGenerator;
 	private UnaryOperator<ArbitraryGenerator> defaultArbitraryGeneratorOperator = it -> it;
-	private final List<MatcherOperator<ArbitraryIntrospector>> arbitraryIntrospectors = new ArrayList<>();
+	private final List<MatcherOperator<ArbitraryIntrospector>> arbitraryIntrospectors =
+		new ArrayList<>(DEFAULT_ARBITRARY_INTROSPECTORS);
 	private final JavaDefaultArbitraryGeneratorBuilder javaDefaultArbitraryGeneratorBuilder =
 		IntrospectedArbitraryGenerator.javaBuilder();
 	private boolean defaultNotNull = false;

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -37,10 +37,10 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator;
-import com.navercorp.fixturemonkey.api.generator.NullObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.MatchArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.NullArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
@@ -266,10 +266,10 @@ public final class FixtureMonkeyBuilder {
 	}
 
 	public FixtureMonkeyBuilder pushExceptGenerateType(Matcher matcher) {
-		fixtureMonkeyOptionsBuilder.insertFirstArbitraryObjectPropertyGenerator(
+		fixtureMonkeyOptionsBuilder.insertFirstArbitraryIntrospector(
 			new MatcherOperator<>(
 				matcher,
-				NullObjectPropertyGenerator.INSTANCE
+				NullArbitraryIntrospector.INSTANCE
 			)
 		);
 		return this;

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.lang.reflect.AnnotatedType;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -697,10 +698,10 @@ class FixtureMonkeyOptionsTest {
 	@Property
 	void addExceptGenerateClass() {
 		FixtureMonkey sut = FixtureMonkey.builder()
-			.addExceptGenerateClass(String.class)
+			.addExceptGenerateClass(Timestamp.class)
 			.build();
 
-		String actual = sut.giveMeOne(String.class);
+		Timestamp actual = sut.giveMeOne(Timestamp.class);
 
 		then(actual).isNull();
 	}


### PR DESCRIPTION
## Summary
Fix addExceptGenerateClass option to not be affected by specific ArbitraryIntrospector

## How Has This Been Tested?
* addExceptGenerateClass

## Is the Document updated?
Yes
