### PR TITLE
Add java conventions plugin to fixture-monkey-tests

### DIFF
--- a/fixture-monkey-tests/java-17-tests/build.gradle
+++ b/fixture-monkey-tests/java-17-tests/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("com.navercorp.fixturemonkey.gradle.plugin.java-conventions")
+}
+
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(17) }
 }

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/InterfaceDefaultMethodTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/InterfaceDefaultMethodTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 
 class InterfaceDefaultMethodTest {
-	private final static FixtureMonkey SUT = FixtureMonkey.create();
+	private static final FixtureMonkey SUT = FixtureMonkey.create();
 
 	@RepeatedTest(TEST_COUNT)
 	void defaultMethod() {

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.jackson.introspector.JacksonObjectArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.ContainerRecord;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.DateTimeRecord;

--- a/fixture-monkey-tests/java-concurrent-tests/build.gradle
+++ b/fixture-monkey-tests/java-concurrent-tests/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("com.navercorp.fixturemonkey.gradle.plugin.java-conventions")
+}
+
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(17) }
 }

--- a/fixture-monkey-tests/java-tests/build.gradle.kts
+++ b/fixture-monkey-tests/java-tests/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.navercorp.fixturemonkey.gradle.plugin.java-conventions")
+}
+
 dependencies {
     testImplementation(project(":fixture-monkey-javax-validation"))
     testImplementation("org.projectlombok:lombok:${Versions.LOMBOK}")

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/AnonymousInstanceTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/AnonymousInstanceTest.java
@@ -32,7 +32,6 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin;
 import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.AnnotatedInterface;
 import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.ContainerInterface;
-import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.DefaultMethodInterface;
 import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.GetterInterface;
 import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.InheritedInterface;
 import com.navercorp.fixturemonkey.tests.java.AnonymousInstanceTestSpecs.InheritedInterfaceWithSameNameMethod;

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableJavaTestSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableJavaTestSpecs.java
@@ -139,7 +139,7 @@ class ImmutableJavaTestSpecs {
 		}
 
 		@Override
-		public boolean contains(Object o) {
+		public boolean contains(Object object) {
 			return false;
 		}
 
@@ -154,37 +154,37 @@ class ImmutableJavaTestSpecs {
 		}
 
 		@Override
-		public <T> T[] toArray(T[] a) {
+		public <T> T[] toArray(T[] array) {
 			return null;
 		}
 
 		@Override
-		public boolean add(String s) {
+		public boolean add(String str) {
 			return false;
 		}
 
 		@Override
-		public boolean remove(Object o) {
+		public boolean remove(Object object) {
 			return false;
 		}
 
 		@Override
-		public boolean containsAll(Collection<?> c) {
+		public boolean containsAll(Collection<?> collection) {
 			return false;
 		}
 
 		@Override
-		public boolean addAll(Collection<? extends String> c) {
+		public boolean addAll(Collection<? extends String> collection) {
 			return false;
 		}
 
 		@Override
-		public boolean retainAll(Collection<?> c) {
+		public boolean retainAll(Collection<?> collection) {
 			return false;
 		}
 
 		@Override
-		public boolean removeAll(Collection<?> c) {
+		public boolean removeAll(Collection<?> collection) {
 			return false;
 		}
 

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonSpecs.java
@@ -134,8 +134,14 @@ public class JacksonSpecs {
 
 	@JsonTypeInfo(use = Id.NAME, include = As.WRAPPER_OBJECT)
 	@JsonSubTypes({
-		@JsonSubTypes.Type(value = TypeAWithAnnotationsIncludeWrapperObject.class, name = "TypeAWithAnnotationsIncludeWrapperObject"),
-		@JsonSubTypes.Type(value = TypeBWithAnnotationsIncludeWrapperObject.class, name = "TypeBWithAnnotationsIncludeWrapperObject")
+		@JsonSubTypes.Type(
+			value = TypeAWithAnnotationsIncludeWrapperObject.class,
+			name = "TypeAWithAnnotationsIncludeWrapperObject"
+			),
+		@JsonSubTypes.Type(
+			value = TypeBWithAnnotationsIncludeWrapperObject.class,
+			name = "TypeBWithAnnotationsIncludeWrapperObject"
+			)
 	})
 	public interface TypeWithAnnotationsIncludeWrapperObject {
 	}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JacksonTest.java
@@ -17,7 +17,6 @@ import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.ContainerObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.Enum;
 import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.JavaTypeObject;
-import com.navercorp.fixturemonkey.tests.java.ImmutableJavaTestSpecs.RootJavaTypeObject;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.ConstructorObject;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdClass;
 import com.navercorp.fixturemonkey.tests.java.JacksonSpecs.JsonTypeInfoIdName;
@@ -214,8 +213,10 @@ class JacksonTest {
 	@RepeatedTest(TEST_COUNT)
 	void sampleEnumKeyMap() {
 		thenNoException()
-			.isThrownBy(() -> SUT.giveMeBuilder(new TypeReference<List<Map<Enum, String>>>() {
-					})
+			.isThrownBy(() -> SUT.giveMeBuilder(
+						new TypeReference<List<Map<Enum, String>>>() {
+						}
+					)
 					.size("$", 2)
 					.sample()
 			);


### PR DESCRIPTION
## Summary
Add java conventions plugin to `fixture-monkey-tests` and fix failing checkstyle.

## How Has This Been Tested?
Checkstyle test passes.

## Is the Document updated?
No update necessary.