### PR TITLE
Add introspector page of generating-objects section for kor doc

### DIFF
--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -51,8 +51,8 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ```
 
 ## BuilderArbitraryIntrospector
-To generate a class using the class's builder, you can use `BuilderArbitraryIntrospector`.
-It requires that the class has a builder.
+클래스 빌더를 사용하여 클래스를 생성하려면 `BuilderArbitraryIntrospector`를 사용할 수 있습니다.
+이런 경우 클래스에 빌더가 있어야 합니다.
 
 ```java
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -9,7 +9,7 @@ weight: 33
 ---
 
 [`instantiate`](../instantiate-methods)를 사용하여 `ArbitraryBuilder`에서 객체를 생성하는 방법을 변경할 수 있지만, 전역적으로 객체를 생성하는 방법을 변경하고 싶은 경우가 있을 수 있습니다.
-Fixture Monkey는 다양한 `Introspector`를 제공한 객체 생성 방법을 제공합니다.
+Fixture Monkey는 다양한 `Introspector`를 제공하는 객체 생성 방법을 제공합니다.
 
 `Introspector`는 Fixture Monkey가 객체를 생성하는 기본 방법을 정의합니다.
 각 introspector는 클래스의 인스턴스를 생성할 수 있는 몇 가지 제약 조건이 있습니다.
@@ -17,8 +17,8 @@ Fixture Monkey는 다양한 `Introspector`를 제공한 객체 생성 방법을 
 사용하려는 introspector를 `FixtureMonkey`의 `objectIntrospector` 옵션을 사용하여 변경할 수 있습니다.
 
 ## BeanArbitraryIntrospector
-The `BeanArbitraryIntrospector` is the default introspector that fixture monkey uses for object creation.
-It creates new instances using reflection and the setter method, so the class it creates must have a no-args constructor and setters.
+`BeanArbitraryIntrospector`는 Fixture Monkey가 객체 생성에 사용하는 기본 introspector입니다.
+리플렉션과 setter 메서드를 사용하여 새 인스턴스를 생성하므로 생성할 클래스에는 인자가 없는 생성자(또는 기본생성자)와 setter가 있어야 합니다.
 
 ```java
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -63,7 +63,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ## FailoverArbitraryIntrospector
 프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.
 이 경우 `FailoverArbitraryIntrospector`를 사용할 수 있습니다.
-`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospec속tor`는 계속 다음 introspector로 객체 생성을 시도합니다
+`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospec속tor`는 계속 다음 introspector로 객체 생성을 시도합니다.
 
 ```java
 FixtureMonkey sut = FixtureMonkey.builder()
@@ -78,4 +78,4 @@ FixtureMonkey sut = FixtureMonkey.builder()
 
 ----------------
 
-최근 [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector)와 [`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin) 같은 introspector도 플러그인 내부에 추가 됐습니다.
+플러그인 별로 관련된 introspector도 존재합니다. 예를들어 [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector)와 [`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin)가 존재합니다.

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -78,5 +78,4 @@ FixtureMonkey sut = FixtureMonkey.builder()
 
 ----------------
 
-Additional introspectors have been introduced inside plugins, such as [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector) or
-[`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin)
+최근 [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector)와 [`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin) 같은 introspector도 플러그인 내부에 추가 됐습니다.

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -41,8 +41,8 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ```
 
 ## FieldReflectionArbitraryIntrospector
-`FieldReflectionArbitraryIntrospector` creates new instances with reflection and also sets the fields with reflection.
-So the class to be generated must have a no-args constructor and one of the getters or setters.
+`FieldReflectionArbitraryIntrospector`는 리플렉션을 사용하여 새 인스턴스를 생성하고 필드를 설정합니다.
+따라서 생성할 클래스는 인자가 없는 생성자(또는 기본 생성자)와 getter 또는 setter 중 하나를 가져야 합니다.
 
 ```java
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -8,13 +8,13 @@ identifier: "introspector"
 weight: 33
 ---
 
