### PR TITLE
Add fixture-monkey page of generating-objects section for kor doc

### DIFF
--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -33,15 +33,15 @@ val fixtureMonkey = FixtureMonkey
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-+ options...
-.build();
+    + options...
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-+ options...
-.build()
+    + options...
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -8,5 +8,203 @@ identifier: "fixturemonkey"
 weight: 31
 ---
 
-### 한국어 번역 필요
+To generate test fixtures, the first step is to create a `FixtureMonkey` instance, which facilitates the creation of test fixtures.
+
+You can use the `create()` method to generate a `FixtureMonkey` instance with default options.
+For Kotlin environments, add the Kotlin plugin.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.create();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey
+.plugin(KotlinPlugin())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+If you want to add some options for creating or customizing the test fixtures, you can add them using the FixtureMonkey builder.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
++ options...
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
++ options...
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For information on what options are available, see the [Fixture Monkey Options section](../../fixture-monkey-options/options).
+
+## Generating instances
+
+The `FixtureMonkey` class provides several methods to help create test objects of the required type.
+
+
+### giveMeOne()
+If you need an instance of a certain type, you can use `giveMeOne()`. Pass either a class or a type reference.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = fixtureMonkey.giveMeOne(Product.class);
+
+List<String> strList = fixtureMonkey.giveMeOne(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product: Product = fixtureMonkey.giveMeOne()
+
+val strList: List<String> = fixtureMonkey.giveMeOne()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### giveMe()
+If you need multiple instances of a certain type, you can use the `giveMe()` method.
+You can choose to generate either a stream of instances or a list by specifying the desired size.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Stream<Product> productStream = fixtureMonkey.giveMe(Product.class);
+
+Stream<List<String>> strListStream = fixtureMonkey.giveMe(new TypeReference<List<String>>() {});
+
+List<Product> productList = fixtureMonkey.giveMe(Product.class, 3);
+
+List<List<String>> strListList = fixtureMonkey.giveMe(new TypeReference<List<String>>() {}, 3);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productSequence: Sequence<Product> = fixtureMonkey.giveMe()
+
+val strListSequence: Sequence<List<String>> = fixtureMonkey.giveMe()
+
+val productList: List<Product> = fixtureMonkey.giveMe(3)
+
+val strListList: List<List<String>> = fixtureMonkey.giveMe(3)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeBuilder()
+If you need to further customize the instance to be created, you can use `giveMeBuilder()`. This will return an `ArbitraryBuilder` of the given type.
+An `ArbitraryBuilder` is a class in Fixture Monkey that acts as a builder for an [`Arbitrary`](../arbitrary) object of the given class.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+ArbitraryBuilder<List<String>> strListBuilder = fixtureMonkey.giveMeBuilder(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val strListBuilder: ArbitraryBuilder<List<String>> = fixtureMonkey.giveMeBuilder()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For cases where you already have a generated instance and want to customize it further, you can also use `giveMeBuilder()`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = new Product(1L, "Book", ...);
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(product);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product = Product(1L, "Book", ...)
+
+val productBuilder = fixtureMonkey.giveMeBuilder(product)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+The generated `ArbitraryBuilder` can be used for further customization of your fixture. For more information on customization options, see the [section on customization objects](../../customizing-objects/apis).
+
+To obtain an instance from the `ArbitraryBuilder`, you can use the `sample()`, `sampleList()`, `sampleStream()` methods of the `ArbitraryBuilder`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Product product = productBuilder.sample();
+List<Product> productList = productBuilder.sampleList(3);
+Stream<Product> productStream = productBuilder.sampleStream();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val product = productBuilder.sample()
+val productList = productBuilder.sampleList(3)
+val productStream = productBuilder.sampleStream()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+In cases where you need an `Arbitrary` itself rather than an instance, you can simply call the `build()` method.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Arbitrary<Product> productArbitrary = productBuilder.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val productArbitrary = productBuilder.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeArbitrary()
+To get an `Arbitrary` of the specified type, you can use the `giveMeArbitrary()` method.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Arbitrary<Product> productArbitrary = fixtureMonkey.giveMeArbitrary(Product.class);
+
+Arbitrary<List<String>> strListArbitrary = fixtureMonkey.giveMeArbitrary(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productArbitrary: Arbitrary<Product> = fixtureMonkey.giveMeArbitrary()
+
+val strListArbitrary: Arbitrary<List<String>> = fixtureMonkey.giveMeArbitrary()
+
+{{< /tab >}}
+{{< /tabpane>}}
 

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -8,10 +8,9 @@ identifier: "fixturemonkey"
 weight: 31
 ---
 
-To generate test fixtures, the first step is to create a `FixtureMonkey` instance, which facilitates the creation of test fixtures.
+테스트 픽스처를 생성하기 위해서는 우선 `FixtureMonkey` 인스턴스를 생성해야 합니다. 해당 인스턴스는 테스트 픽스처 생성에 도움을 줍니다.
 
-You can use the `create()` method to generate a `FixtureMonkey` instance with default options.
-For Kotlin environments, add the Kotlin plugin.
+`FixtureMonkey` 인스턴스를 생성하기 위해서는 `create()` 메서드를 사용하면 됩니다. Kotlin 환경에서는 Kotlin 플러그인을 추가해야 합니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -28,7 +27,7 @@ val fixtureMonkey = FixtureMonkey
 {{< /tab >}}
 {{< /tabpane>}}
 
-If you want to add some options for creating or customizing the test fixtures, you can add them using the FixtureMonkey builder.
+테스트 픽스터를 생성하거나 커스텀하기 위해서는 FixtureMonkey 빌더를 사용하여 옵션을 추가할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -47,7 +46,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-For information on what options are available, see the [Fixture Monkey Options section](../../fixture-monkey-options/options).
+어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey Options section](../../fixture-monkey-options/options)을 참고하십시오.
 
 ## Generating instances
 

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -46,14 +46,14 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey 옵션](../../fixture-monkey-options/options)을 참고하십시오.
+어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey 옵션](../../fixture-monkey-options/options)을 참고해주세요.
 
 ## 인스턴스 생성
 
 `FixtureMonkey` 클래스는 테스트에 필요한 객체 생성에 도움 되는 메서드를 제공합니다.
 
 ### giveMeOne()
