### PR TITLE
Add AnonymousArgumentConstructorIntrospector as a default fallback introspector

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/FilteredCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/FilteredCombinableArbitrary.java
@@ -28,6 +28,7 @@ import org.apiguardian.api.API.Status;
 import net.jqwik.api.TooManyFilterMissesException;
 
 import com.navercorp.fixturemonkey.api.exception.FixedValueFilterMissException;
+import com.navercorp.fixturemonkey.api.exception.RetryableException;
 import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.api.exception.ValidationFailedException;
 import com.navercorp.fixturemonkey.api.property.PropertyPath;
@@ -78,7 +79,7 @@ final class FilteredCombinableArbitrary<T> implements CombinableArbitrary<T> {
 				if (fixed()) {
 					throw new FixedValueFilterMissException("Fixed value can not satisfy given filter.");
 				}
-			} catch (TooManyFilterMissesException | ValidationFailedException | RetryableFilterMissException ex) {
+			} catch (TooManyFilterMissesException | RetryableException ex) {
 				if (lastException == null || ex.getCause() != null) {
 					lastException = ex;
 				}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/exception/RetryableException.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/exception/RetryableException.java
@@ -18,27 +18,20 @@
 
 package com.navercorp.fixturemonkey.api.exception;
 
-import java.util.Set;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.validator.ArbitraryValidator;
-
-/**
- * It is thrown when validated by {@link ArbitraryValidator}.
- * A new populated object would be generated when this exception is thrown.
- */
-@API(since = "0.6.0", status = Status.MAINTAINED)
-public final class ValidationFailedException extends RetryableException {
-	private final Set<String> constraintViolationPropertyNames;
-
-	public ValidationFailedException(String message, Set<String> constraintViolationPropertyNames) {
+@API(since = "1.0.10", status = Status.EXPERIMENTAL)
+public class RetryableException extends RuntimeException {
+	public RetryableException(String message) {
 		super(message);
-		this.constraintViolationPropertyNames = constraintViolationPropertyNames;
 	}
 
-	public Set<String> getConstraintViolationPropertyNames() {
-		return constraintViolationPropertyNames;
+	public RetryableException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public RetryableException(Throwable cause) {
+		super(cause);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/exception/RetryableFilterMissException.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/exception/RetryableFilterMissException.java
@@ -26,7 +26,7 @@ import org.apiguardian.api.API.Status;
  * A new populated object would be generated when this exception is thrown.
  */
 @API(since = "0.6.0", status = Status.MAINTAINED)
-public final class RetryableFilterMissException extends RuntimeException {
+public final class RetryableFilterMissException extends RetryableException {
 	public RetryableFilterMissException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -26,12 +26,14 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet;
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet;
+import com.navercorp.fixturemonkey.api.introspector.AnonymousArgumentConstructorIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.ArrayIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.EnumIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IterableIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IteratorIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaArbitraryIntrospector;
@@ -157,7 +159,12 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 					new JavaTimeArbitraryIntrospector(this.javaTimeArbitraryGeneratorSet),
 					this.priorityIntrospector,
 					this.containerIntrospector,
-					this.objectIntrospector,
+					new FailoverIntrospector(
+						Arrays.asList(
+							this.objectIntrospector,
+							AnonymousArgumentConstructorIntrospector.INSTANCE
+						)
+					),
 					this.fallbackIntrospector
 				)
 			)

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/AnonymousArgumentConstructorIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/AnonymousArgumentConstructorIntrospector.java
@@ -1,0 +1,83 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorArbitraryIntrospector.ConstructorWithParameterNames;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
+import com.navercorp.fixturemonkey.api.type.TypeCache;
+import com.navercorp.fixturemonkey.api.type.Types;
+
+@API(since = "1.0.10", status = Status.EXPERIMENTAL)
+public final class AnonymousArgumentConstructorIntrospector implements ArbitraryIntrospector {
+	public static final AnonymousArgumentConstructorIntrospector INSTANCE =
+		new AnonymousArgumentConstructorIntrospector();
+
+	private static final ConcurrentLruCache<Class<?>, ConstructorArbitraryIntrospector> introspectorsByType =
+		new ConcurrentLruCache<>(2048);
+	private static final Logger LOGGER = LoggerFactory.getLogger(AnonymousArgumentConstructorIntrospector.class);
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		Class<?> type = Types.getActualType(context.getResolvedType());
+
+		LOGGER.info(
+			"Type {} is generated. But it cannot be manipulated. "
+				+ "If you want to, You have to use a custom ConstructorParameterPropertyGenerator.",
+			type
+		);
+		return getConstructorArbitraryIntrospector(type).introspect(context);
+	}
+
+	private static ConstructorArbitraryIntrospector getConstructorArbitraryIntrospector(Class<?> type) {
+		return introspectorsByType.computeIfAbsent(
+			type,
+			clazz -> {
+				Constructor<?> constructor = TypeCache.getDeclaredConstructors(clazz).stream()
+					.findFirst()
+					.orElseThrow(
+						() -> new IllegalArgumentException("Given type " + clazz.getTypeName() + " has no constructor.")
+					);
+
+				return new ConstructorArbitraryIntrospector(
+					new ConstructorWithParameterNames<>(
+						constructor,
+						Collections.emptyList()
+					)
+				);
+			}
+		);
+	}
+
+	@Override
+	public PropertyGenerator getRequiredPropertyGenerator(Property property) {
+		Class<?> type = Types.getActualType(property.getType());
+		return getConstructorArbitraryIntrospector(type).getRequiredPropertyGenerator(property);
+	}
+}

--- a/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
+++ b/fixture-monkey-jackson/src/main/java/com/navercorp/fixturemonkey/jackson/introspector/JacksonObjectArbitraryIntrospector.java
@@ -48,9 +48,11 @@ import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.property.CompositeProperty;
 import com.navercorp.fixturemonkey.api.property.ConstructorProperty;
+import com.navercorp.fixturemonkey.api.property.DefaultPropertyGenerator;
 import com.navercorp.fixturemonkey.api.property.FieldProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyDescriptorProperty;
+import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
 import com.navercorp.fixturemonkey.api.type.Types;
 import com.navercorp.fixturemonkey.jackson.FixtureMonkeyJackson;
 import com.navercorp.fixturemonkey.jackson.type.JacksonTypeReference;
@@ -211,5 +213,10 @@ public final class JacksonObjectArbitraryIntrospector implements ArbitraryIntros
 		return property instanceof FieldProperty
 			|| property instanceof PropertyDescriptorProperty
 			|| property instanceof ConstructorProperty;
+	}
+
+	@Override
+	public PropertyGenerator getRequiredPropertyGenerator(Property property) {
+		return new DefaultPropertyGenerator();
 	}
 }

--- a/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-jakarta-validation/src/test/java/com/navercorp/fixturemonkey/jakarta/validation/JakartaValidationFixtureMonkeyTest.java
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 import com.navercorp.fixturemonkey.jakarta.validation.spec.BigDecimalIntrospectorSpec;
 import com.navercorp.fixturemonkey.jakarta.validation.spec.BigIntegerIntrospectorSpec;
@@ -481,8 +480,7 @@ class JakartaValidationFixtureMonkeyTest {
 				.setNull("notBlank")
 				.sample()
 		)
-			.getCause()
-			.isExactlyInstanceOf(RetryableFilterMissException.class)
+			.isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("failed due to property \"not");
 	}
 }

--- a/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
+++ b/fixture-monkey-javax-validation/src/test/java/com/navercorp/fixturemonkey/javax/validation/JavaxValidationFixtureMonkeyTest.java
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 import net.jqwik.api.Property;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin;
 import com.navercorp.fixturemonkey.javax.validation.spec.BigDecimalIntrospectorSpec;
 import com.navercorp.fixturemonkey.javax.validation.spec.BigIntegerIntrospectorSpec;
@@ -481,8 +480,7 @@ class JavaxValidationFixtureMonkeyTest {
 				.setNull("notBlank")
 				.sample()
 		)
-			.getCause()
-			.isExactlyInstanceOf(RetryableFilterMissException.class)
+			.isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("failed due to property \"not");
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -22,6 +22,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.api.experimental.JavaGetterMethodPropertySelector.javaGetter
 import com.navercorp.fixturemonkey.api.experimental.TypedExpressionGenerator.typedRoot
+import com.navercorp.fixturemonkey.api.introspector.AnonymousArgumentConstructorIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.FactoryMethodArbitraryIntrospector
@@ -289,6 +290,26 @@ class KotlinTest {
         val actual: String = sut.giveMeOne()
 
         then(actual).isEqualTo(expected)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun sampleByAnonymousArgumentConstructorIntrospector() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(AnonymousArgumentConstructorIntrospector.INSTANCE)
+            .build()
+
+        val actual: kotlin.time.Duration = sut.giveMeOne()
+
+        then(actual).isNotNull
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun sampleByFallbackIntrospector() {
+        class DurationObject(val duration: kotlin.time.Duration)
+
+        val actual = SUT.giveMeOne<DurationObject>().duration
+
+        then(actual).isNotNull
     }
 
     companion object {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
@@ -28,7 +28,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.exception.ContainerSizeFilterMissException;
 import com.navercorp.fixturemonkey.api.exception.FixedValueFilterMissException;
-import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
+import com.navercorp.fixturemonkey.api.exception.RetryableException;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.validator.ArbitraryValidator;
@@ -78,7 +78,7 @@ final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 			} catch (ContainerSizeFilterMissException ex) {
 				lastException = ex;
 				objectTree.clear();
-			} catch (FixedValueFilterMissException | RetryableFilterMissException ex) {
+			} catch (FixedValueFilterMissException | RetryableException ex) {
 				lastException = ex;
 			} finally {
 				arbitrary.clear();
@@ -105,7 +105,7 @@ final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 			} catch (ContainerSizeFilterMissException ex) {
 				lastException = ex;
 				objectTree.clear();
-			} catch (FixedValueFilterMissException | RetryableFilterMissException ex) {
+			} catch (FixedValueFilterMissException | RetryableException ex) {
 				lastException = ex;
 			} finally {
 				arbitrary.clear();


### PR DESCRIPTION
## Summary
Add AnonymousArgumentConstructorIntrospector as a default fallback introspector

## How Has This Been Tested?
* sampleByAnonymousArgumentConstructorIntrospector
* sampleByFallbackIntrospector

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*
