### PR TITLE
Fix mutation of a generated object by FieldReflection, BeanArbitraryIntrospector

### DIFF
--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -6,6 +6,12 @@ docs:
 weight: 100
 ---
 sectionStart
+### v.1.0.11
+Fix mutation of a generated object by FieldReflection, BeanArbitraryIntrospector
+
+sectionEnd
+
+sectionStart
 ### v.1.0.10
 Fix setting object field by any other type.
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -63,11 +63,12 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 		CombinableArbitrary<?> generated = context.getGenerated();
 		if (generated == CombinableArbitrary.NOT_GENERATED) {
 			try {
-				generated = CombinableArbitrary.from(Reflections.newInstance(type));
+				checkPrerequisite(type);
 			} catch (Exception ex) {
 				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
+			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));
 		}
 
 		Map<String, PropertyDescriptor> propertyDescriptorsByPropertyName =
@@ -79,6 +80,10 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 					.build(combine(generated::combined, propertyDescriptorsByPropertyName))
 			)
 		);
+	}
+
+	private void checkPrerequisite(Class<?> type) {
+		Reflections.newInstance(type);
 	}
 
 	private Function<Map<ArbitraryProperty, Object>, Object> combine(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -59,11 +59,12 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 		CombinableArbitrary<?> generated = context.getGenerated();
 		if (generated == CombinableArbitrary.NOT_GENERATED) {
 			try {
-				generated = CombinableArbitrary.from(Reflections.newInstance(type));
+				checkPrerequisite(type);
 			} catch (Exception ex) {
 				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
+			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));
 		}
 
 		Map<String, Field> fieldsByPropertyName = TypeCache.getFieldsByName(type);
@@ -74,6 +75,10 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 					.build(combine(generated::combined, fieldsByPropertyName))
 			)
 		);
+	}
+
+	private void checkPrerequisite(Class<?> type) {
+		Reflections.newInstance(type);
 	}
 
 	private Function<Map<ArbitraryProperty, Object>, Object> combine(

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -50,6 +50,7 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
@@ -81,6 +82,7 @@ import com.navercorp.fixturemonkey.tests.java.ImmutableRecursiveTypeSpecs.SelfRe
 import com.navercorp.fixturemonkey.tests.java.ImmutableRecursiveTypeSpecs.SelfRecursiveMapObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableRecursiveTypeSpecs.SelfRecursiveObject;
 import com.navercorp.fixturemonkey.tests.java.NestedClassTestSpecs.Inner;
+import com.navercorp.fixturemonkey.tests.java.NoArgsConstructorJavaTestSpecs.NestedObject;
 
 @SuppressWarnings("rawtypes")
 class JavaTest {
@@ -1170,5 +1172,41 @@ class JavaTest {
 			.collect(Collectors.toList());
 
 		then(actual).allMatch(expected::equals);
+	}
+
+	@Test
+	void beanArbitraryIntrospectorSampleTwiceResultNotMutated() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+			.defaultNotNull(true)
+			.build();
+		NestedObject stringObject = sut.giveMeOne(NestedObject.class);
+		String actual = stringObject.getObject().getValue();
+
+		// when
+		sut.giveMeOne(NestedObject.class);
+
+		// then
+		String expected = stringObject.getObject().getValue();
+		then(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void fieldReflectionArbitraryIntrospectorSampleTwiceResultNotMutated() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+			.defaultNotNull(true)
+			.build();
+		NestedObject stringObject = sut.giveMeOne(NestedObject.class);
+		String actual = stringObject.getObject().getValue();
+
+		// when
+		sut.giveMeOne(NestedObject.class);
+
+		// then
+		String expected = stringObject.getObject().getValue();
+		then(actual).isEqualTo(expected);
 	}
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/NoArgsConstructorJavaTestSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/NoArgsConstructorJavaTestSpecs.java
@@ -30,4 +30,18 @@ class NoArgsConstructorJavaTestSpecs {
 		private Boolean wrapperBoolean;
 		private Enum enumValue;
 	}
+
+	@NoArgsConstructor
+	@Getter
+	@Setter
+	public static class StringObject {
+		private String value;
+	}
+
+	@NoArgsConstructor
+	@Getter
+	@Setter
+	public static class NestedObject {
+		private StringObject object;
+	}
 }


### PR DESCRIPTION
## Summary
Fix mutation of a generated object by FieldReflection, BeanArbitraryIntrospector

## How Has This Been Tested?
* beanArbitraryIntrospectorSampleTwiceResultNotMutated
* fieldReflectionArbitraryIntrospectorSampleTwiceResultNotMutated

## Is the Document updated?
Yes 