-특정 타입의 인스턴스가 필요하다면 `giveMeOne()`을 사용할 수 있습니다. 인자로 클래스 또는 타입을 전달하십시오.
+특정 타입의 인스턴스가 필요하다면 `giveMeOne()`을 사용할 수 있습니다. 인자로 클래스 또는 타입을 전달해주세요.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -188,7 +188,7 @@ val productArbitrary = productBuilder.build()
 ### giveMeArbitrary()
 특정한 유형의 `Arbitrary`를 얻으려면 `giveMeArbitrary()` 메서드를 사용할 수 있습니다.
 
-{{< tabpane per휘 ㅇsist=false >}}
+{{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
 
 Arbitrary<Product> productArbitrary = fixtureMonkey.giveMeArbitrary(Product.class);

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -46,11 +46,11 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey Options section](../../fixture-monkey-options/options)을 참고하십시오.
+어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey 옵션](../../fixture-monkey-options/options)을 참고하십시오.
 
 ## 인스턴스 생성
 
-`FixtureMonkey` 클래스는 테스트에 필요한 객체를 생성하는데 도움이 되는 메서드를 제공합니다.
+`FixtureMonkey` 클래스는 테스트에 필요한 객체 생성에 도움 되는 메서드를 제공합니다.
 
 ### giveMeOne()
 특정 타입의 인스턴스가 필요하다면 `giveMeOne()`을 사용할 수 있습니다. 인자로 클래스 또는 타입을 전달하십시오.
@@ -143,7 +143,7 @@ val productBuilder = fixtureMonkey.giveMeBuilder(product)
 
 `ArbitraryBuilder`는 픽스처를 커스텀하는 데 사용될 수 있습니다. 커스텀 옵션에 대한 자세한 내용은 [커스텀 객체](../../customizing-objects/apis)를 참고하십시오.
 
-`ArbitraryBuilder`에서 인스턴스를 얻으려면 `ArbitraryBuilder`의 `sample()`, `sampleList()`, `sampleStream()` 메서드를 사용할 수 있습니다.
+`ArbitraryBuilder`에서 인스턴스를 얻기 위해 `ArbitraryBuilder`의 `sample()`, `sampleList()`, `sampleStream()` 메서드를 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -188,7 +188,7 @@ val productArbitrary = productBuilder.build()
 ### giveMeArbitrary()
 특정한 유형의 `Arbitrary`를 얻으려면 `giveMeArbitrary()` 메서드를 사용할 수 있습니다.
 
-{{< tabpane persist=false >}}
+{{< tabpane per휘 ㅇsist=false >}}
 {{< tab header="Java" lang="java">}}
 
 Arbitrary<Product> productArbitrary = fixtureMonkey.giveMeArbitrary(Product.class);

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -27,7 +27,7 @@ val fixtureMonkey = FixtureMonkey
 {{< /tab >}}
 {{< /tabpane>}}
 
-테스트 픽스터를 생성하거나 커스텀하기 위해서는 FixtureMonkey 빌더를 사용하여 옵션을 추가할 수 있습니다.
+테스트 픽스처를 생성하거나 커스텀하기 위해서는 FixtureMonkey 빌더를 사용하여 옵션을 추가할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -48,13 +48,12 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey Options section](../../fixture-monkey-options/options)을 참고하십시오.
 
-## Generating instances
+## 인스턴스 생성
 
-The `FixtureMonkey` class provides several methods to help create test objects of the required type.
-
+`FixtureMonkey` 클래스는 테스트에 필요한 객체를 생성하는데 도움이 되는 메서드를 제공합니다.
 
 ### giveMeOne()
