### PR TITLE
fix: Change Java Integer type to Int type in Kotlin

### DIFF
--- a/docs/content/v1.0.x/docs/get-started/creating-objects-in-kotlin.md
+++ b/docs/content/v1.0.x/docs/get-started/creating-objects-in-kotlin.md
@@ -41,7 +41,7 @@ data class Product (
 
   val productType: ProductType,
 
-  val merchantInfo: Map<Integer, String>
+  val merchantInfo: Map<Int, String>
 )
 ```
 


### PR DESCRIPTION
## Summary

Kotlin uses `Int` instead of `Integer`, but I will fix the parts of the Kotlin example that are written as `Integer`.

In my opinion, this is more Kotlin-like.
