### PR TITLE
Add generating-complex-types page of generating-objects section for kor doc

### DIFF
--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -8,7 +8,7 @@ identifier: "generating-complex-types"
 weight: 32
 ---
 
-Fixture Monkey는 생성하기 어려운 객체를 테스트 픽스처로 쉽게 생성할 수 있습니다.
+Fixture Monkey는 생성하기 어려울 정도로 복잡한 객체를 테스트 픽스처로 쉽게 생성할 수 있습니다.
 
 이 페이지는 생성할 수 있는 다양한 타입의 객체를 보여줍니다.
 

--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -8,4 +8,120 @@ identifier: "generating-complex-types"
 weight: 32
 ---
 
-### 한국어 번역 필요
+Fixture Monkey is capable of generating complex objects that are difficult to create as test fixtures.
+
+This page contains examples of the various types of objects that can be generated.
+
+## Java
+### Generic Objects
+```java
+@Value
+public static class GenericObject<T> {
+   T foo;
+}
+
+@Value
+public static class GenericArrayObject<T> {
+   GenericObject<T>[] foo;
+}
+
+@Value
+public static class TwoGenericObject<T, U> {
+   T foo;
+   U bar;
+}
+
+@Value
+public static class ThreeGenericObject<T, U, V> {
+   T foo;
+   U bar;
+   V baz;
+}
+```
+
+### Generic Interfaces
+```java
+public interface GenericInterface<T> {
+}
+
+@Value
+public static class GenericInterfaceImpl<T> implements GenericInterface<T> {
+   T foo;
+}
+
+public interface TwoGenericInterface<T, U> {
+}
+
+@Value
+public static class TwoGenericImpl<T, U> implements TwoGenericInterface<T, U> {
+   T foo;
+
+   U bar;
+}
+```
+
+### SelfReference
+```java
+@Value
+public class SelfReference {
+   String foo;
+   SelfReference bar;
+}
+
+@Value
+public class SelfReferenceList {
+   String foo;
+   List<SelfReferenceList> bar;
+}
+```
+
+### Interface
+```java
+public interface Interface {
+   String foo();
+
+   Integer bar();
+}
+
+public interface InheritedInterface extends Interface {
+   String foo();
+}
+
+public interface InheritedInterfaceWithSameNameMethod extends Interface {
+   String foo();
+}
+
+public interface ContainerInterface {
+   List<String> baz();
+
+   Map<String, Integer> qux();
+}
+
+public interface InheritedTwoInterface extends Interface, ContainerInterface {
+}
+```
+
+## Kotlin
+### Generic Objects
+```kotlin
+class Generic<T>(val foo: T)
+
+class GenericImpl(val foo: Generic<String>)
+```
+
+### SelfReference
+```kotlin
+class SelfReference(val foo: String, val bar: SelfReference?)
+```
+
+### Sealed class, Value class
+```kotlin
+sealed class SealedClass
+
+object ObjectSealedClass : SealedClass()
+
+class SealedClassImpl(val foo: String) : SealedClass()
+
+@JvmInline
+value class ValueClass(val foo: String)
+```

--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -8,7 +8,7 @@ identifier: "generating-complex-types"
 weight: 32
 ---
 
-Fixture Monkey는 생성하기 어려울 정도로 복잡한 객체를 테스트 픽스처로 쉽게 생성할 수 있습니다.
+Fixture Monkey는 직접 생성하기 어려운 복잡한 객체도 테스트 픽스처로 쉽게 생성할 수 있습니다.
 
 이 페이지는 생성할 수 있는 다양한 타입의 객체를 보여줍니다.
 

--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -8,9 +8,9 @@ identifier: "generating-complex-types"
 weight: 32
 ---
 
-Fixture Monkey is capable of generating complex objects that are difficult to create as test fixtures.
+Fixture Monkey는 생성하기 어려운 객체를 테스트 픽스처로 쉽게 생성할 수 있습니다.
 
-This page contains examples of the various types of objects that can be generated.
+이 페이지는 생성할 수 있는 다양한 타입의 객체를 보여줍니다.
 
 ## Java
 ### Generic Objects


### PR DESCRIPTION
## Summary

Translating generating-complex-types page of generating-objects section into Korean

related to https://github.com/naver/fixture-monkey/issues/864

## (Optional): Description

We were translating about how to create a complex object. 
There were two lines of text to translate.

## How Has This Been Tested?

Using command `npm start`

## Is the Document updated?

We do not update the document because it is a request for Korean translation.

