### PR TITLE
add access to the private primary constructor for value class properties

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -83,6 +83,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
         try {
             val parameterKotlinType = parameter.type.jvmErasure
             return if (parameterKotlinType.isValue) {
+                parameterKotlinType.primaryConstructor!!.isAccessible = true
                 parameterKotlinType.primaryConstructor!!.call(arbitrariesByPropertyName[parameter.name])
             } else {
                 arbitrariesByPropertyName[parameter.name]

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
@@ -56,9 +56,36 @@ class ValueClassTest {
         then(actual.foo).isNotNull
     }
 
+    @Test
+    fun privateConstructorValueClassProperty() {
+        class ValueClassObject(val foo: FooWithPrivateConstructor)
+
+        val actual: ValueClassObject = SUT.giveMeOne()
+
+        then(actual).isNotNull
+        then(actual.foo).isNotNull
+    }
+
+    @Test
+    fun privateConstructorValueClassPropertyFixed() {
+        class ValueClassObject(val foo: FooWithPrivateConstructor)
+
+        val actual: ValueClassObject = SUT.giveMeBuilder<ValueClassObject>()
+            .fixed()
+            .sample()
+
+        then(actual).isNotNull
+        then(actual.foo).isNotNull
+    }
+
     @JvmInline
     value class Foo(
         val bar: String,
+    )
+
+    @JvmInline
+    value class FooWithPrivateConstructor private constructor(
+        val bar: String
     )
 
     companion object {


### PR DESCRIPTION
## Summary

### (issue at https://github.com/naver/fixture-monkey/issues/910)

1. an access to private constructor has been added when resolving value class properties 
2. test cases for the fix above


## How Has This Been Tested?

test cases added for a class with a value class property with the private primary constructor.

