### PR TITLE
Refactor does not throw exception when it cannot generate

### DIFF
--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -9,6 +9,8 @@ sectionStart
 ### v.1.0.10
 Fix setting object field by any other type.
 
+Refactor does not throw exception when it cannot generate, the next ArbitraryIntrospector will be used.
+
 sectionEnd
 
 sectionStart

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
@@ -32,6 +32,8 @@ import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
@@ -54,6 +56,8 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 		it -> true
 	);
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(ConstructorPropertiesArbitraryIntrospector.class);
+
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		Property property = context.getResolvedProperty();
@@ -64,8 +68,12 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 
 		Entry<Constructor<?>, String[]> parameterNamesByConstructor = TypeCache.getParameterNamesByConstructor(type);
 		if (parameterNamesByConstructor == null) {
-			throw new IllegalArgumentException(
-				"Primary Constructor does not exist. type " + type.getSimpleName());
+			LOGGER.warn(
+				"Given type {} is failed to generate due to the exception. It may be null.",
+				type,
+				new IllegalArgumentException("Primary Constructor does not exist. type " + type.getSimpleName())
+			);
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 
 		Constructor<?> primaryConstructor = parameterNamesByConstructor.getKey();

--- a/fixture-monkey-tests/kotlin-tests/build.gradle.kts
+++ b/fixture-monkey-tests/kotlin-tests/build.gradle.kts
@@ -10,4 +10,6 @@ dependencies {
     testImplementation(project(":fixture-monkey-javax-validation"))
     testImplementation("io.kotest:kotest-runner-junit5:${Versions.KOTEST}")
     testImplementation("io.kotest:kotest-assertions-core:${Versions.KOTEST}")
+    testImplementation("org.projectlombok:lombok:${Versions.LOMBOK}")
+    testAnnotationProcessor("org.projectlombok:lombok:${Versions.LOMBOK}")
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/java/com/navercorp/fixturemonkey/tests/kotlin/BuilderJavaTestSpecs.java
+++ b/fixture-monkey-tests/kotlin-tests/src/test/java/com/navercorp/fixturemonkey/tests/kotlin/BuilderJavaTestSpecs.java
@@ -1,0 +1,28 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.kotlin;
+
+import lombok.Builder;
+
+class BuilderJavaTestSpecs {
+	@Builder(buildMethodName = "notBuild")
+	public static class BuilderObjectCustomBuildName {
+		private final String string;
+	}
+}

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -22,10 +22,14 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.api.experimental.JavaGetterMethodPropertySelector.javaGetter
 import com.navercorp.fixturemonkey.api.experimental.TypedExpressionGenerator.typedRoot
+import com.navercorp.fixturemonkey.api.introspector.AnonymousArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.FactoryMethodArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.type.Types.GeneratingWildcardType
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.get
@@ -41,6 +45,7 @@ import com.navercorp.fixturemonkey.kotlin.setExpGetter
 import com.navercorp.fixturemonkey.kotlin.sizeExp
 import com.navercorp.fixturemonkey.kotlin.sizeExpGetter
 import com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT
+import com.navercorp.fixturemonkey.tests.kotlin.BuilderJavaTestSpecs.BuilderObjectCustomBuildName
 import com.navercorp.fixturemonkey.tests.kotlin.ImmutableJavaTestSpecs.ArrayObject
 import com.navercorp.fixturemonkey.tests.kotlin.ImmutableJavaTestSpecs.NestedArrayObject
 import com.navercorp.fixturemonkey.tests.kotlin.JavaConstructorTestSpecs.JavaTypeObject
@@ -48,6 +53,7 @@ import org.assertj.core.api.BDDAssertions.then
 import org.assertj.core.api.BDDAssertions.thenThrownBy
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -179,9 +185,11 @@ class KotlinTest {
             .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
             .build()
 
-        // when, then
-        thenThrownBy { sut.giveMeOne<ConstructorWithoutAnyAnnotations>() }
-            .hasMessageContaining("Primary Constructor does not exist.")
+        // when
+        val actual: ConstructorWithoutAnyAnnotations = sut.giveMeOne()
+
+        // then
+        then(actual).isNull()
     }
 
     @Test
@@ -306,6 +314,79 @@ class KotlinTest {
 
         // then
         then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun primaryConstructorArbitraryIntrospectorNotThrows() {
+        val actual: Timestamp = SUT.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun beanArbitraryIntrospectorNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: Timestamp = sut.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun fieldReflectionArbitraryIntrospectorNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: Timestamp = sut.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun constructorPropertiesArbitraryIntrospectorNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: Timestamp = sut.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun anonymousArbitraryIntrospectorNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(AnonymousArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: Timestamp = sut.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun builderArbitraryIntrospectorNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: Timestamp = sut.giveMeOne()
+
+        then(actual).isNull()
+    }
+
+    @Test
+    fun builderArbitraryIntrospectorMissBuildMethodNotThrows() {
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+            .build()
+
+        val actual: BuilderObjectCustomBuildName = sut.giveMeOne()
+
+        then(actual).isNull()
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Refactor does not throw exception when it cannot generate

## (Optional): Description
The next ArbitraryIntrospector will be used

## How Has This Been Tested?
* primaryConstructorArbitraryIntrospectorNotThrows
* beanArbitraryIntrospectorNotThrows
* constructorPropertiesArbitraryIntrospectorNotThrows
* anonymousArbitraryIntrospectorNotThrows
* builderArbitraryIntrospectorNotThrows
* builderArbitraryIntrospectorMissBuildMethodNotThrows

## Is the Document updated?
Yes
