### PR TITLE
Change regular expression generation library to RgxGen

### DIFF
--- a/fixture-monkey-api/build.gradle.kts
+++ b/fixture-monkey-api/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     compileOnly("net.jqwik:jqwik-web:${Versions.JQWIK}")
     compileOnly("net.jqwik:jqwik-time:${Versions.JQWIK}")
     compileOnly("com.github.curious-odd-man:rgxgen:1.4")
+    compileOnly("com.github.mifmif:generex:1.0.2")
 
     testImplementation("net.jqwik:jqwik-engine:${Versions.JQWIK}")
     testImplementation("net.jqwik:jqwik-api:${Versions.JQWIK}")

--- a/fixture-monkey-api/build.gradle.kts
+++ b/fixture-monkey-api/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     compileOnly("net.jqwik:jqwik-api:${Versions.JQWIK}")
     compileOnly("net.jqwik:jqwik-web:${Versions.JQWIK}")
     compileOnly("net.jqwik:jqwik-time:${Versions.JQWIK}")
-    compileOnly("com.github.mifmif:generex:1.0.2")
+    compileOnly("com.github.curious-odd-man:rgxgen:1.4")
 
     testImplementation("net.jqwik:jqwik-engine:${Versions.JQWIK}")
     testImplementation("net.jqwik:jqwik-api:${Versions.JQWIK}")
