### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/v1.0.x/docs/generating-objects/instantiate-methods.md
+++ b/docs/content/v1.0.x/docs/generating-objects/instantiate-methods.md
@@ -21,7 +21,7 @@ If you want to set a global option as the default method for creating all object
 
 The `instantiate()` method is just a convenient way to modify the generation method from the `ArbitraryBuilder`.
 
-## Constuctor
+## Constructor
 Let's say you have a custom class with a few different constructors that looks like this:
 
 {{< tabpane persist=false >}}


### PR DESCRIPTION
## Summary

We found a typo and fixed it.

## (Optional): Description

Fixed a word. Changed the word written as `Constuctor` to `Constructor`.

## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*

Only words were modified.

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*

This is not a case of modifying, so I didn't proceed.