-While you can change the way an object is created in the `ArbitraryBuilder` with [`instantiate`](../instantiate-methods), there may be cases where you want to change the way objects are created globally.
-Fixture Monkey lets you choose the way you want to create your object by providing different `Introspectors`.
+[`instantiate`](../instantiate-methods)를 사용하여 `ArbitraryBuilder`에서 객체를 생성하는 방법을 변경할 수 있지만, 전역적으로 객체를 생성하는 방법을 변경하고 싶은 경우가 있을 수 있습니다.
+Fixture Monkey는 다양한 `Introspector`를 제공한 객체 생성 방법을 제공합니다.
 
-An `Introspector` defines the default way of how Fixture Monkey creates objects.
-Each introspector has some kind of restrictions that the class must have in order for the introspector to generate instances of that class.
+`Introspector`는 Fixture Monkey가 객체를 생성하는 기본 방법을 정의합니다.
+각 introspector는 클래스의 인스턴스를 생성할 수 있는 몇 가지 제약 조건이 있습니다.
 
-You can change the introspector you use by using the `objectIntrospector` option of Fixture Monkey.
+사용하려는 introspector를 `FixtureMonkey`의 `objectIntrospector` 옵션을 사용하여 변경할 수 있습니다.
 
 ## BeanArbitraryIntrospector
 The `BeanArbitraryIntrospector` is the default introspector that fixture monkey uses for object creation.

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -61,9 +61,9 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ```
 
 ## FailoverArbitraryIntrospector
-Sometimes your production code may contain several classes with different configurations, making it difficult to generate all objects with a single introspector.
-In this case, you can use the `FailoverArbitraryIntrospector`.
-This introspector allows you to use multiple introspectors, and it will continue the introspection even if one of the introspectors fails to generate.
+프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.
+이 경우 `FailoverArbitraryIntrospector`를 사용할 수 있습니다.
+`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospector`는 계속 introspector를 생성합니다.
 
 ```java
 FixtureMonkey sut = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -63,7 +63,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ## FailoverArbitraryIntrospector
 프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.
 이 경우 `FailoverArbitraryIntrospector`를 사용할 수 있습니다.
-`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospec속tor`는 계속 다음 introspector로 객체 생성을 시도합니다.
+`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospector`는 계속 다음 introspector로 객체 생성을 시도합니다.
 
 ```java
 FixtureMonkey sut = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -9,7 +9,7 @@ weight: 33
 ---
 
 [`instantiate`](../instantiate-methods)를 사용하여 `ArbitraryBuilder`에서 객체를 생성하는 방법을 변경할 수 있지만, 전역적으로 객체를 생성하는 방법을 변경하고 싶은 경우가 있을 수 있습니다.
-Fixture Monkey는 다양한 `Introspector`를 제공하는 객체 생성 방법을 제공합니다.
+Fixture Monkey는 다양한 `Introspector`로 객체를 생성하는 방법을 제공합니다.
 
 `Introspector`는 Fixture Monkey가 객체를 생성하는 기본 방법을 정의합니다.
 각 introspector는 클래스의 인스턴스를 생성할 수 있는 몇 가지 제약 조건이 있습니다.
@@ -27,12 +27,12 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ```
 
 ## ConstructorPropertiesArbitraryIntrospector
-To generate an object with its given constructor, you can use `ConstructorPropertiesArbitraryIntrospector`.
+주어진 생성자로 객체를 생성하려면 `ConstructorPropertiesArbitraryIntrospector`를 사용해야 합니다.
 
-For `ConstructorPropertiesArbitraryIntrospector`, the generated class should have a constructor with `@ConstructorProperties` or the class should be a record type.
-(Or, if you are using Lombok, you can add `lombok.anyConstructor.addConstructorProperties=true` to the lombok.config file.)
+`ConstructorPropertiesArbitraryIntrospector`안 경우 클래스 생성자에 `@ConstructorProperties`가 있거나 없으면 클래스가 레코드 타입이어야 합니다.
+(또는 Lombok을 사용하는 경우 lombok.config 파일에 `lombok.anyConstructor.addConstructorProperties=true`를 추가할 수 있습니다.)
 
