### PR TITLE
Fix the missing href link on the 'Get Started' button on the main page

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -36,7 +36,7 @@
         </a>
         {{ with .Site.Language }}
         <a class="btn btn-primary btn-lg px-2 ms-auto fw-semibold get-started-button"
-           href="{{ index .Params " getStartedPage" }}" role="button">{{ i18n "get-started" }}</a>
+           href="{{ index .Params "getStartedPage" }}" role="button">{{ i18n "get-started" }}</a>
         {{ end }}
     </div>
 </section>


### PR DESCRIPTION
## Summary
공백 문자열로 인해 Get Started 페이지로 링크가 되지 않는 점을 수정하였습니다.

## (Optional): Description
*Describe your changes in detail*


## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*
로컬 환경 구동 테스트

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*