-If you need an instance of a certain type, you can use `giveMeOne()`. Pass either a class or a type reference.
+특정 타입의 인스턴스가 필요하다면 `giveMeOne()`을 사용할 수 있습니다. 인자로 클래스 또는 타입을 전달하십시오.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -75,8 +74,7 @@ val strList: List<String> = fixtureMonkey.giveMeOne()
 
 
 ### giveMe()
-If you need multiple instances of a certain type, you can use the `giveMe()` method.
-You can choose to generate either a stream of instances or a list by specifying the desired size.
+특정한 타입으로 고정된 두 개 이상의 인스턴스가 필요하다면 `giveMe()`를 사용할 수 있습니다. 원하는 크기를 지정하여 인스턴스의 스트림 또는 리스트를 생성할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -104,8 +102,8 @@ val strListList: List<List<String>> = fixtureMonkey.giveMe(3)
 {{< /tabpane>}}
 
 ### giveMeBuilder()
-If you need to further customize the instance to be created, you can use `giveMeBuilder()`. This will return an `ArbitraryBuilder` of the given type.
-An `ArbitraryBuilder` is a class in Fixture Monkey that acts as a builder for an [`Arbitrary`](../arbitrary) object of the given class.
+인스턴스를 커스텀 할 경우 `giveMeBuilder()`를 사용할 수 있습니다. 이는 주어진 타입의 `ArbitraryBuilder`를 반환합니다.
+`ArbitraryBuilder`는 주어진 클래스의 [`Arbitrary`](../arbitrary) 객체를 빌드하는 데 사용되는 Fixture Monkey의 클래스입니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -124,7 +122,7 @@ val strListBuilder: ArbitraryBuilder<List<String>> = fixtureMonkey.giveMeBuilder
 {{< /tab >}}
 {{< /tabpane>}}
 
-For cases where you already have a generated instance and want to customize it further, you can also use `giveMeBuilder()`.
+이미 생성된 인스턴에 추가로 커스텀하는 경우 `giveMeBuilder()`를 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -143,9 +141,9 @@ val productBuilder = fixtureMonkey.giveMeBuilder(product)
 {{< /tab >}}
 {{< /tabpane>}}
 
-The generated `ArbitraryBuilder` can be used for further customization of your fixture. For more information on customization options, see the [section on customization objects](../../customizing-objects/apis).
+`ArbitraryBuilder`는 픽스처를 커스텀하는 데 사용될 수 있습니다. 커스텀 옵션에 대한 자세한 내용은 [커스텀 객체](../../customizing-objects/apis)를 참고하십시오.
 
-To obtain an instance from the `ArbitraryBuilder`, you can use the `sample()`, `sampleList()`, `sampleStream()` methods of the `ArbitraryBuilder`.
+`ArbitraryBuilder`에서 인스턴스를 얻으려면 `ArbitraryBuilder`의 `sample()`, `sampleList()`, `sampleStream()` 메서드를 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -168,7 +166,7 @@ val productStream = productBuilder.sampleStream()
 {{< /tab >}}
 {{< /tabpane>}}
 
-In cases where you need an `Arbitrary` itself rather than an instance, you can simply call the `build()` method.
+인스턴스가 아닌 임의 객체(`Arbitrary`)만 필요한 경우 옵션을 추가하지 않고 `build()` 메서드만 호출하면 됩니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -188,7 +186,7 @@ val productArbitrary = productBuilder.build()
 {{< /tabpane>}}
 
 ### giveMeArbitrary()
-To get an `Arbitrary` of the specified type, you can use the `giveMeArbitrary()` method.
+특정한 유형의 `Arbitrary`를 얻으려면 `giveMeArbitrary()` 메서드를 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -8,7 +8,7 @@ identifier: "fixturemonkey"
 weight: 31
 ---
 
-테스트 픽스처를 생성하기 위해서는 우선 `FixtureMonkey` 인스턴스를 생성해야 합니다. 해당 인스턴스는 테스트 픽스처 생성에 도움을 줍니다.
+테스트 픽스처를 생성하기 위해서는 우선 `FixtureMonkey` 인스턴스를 생성해야 합니다. 해당 인스턴스는 테스트 픽스쳐 생성을 담당합니다.
 
 `FixtureMonkey` 인스턴스를 생성하기 위해서는 `create()` 메서드를 사용하면 됩니다. Kotlin 환경에서는 Kotlin 플러그인을 추가해야 합니다.
 


### PR DESCRIPTION
## Summary

Translating the fixture-monkey page of generating-objects section into Korean

related to https://github.com/naver/fixture-monkey/issues/864

## (Optional): Description

The process of creating a fixureMonkey instance for creating a text fixture was documented.


## How Has This Been Tested?

I copied the English document and then compared it one by one and translated it.

## Is the Document updated?

We do not update the document because it is a request for Korean translation.