@@ -37,6 +37,7 @@ dependencies {
     testImplementation("org.projectlombok:lombok:${Versions.LOMBOK}")
     testImplementation("org.assertj:assertj-core:${Versions.ASSERTJ}")
     testImplementation("net.jqwik:jqwik-time:${Versions.JQWIK}")
+    testImplementation("com.github.curious-odd-man:rgxgen:1.4")
     testAnnotationProcessor("org.projectlombok:lombok:${Versions.LOMBOK}")
 }
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaArbitraryResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaArbitraryResolver.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.api.jqwik;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -76,15 +77,16 @@ public final class JqwikJavaArbitraryResolver implements JavaArbitraryResolver {
 
 		Arbitrary<String> arbitrary = stringArbitrary;
 		if (pattern != null) {
-			Integer minValue = min != null ? min.intValue() : null;
-			Integer maxValue = max != null ? max.intValue() : null;
+			int minLength = min == null ? 0 : min.intValue();
+			int maxLength = max == null ? Integer.MAX_VALUE : max.intValue();
+
+			Predicate<String> lengthCondition = it -> it.length() >= minLength && it.length() <= maxLength;
+			Predicate<String> notBlankCondition = it -> !(notBlank && it.trim().isEmpty());
 
 			return Arbitraries.ofSuppliers(() -> REGEX_GENERATOR.generate(
 				pattern.getRegexp(),
 				pattern.getFlags(),
-				minValue,
-				maxValue,
-				notBlank
+				lengthCondition.and(notBlankCondition)
 			));
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaArbitraryResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaArbitraryResolver.java
@@ -18,11 +18,8 @@
 
 package com.navercorp.fixturemonkey.api.jqwik;
 
-import static java.util.stream.Collectors.toList;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -81,19 +78,14 @@ public final class JqwikJavaArbitraryResolver implements JavaArbitraryResolver {
 		if (pattern != null) {
 			Integer minValue = min != null ? min.intValue() : null;
 			Integer maxValue = max != null ? max.intValue() : null;
-			List<String> values = REGEX_GENERATOR.generateAll(
+
+			return Arbitraries.ofSuppliers(() -> REGEX_GENERATOR.generate(
 				pattern.getRegexp(),
 				pattern.getFlags(),
 				minValue,
-				maxValue
-			);
-			if (notBlank) {
-				values = values.stream()
-					.filter(it -> it != null && !it.trim().isEmpty())
-					.collect(toList());
-			}
-
-			return Arbitraries.of(values);
+				maxValue,
+				notBlank
+			));
 		}
 
 		if (email) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/RegexGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/RegexGenerator.java
@@ -64,10 +64,10 @@ public final class RegexGenerator {
 	}
 
 	public String generate(String regex, int[] flags, Predicate<String> stringCondition) {
-		boolean caseSensitive = Arrays.stream(flags).noneMatch(it -> it == FLAG_CASE_INSENSITIVE);
+		boolean caseInSensitive = Arrays.stream(flags).anyMatch(it -> it == FLAG_CASE_INSENSITIVE);
 
 		try {
-			RgxGen rgxGen = generateRgxGen(regex, caseSensitive);
+			RgxGen rgxGen = generateRgxGen(regex, caseInSensitive);
 
 			String result = executor.submit(() ->
 				rgxGen.stream()
@@ -75,7 +75,7 @@ public final class RegexGenerator {
 					.findFirst()
 			).get(DEFAULT_REGEXP_GENERATION_TIMEOUT_SEC, TimeUnit.SECONDS).orElse(null);
 
-			checkValidity(regex, result, caseSensitive);
+			checkValidity(regex, result, caseInSensitive);
 			return result;
 		} catch (Exception ex) {
 			throw new IllegalArgumentException(
@@ -138,9 +138,9 @@ public final class RegexGenerator {
 		return result;
 	}
 
-	private static RgxGen generateRgxGen(String regex, boolean caseSensitive) {
+	private static RgxGen generateRgxGen(String regex, boolean caseInSensitive) {
 		RgxGenProperties properties = new RgxGenProperties();
-		if (!caseSensitive) {
+		if (caseInSensitive) {
 			RgxGenOption.CASE_INSENSITIVE.setInProperties(properties, true);
 		}
 		RgxGen rgxGen = new RgxGen(regex);
@@ -148,12 +148,12 @@ public final class RegexGenerator {
 		return rgxGen;
 	}
 
-	private static void checkValidity(String regex, String result, boolean caseSensitive) {
+	private static void checkValidity(String regex, String result, boolean caseInSensitive) {
 		Pattern pattern;
-		if (caseSensitive) {
-			pattern = Pattern.compile(regex);
-		} else {
+		if (caseInSensitive) {
 			pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+		} else {
+			pattern = Pattern.compile(regex);
 		}
 
 		if (!pattern.matcher(result).matches()) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/RegexGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/RegexGenerator.java
@@ -35,8 +35,6 @@ import javax.annotation.Nullable;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.github.curiousoddman.rgxgen.RgxGen;
 import com.github.curiousoddman.rgxgen.config.RgxGenOption;
@@ -45,7 +43,7 @@ import com.github.curiousoddman.rgxgen.iterators.StringIterator;
 
 @API(since = "0.6.9", status = Status.MAINTAINED)
 public final class RegexGenerator {
-	private static final Logger LOGGER = LoggerFactory.getLogger(RegexGenerator.class);
+	private static final int FLAG_CASE_INSENSITIVE = 2;
 	public static final int DEFAULT_REGEXP_GENERATION_TIMEOUT_SEC = 10;
 	public static final int DEFAULT_REGEXP_GENERATION_MAX_SIZE = 100;
 
@@ -90,7 +88,7 @@ public final class RegexGenerator {
 
 	private static RgxGen generateRgxGen(String regex, int[] flags) {
 		RgxGenProperties properties = new RgxGenProperties();
-		if (Arrays.stream(flags).anyMatch(it -> it == 2)) {
+		if (Arrays.stream(flags).anyMatch(it -> it == FLAG_CASE_INSENSITIVE)) {
 			RgxGenOption.CASE_INSENSITIVE.setInProperties(properties, true);
 		}
 		RgxGen rgxGen = new RgxGen(regex);

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
@@ -32,7 +32,7 @@ class RegexGeneratorTest {
 	@Test
 	void regExpGenerationSuccess() {
 		String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
-		String result = SUT.generate(emailRegex, new int[] {}, null, null, false);
+		String result = SUT.generate(emailRegex, new int[] {}, it -> true);
 
 		Pattern pattern = Pattern.compile(emailRegex);
 		then(pattern.matcher(result).matches()).isTrue();
@@ -40,19 +40,17 @@ class RegexGeneratorTest {
 
 	@Test
 	void generateRegExpWithCaseInsensitiveFlag() {
-		String result = SUT.generate("a", new int[] {FLAG_CASE_INSENSITIVE}, null, null, false);
+		String result = SUT.generate("a", new int[] {FLAG_CASE_INSENSITIVE}, it -> true);
 
 		then(result).isIn("a", "A");
 	}
 
 	@Test
-	void generateRegExpWithMinMaxLength() {
+	void generateRegExpWithPredicate() {
 		String result = SUT.generate(
 			"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
 			new int[] {},
-			3,
-			50,
-			false
+			it -> it.length() >= 3 && it.length() <= 50
 		);
 
 		then(result.length()).isBetween(3, 50);
@@ -61,7 +59,11 @@ class RegexGeneratorTest {
 	@Test
 	void generateInvalidRegExpThrows() {
 		thenThrownBy(
-			() -> SUT.generate("^^a", new int[] {}, null, null, false)
+			() -> SUT.generate(
+				"^^a",
+				new int[] {},
+				it -> true
+			)
 		).isExactlyInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -71,9 +73,7 @@ class RegexGeneratorTest {
 			() -> SUT.generate(
 				"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
 				new int[] {},
-				null,
-				3,
-				false
+				it -> it.length() <= 3
 			)
 		).isExactlyInstanceOf(IllegalArgumentException.class);
 	}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
@@ -1,0 +1,57 @@
+package com.navercorp.fixturemonkey.api.random;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+public class RegexGeneratorTest {
+	private static final RegexGenerator SUT = new RegexGenerator();
+	private static final int FLAG_CASE_INSENSITIVE = 2;
+
+	@Test
+	void regExpGenerationSuccess() {
+		String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+		List<String> strings = SUT.generateAll(emailRegex, new int[] {}, null, null);
+
+		Pattern pattern = Pattern.compile(emailRegex);
+		then(strings).allMatch(it -> pattern.matcher(it).matches());
+	}
+
+	@Test
+	void generateRegExpWithCaseInsensitiveFlag() {
+		List<String> strings = SUT.generateAll("a", new int[] {FLAG_CASE_INSENSITIVE}, null, null);
+
+		then("a").isIn(strings);
+		then("A").isIn(strings);
+	}
+
+	@Test
+	void generateRegExpWithMinMaxLength() {
+		List<String> strings = SUT.generateAll("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", new int[] {}, 3, 7);
+
+		then(strings).allMatch(it -> it.length() >= 3 && it.length() <= 7);
+	}
+
+	@Test
+	void generateInvalidRegExpThrows() {
+		thenThrownBy(
+			() -> SUT.generateAll("^^a", new int[] {}, null, null)
+		).isExactlyInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void generateIncalculableRegExpThrows() {
+		thenThrownBy(
+			() -> SUT.generateAll(
+				"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+				new int[] {},
+				20,
+				null
+			)
+		).isExactlyInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.api.random;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -8,7 +26,7 @@ import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
-public class RegexGeneratorTest {
+class RegexGeneratorTest {
 	private static final RegexGenerator SUT = new RegexGenerator();
 	private static final int FLAG_CASE_INSENSITIVE = 2;
 

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
@@ -49,9 +49,14 @@ class RegexGeneratorTest {
 
 	@Test
 	void generateRegExpWithMinMaxLength() {
-		List<String> strings = SUT.generateAll("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", new int[] {}, 3, 7);
+		List<String> strings = SUT.generateAll(
+			"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+			new int[] {},
+			3,
+			50
+		);
 
-		then(strings).allMatch(it -> it.length() >= 3 && it.length() <= 7);
+		then(strings).allMatch(it -> it.length() >= 3 && it.length() <= 50);
 	}
 
 	@Test
@@ -67,8 +72,8 @@ class RegexGeneratorTest {
 			() -> SUT.generateAll(
 				"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
 				new int[] {},
-				20,
-				null
+				null,
+				3
 			)
 		).isExactlyInstanceOf(IllegalArgumentException.class);
 	}

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/random/RegexGeneratorTest.java
@@ -21,7 +21,6 @@ package com.navercorp.fixturemonkey.api.random;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
-import java.util.List;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
@@ -33,47 +32,48 @@ class RegexGeneratorTest {
 	@Test
 	void regExpGenerationSuccess() {
 		String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
-		List<String> strings = SUT.generateAll(emailRegex, new int[] {}, null, null);
+		String result = SUT.generate(emailRegex, new int[] {}, null, null, false);
 
 		Pattern pattern = Pattern.compile(emailRegex);
-		then(strings).allMatch(it -> pattern.matcher(it).matches());
+		then(pattern.matcher(result).matches()).isTrue();
 	}
 
 	@Test
 	void generateRegExpWithCaseInsensitiveFlag() {
-		List<String> strings = SUT.generateAll("a", new int[] {FLAG_CASE_INSENSITIVE}, null, null);
+		String result = SUT.generate("a", new int[] {FLAG_CASE_INSENSITIVE}, null, null, false);
 
-		then("a").isIn(strings);
-		then("A").isIn(strings);
+		then(result).isIn("a", "A");
 	}
 
 	@Test
 	void generateRegExpWithMinMaxLength() {
-		List<String> strings = SUT.generateAll(
+		String result = SUT.generate(
 			"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
 			new int[] {},
 			3,
-			50
+			50,
+			false
 		);
 
-		then(strings).allMatch(it -> it.length() >= 3 && it.length() <= 50);
+		then(result.length()).isBetween(3, 50);
 	}
 
 	@Test
 	void generateInvalidRegExpThrows() {
 		thenThrownBy(
-			() -> SUT.generateAll("^^a", new int[] {}, null, null)
+			() -> SUT.generate("^^a", new int[] {}, null, null, false)
 		).isExactlyInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	void generateIncalculableRegExpThrows() {
 		thenThrownBy(
-			() -> SUT.generateAll(
+			() -> SUT.generate(
 				"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
 				new int[] {},
 				null,
-				3
+				3,
+				false
 			)
 		).isExactlyInstanceOf(IllegalArgumentException.class);
 	}

--- a/fixture-monkey/build.gradle.kts
+++ b/fixture-monkey/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api(project(":fixture-monkey-api"))
 
     api("net.jqwik:jqwik:${Versions.JQWIK}")
-    api("com.github.mifmif:generex:1.0.2")
+    api("com.github.curious-odd-man:rgxgen:1.4")
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT_JUPITER}")

--- a/fixture-monkey/build.gradle.kts
+++ b/fixture-monkey/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
 
     api("net.jqwik:jqwik:${Versions.JQWIK}")
     api("com.github.curious-odd-man:rgxgen:1.4")
+    api("com.github.mifmif:generex:1.0.2")
 
     testRuntimeOnly(project(":fixture-monkey-engine"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT_JUPITER}")

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
@@ -88,7 +88,7 @@ final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 		throw new IllegalArgumentException(
 			String.format(
 				"Given type %s could not be generated."
-					+ "Check the ArbitraryIntrospector used or the APIs used in the ArbitraryBuilder..",
+					+ " Check the ArbitraryIntrospector used or the APIs used in the ArbitraryBuilder.",
 				rootProperty.getType()
 			),
 			lastException
@@ -115,7 +115,7 @@ final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 		throw new IllegalArgumentException(
 			String.format(
 				"Given type %s could not be generated."
-					+ "Check the ArbitraryIntrospector used or the APIs used in the ArbitraryBuilder.",
+					+ " Check the ArbitraryIntrospector used or the APIs used in the ArbitraryBuilder.",
 				rootProperty.getType()
 			),
 			lastException


### PR DESCRIPTION
## Summary
Related to #772, #713

Changes the regular expression generation library to RgxGen.

## (Optional): Description
- An exception is thrown when RgxGen fails to generate or takes more than 10 seconds.
- The option of generating random values(or null) when RgxGen fails was considered but not implemented because the fixture generation will still fail at the `ArbitaryValidator`
- Some of the cases mentioned in the referenced issues (`^[\\S]+$`, `\\S+`) are now generatable. However, cases like `^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,20}$` fails to be generated because the library has limitations (https://github.com/curious-odd-man/RgxGen?tab=readme-ov-file#limitations). 

## How Has This Been Tested?
Added RegexGeneratorTest.

## Is the Document updated?
Will add a subsequent commit to update the document once this PR is reviewed and finalized.
