### PR TITLE
Fix missing required PropertyGenerator within introspectors

### DIFF
--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -9,7 +9,9 @@ sectionStart
 ### v.1.0.13
 Add InterfacePlugin supports abstract classes through `abstractClassExtends` option.
 
-Fix setLazy with value wrapped by Just would not be manipulated
+Fix setLazy with value wrapped by Just would not be manipulated.
+
+Fix missing required PropertyGenerator within introspectors.
 
 sectionEnd
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TypedArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/TypedArbitraryIntrospector.java
@@ -18,6 +18,8 @@
 
 package com.navercorp.fixturemonkey.api.introspector;
 
+import javax.annotation.Nullable;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -25,6 +27,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
 
 /**
  * Introspects specific properties matched by {@link Matcher}.
@@ -45,5 +48,15 @@ public final class TypedArbitraryIntrospector implements ArbitraryIntrospector, 
 	@Override
 	public boolean match(Property property) {
 		return arbitraryIntrospector.match(property);
+	}
+
+	@Nullable
+	@Override
+	public PropertyGenerator getRequiredPropertyGenerator(Property property) {
+		if (arbitraryIntrospector.match(property)) {
+			return arbitraryIntrospector.getOperator().getRequiredPropertyGenerator(property);
+		}
+
+		return null;
 	}
 }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -23,7 +23,10 @@ import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult
+import com.navercorp.fixturemonkey.api.property.Property
+import com.navercorp.fixturemonkey.api.property.PropertyGenerator
 import com.navercorp.fixturemonkey.api.type.Types
+import com.navercorp.fixturemonkey.kotlin.property.KotlinPropertyGenerator
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.MAINTAINED
 import org.slf4j.LoggerFactory
@@ -71,6 +74,8 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
         )
     }
 
+    override fun getRequiredPropertyGenerator(property: Property): PropertyGenerator = KOTLIN_PROPERTY_GENERATOR
+
     private fun resolveArbitrary(
         parameter: KParameter,
         arbitrariesByPropertyName: Map<String?, Any?>,
@@ -91,6 +96,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
     companion object {
         val INSTANCE = PrimaryConstructorArbitraryIntrospector()
         private val LOGGER = LoggerFactory.getLogger(PrimaryConstructorArbitraryIntrospector::class.java)
+        private val KOTLIN_PROPERTY_GENERATOR = KotlinPropertyGenerator()
         private val CONSTRUCTOR_CACHE = ConcurrentLruCache<Class<*>, KFunction<*>>(2048)
     }
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ConstructorTestSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ConstructorTestSpecs.java
@@ -1,5 +1,6 @@
 package com.navercorp.fixturemonkey.tests.java;
 
+import java.beans.ConstructorProperties;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -223,6 +224,19 @@ public class ConstructorTestSpecs {
 
 		public SimpleContainerObject(List<JavaTypeObject> list) {
 			this.list = list;
+		}
+	}
+
+	public static class FieldAndConstructorParameterMismatchObject {
+		private final String value;
+
+		@ConstructorProperties("integer")
+		public FieldAndConstructorParameterMismatchObject(int integer) {
+			this.value = String.valueOf(integer);
+		}
+
+		public String getValue() {
+			return value;
 		}
 	}
 }

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -62,6 +62,7 @@ import com.navercorp.fixturemonkey.customizer.Values;
 import com.navercorp.fixturemonkey.resolver.ArbitraryBuilderCandidateFactory;
 import com.navercorp.fixturemonkey.resolver.ArbitraryBuilderCandidateList;
 import com.navercorp.fixturemonkey.tests.java.ConstructorAndPropertyTestSpecs.ConsturctorAndProperty;
+import com.navercorp.fixturemonkey.tests.java.ConstructorTestSpecs.FieldAndConstructorParameterMismatchObject;
 import com.navercorp.fixturemonkey.tests.java.ConstructorTestSpecs.SimpleContainerObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableDepthTestSpecs.DepthStringValueList;
 import com.navercorp.fixturemonkey.tests.java.ImmutableDepthTestSpecs.OneDepthStringValue;
@@ -1208,5 +1209,19 @@ class JavaTest {
 		// then
 		String expected = stringObject.getObject().getValue();
 		then(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void fieldAndConstructorParameterMismatch() {
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.pushExactTypeArbitraryIntrospector(
+				FieldAndConstructorParameterMismatchObject.class,
+				ConstructorPropertiesArbitraryIntrospector.INSTANCE
+			)
+			.build();
+
+		String actual = sut.giveMeOne(FieldAndConstructorParameterMismatchObject.class).getValue();
+
+		then(actual).isNotNull();
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -40,6 +40,7 @@ import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.navercorp.fixturemonkey.kotlin.instantiator.instantiateBy
 import com.navercorp.fixturemonkey.kotlin.into
 import com.navercorp.fixturemonkey.kotlin.intoGetter
+import com.navercorp.fixturemonkey.kotlin.introspector.PrimaryConstructorArbitraryIntrospector
 import com.navercorp.fixturemonkey.kotlin.pushExactTypeArbitraryIntrospector
 import com.navercorp.fixturemonkey.kotlin.setExp
 import com.navercorp.fixturemonkey.kotlin.setExpGetter
@@ -405,6 +406,22 @@ class KotlinTest {
 
         // then
         then(actual).isEqualTo(expected)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun pushPrimaryConstructorIntrospector() {
+        // given
+        class StringObject(val string: String)
+
+        val sut = FixtureMonkey.builder()
+            .pushExactTypeArbitraryIntrospector<StringObject>(PrimaryConstructorArbitraryIntrospector.INSTANCE)
+            .build()
+
+        // when
+        val actual = sut.giveMeOne<StringObject>().string
+
+        // then
+        then(actual).isNotNull
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Fix missing required PropertyGenerator within introspectors

## How Has This Been Tested?
* pushPrimaryConstructorIntrospector
* fieldAndConstructorParameterMismatch

## Is the Document updated?
Yes
