### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/v1.0.x/docs/get-started/creating-objects-in-kotlin.md
+++ b/docs/content/v1.0.x/docs/get-started/creating-objects-in-kotlin.md
@@ -9,7 +9,7 @@ identifier: "creating-objects-in-kotlin"
 
 Fixture Monkey also supports generating classes written in Kotlin code.
 
-In order to do this, first make sure you added the `fixture-monkey-kotlin-starter` dependency.
+In order to do this, first make sure you added the `fixture-monkey-starter-kotlin` dependency.
 
 Then we can add the Kotlin Plugin, to enable additional features of fixture monkey that support using Kotlin.
 

--- a/docs/content/v1.0.x/docs/plugins/kotlin-plugin/features.md
+++ b/docs/content/v1.0.x/docs/plugins/kotlin-plugin/features.md
@@ -32,7 +32,7 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:{{< fixtur
 
 ##### fixture-monkey-starter-kotlin
 
-To help you get started using Fixture Monkey in a Kotlin environment, there is also a starter dependency **fixture-monkey-kotlin-starter** that comes with pre-configured dependencies such as **fixture-monkey-starter** or **fixture-monkey-jakarta-validation**.
+To help you get started using Fixture Monkey in a Kotlin environment, there is also a starter dependency **fixture-monkey-starter-kotlin** that comes with pre-configured dependencies such as **fixture-monkey-starter** or **fixture-monkey-jakarta-validation**.
 
 #### Gradle
 ```groovy

--- a/docs/content/v1.0.x/docs/plugins/kotlin-plugin/kotlin-exp.md
+++ b/docs/content/v1.0.x/docs/plugins/kotlin-plugin/kotlin-exp.md
@@ -49,7 +49,7 @@ data class KotlinClass(
 }
 ```
 
-To use Kotlin Exp to reference a property, you need to use the `Exp` or `ExpGetter` suffix to the normal [Fixture Customization APIs]((../../customizing-objects/apis).
+To use Kotlin Exp to reference a property, you need to use the `Exp` or `ExpGetter` suffix to the normal [Fixture Customization APIs](../../../customizing-objects/apis).
 
 Let's look at the example of customizing properties with Kotlin Exp using `setExp()` and `setExpGetter()`.
 


### PR DESCRIPTION
## Summary

- fix wrong markdown link in docs
- change dependency name for kotlin starter in docs