-When you create a record class and have multiple constructors, the constructor with the `@ConstructorProperties` annotation has priority.
+레코드 클래스를 생성할 때 여러 생성자를 가질 경우 `@ConstructorProperties` 주석이 있는 생성자가 우선 선택됩니다.
 
 ```java
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -8,4 +8,75 @@ identifier: "introspector"
 weight: 33
 ---
 
-### 한국어 번역 필요
+While you can change the way an object is created in the `ArbitraryBuilder` with [`instantiate`](../instantiate-methods), there may be cases where you want to change the way objects are created globally.
+Fixture Monkey lets you choose the way you want to create your object by providing different `Introspectors`.
+
+An `Introspector` defines the default way of how Fixture Monkey creates objects.
+Each introspector has some kind of restrictions that the class must have in order for the introspector to generate instances of that class.
+
+You can change the introspector you use by using the `objectIntrospector` option of Fixture Monkey.
+
+## BeanArbitraryIntrospector
+The `BeanArbitraryIntrospector` is the default introspector that fixture monkey uses for object creation.
+It creates new instances using reflection and the setter method, so the class it creates must have a no-args constructor and setters.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## ConstructorPropertiesArbitraryIntrospector
+To generate an object with its given constructor, you can use `ConstructorPropertiesArbitraryIntrospector`.
+
+For `ConstructorPropertiesArbitraryIntrospector`, the generated class should have a constructor with `@ConstructorProperties` or the class should be a record type.
+(Or, if you are using Lombok, you can add `lombok.anyConstructor.addConstructorProperties=true` to the lombok.config file.)
+
+When you create a record class and have multiple constructors, the constructor with the `@ConstructorProperties` annotation has priority.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FieldReflectionArbitraryIntrospector
+`FieldReflectionArbitraryIntrospector` creates new instances with reflection and also sets the fields with reflection.
+So the class to be generated must have a no-args constructor and one of the getters or setters.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## BuilderArbitraryIntrospector
+To generate a class using the class's builder, you can use `BuilderArbitraryIntrospector`.
+It requires that the class has a builder.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FailoverArbitraryIntrospector
+Sometimes your production code may contain several classes with different configurations, making it difficult to generate all objects with a single introspector.
+In this case, you can use the `FailoverArbitraryIntrospector`.
+This introspector allows you to use multiple introspectors, and it will continue the introspection even if one of the introspectors fails to generate.
+
+```java
+FixtureMonkey sut = FixtureMonkey.builder()
+    .objectIntrospector(new FailoverIntrospector(
+        Arrays.asList(
+            FieldReflectionArbitraryIntrospector.INSTANCE,
+            ConstructorPropertiesArbitraryIntrospector.INSTANCE
+        )
+    ))
+    .build();
+```
+
+----------------
+
+Additional introspectors have been introduced inside plugins, such as [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector) or
+[`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin)

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -63,7 +63,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ## FailoverArbitraryIntrospector
 프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.
 이 경우 `FailoverArbitraryIntrospector`를 사용할 수 있습니다.
-`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospector`는 계속 introspector를 생성합니다.
+`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospec속tor`는 계속 다음 introspector로 객체 생성을 시도합니다
 
 ```java
 FixtureMonkey sut = FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -29,7 +29,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 ## ConstructorPropertiesArbitraryIntrospector
 주어진 생성자로 객체를 생성하려면 `ConstructorPropertiesArbitraryIntrospector`를 사용해야 합니다.
 
-`ConstructorPropertiesArbitraryIntrospector`안 경우 클래스 생성자에 `@ConstructorProperties`가 있거나 없으면 클래스가 레코드 타입이어야 합니다.
+`ConstructorPropertiesArbitraryIntrospector`인 경우 클래스 생성자에 `@ConstructorProperties`가 있거나 없으면 클래스가 레코드 타입이어야 합니다.
 (또는 Lombok을 사용하는 경우 lombok.config 파일에 `lombok.anyConstructor.addConstructorProperties=true`를 추가할 수 있습니다.)
 
 레코드 클래스를 생성할 때 여러 생성자를 가질 경우 `@ConstructorProperties` 주석이 있는 생성자가 우선 선택됩니다.


### PR DESCRIPTION
## Summary

Translating introspector page of generating-objects section into Korean

related to https://github.com/naver/fixture-monkey/issues/864

## How Has This Been Tested?

Using command `npm start`

## Is the Document updated?

We do not update the document because it is a request for Korean translation.

