### PR TITLE
Add 'Fixture Monkey Options' section for kor doc 

### DIFF
--- a/docs/config/_default/languages.toml
+++ b/docs/config/_default/languages.toml
@@ -1,6 +1,8 @@
 [v1-0-0]
   languageName = "v1.0.x"
+  languageCode = "ENG"
   contentDir = "content/v1.0.x"
+  translation = true
   weight = 10
   [v1-0-0.params]
     languageISO = "EN"
@@ -9,9 +11,33 @@
 
 [v0-6-0]
   languageName = "v0.6.x"
+  languageCode = "ENG"
   contentDir = "content/v0.6.x"
+  translation = true
   weight = 15
   [v0-6-0.params]
     languageISO = "EN"
     languageTag = "en-US"
+    getStartedPage = "/v0-6-0/docs/getting-started/java/"
+
+[v1-0-0-kor]
+  languageName = "v1.0.x"
+  languageCode = "KOR"
+  contentDir = "content/v1.0.x-kor"
+  weight = 10
+  translation = false
+  [v1-0-0-kor.params]
+    languageISO = "KO"
+    languageTag = "ko-KR"
+    getStartedPage = "/docs/get-started/requirements/"
+
+[v0-6-0-kor]
+  languageName = "v0.6.x"
+  languageCode = "KOR"
+  contentDir = "content/v0.6.x-kor"
+  weight = 15
+  translation = false
+  [v0-6-0-kor.params]
+    languageISO = "KO"
+    languageTag = "ko-KR"
     getStartedPage = "/v0-6-0/docs/getting-started/java/"

--- a/docs/config/_default/menus/menus.v1-0-0-kor.toml
+++ b/docs/config/_default/menus/menus.v1-0-0-kor.toml
@@ -1,0 +1,64 @@
+[[main]]
+name = "Docs"
+url = "/docs/introduction/overview/"
+weight = 10
+
+[[docs]]
+name = "Introduction"
+weight = 10
+identifier = "get-started"
+url = "/docs/introduction/"
+
+[[docs]]
+name = "Getting Started"
+weight = 20
+identifier = "get-started"
+url = "/docs/get-started/"
+
+[[docs]]
+name = "Generating Objects"
+weight = 30
+identifier = "generating-objects"
+url = "/docs/generating-objects/"
+
+[[docs]]
+name = "Customizing Objects"
+weight = 40
+identifier = "customizing-objects"
+url = "/docs/customizing-objects/"
+
+[[docs]]
+name = "Fixture Monkey Options"
+weight = 50
+identifier = "fixture-monkey-options"
+url = "/docs/fixture-monkey-options/"
+
+[[docs]]
+name = "Plugins"
+weight = 60
+identifier = "plugins"
+url = "/docs/plugins/"
+
+[[docs]]
+name = "IntelliJ Plugin"
+weight = 70
+identifier = "intellij-plugin"
+url = "/docs/intellij-plugin/"
+
+[[main]]
+name = "Release Notes"
+weight = 20
+identifier = "release-notes"
+url = "/release-notes/"
+
+[[social]]
+name = "GitHub"
+pre = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" class=\"feather feather-github\"><path d=\"M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22\"></path></svg>"
+url = "https://github.com/naver/fixture-monkey"
+post = "v0.1.0"
+weight = 10
+
+[[footer]]
+name = "© 2023 Naver All Rights Reserved"
+# url = "/privacy-policy/"
+weight = 10

--- a/docs/content/v1.0.x-kor/_index.md
+++ b/docs/content/v1.0.x-kor/_index.md
@@ -1,0 +1,9 @@
+---
+title : "Fixture Monkey"
+description : ""
+lead: ""
+date: 2020-10-06T08:47:36+00:00
+lastmod: 2020-10-06T08:47:36+00:00
+draft: false
+images: []
+---

--- a/docs/content/v1.0.x-kor/docs/cheat-sheet/_index.md
+++ b/docs/content/v1.0.x-kor/docs/cheat-sheet/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Cheat sheet"
+images: []
+menu:
+docs:
+weight: 100
+---

--- a/docs/content/v1.0.x-kor/docs/cheat-sheet/faq.md
+++ b/docs/content/v1.0.x-kor/docs/cheat-sheet/faq.md
@@ -1,0 +1,9 @@
+---
+title: "FAQ"
+weight: 101
+menu:
+docs:
+  parent: "cheat-sheet"
+  identifier: "faq"
+---
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/_index.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Customizing Objects"
+images: []
+menu:
+docs:
+weight: 40
+---

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/apis.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/apis.md
@@ -1,0 +1,10 @@
+---
+title: "Fixture Customization APIs"
+weight: 41
+menu:
+docs:
+  parent: "customizing-objects"
+  identifier: "fixture-customization-apis"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/apis.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/apis.md
@@ -7,4 +7,336 @@ docs:
   identifier: "fixture-customization-apis"
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 ArbitraryBuilder를 통해 생성된 객체를 커스텀할 수 있는 다양한 API를 제공합니다.
+
+## Customizing Fixtures
+
+### set()
+
+`set()` 메서드는 [표현식](../expressions)에 참조된 하나 이상의 프로퍼티에 값을 설정하는 데 사용됩니다. 
+
+`Supplier`, [`Arbitrary`](../arbitrary), `ArbitraryBuilder`, `NOT_NULL`, `NULL`, 또는 `Just` 를 포함한 다양한 타입을 값으로 설정할 수 있습니다.
+또한 객체의 특정 인스턴스를 값으로 사용할 수도 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .set("id", 1000);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .setExp(Product::id, 1000)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+##### Just
+
+> `set()`을 사용할 때 `Just`로 래핑된 객체를 사용하면 인스턴스를 분해하지 않고 값을 직접 설정할 수 있습니다.
+> 일반적으로 `ArbitraryBuilder`에서 프로퍼티를 `set()`하면 주어진 인스턴스를 사용하지 않고 깊은 복사를 수행합니다.
+> 따라서 인스턴스로 설정해야 하는 경우 `Values.just(instance)`를 사용해야 합니다.
+> 이 기능은 Mocking 프레임워크를 사용할 때 Mock 인스턴스에 프로퍼티를 설정해야 하는 경우 유용합니다.
+
+> `Just` 로 설정한 후에는 하위 속성을 변경할 수 없으니 유의하세요.
+
+```java
+Product product = fixture.giveMeBuilder(Product.class)
+	  		  .set("options", Values.just(List.of("red", "medium", "adult"))
+	  		  .set("options[0]", "blue")
+	    		  .sample();
+```
+
+> 예를 들어, 위에서 생성된 Product 인스턴스의 options[0] 값은 "blue" 가 아닌 `Just`로 설정된 리스트로 유지됩니다.
+
+### size(), minSize(), maxSize()
+
+`size()` 메서드를 사용하면 컨테이너 프로퍼티의 크기를 지정할 수 있습니다.
+정확한 크기를 설정하거나 최소값과 최대값을 사용하여 범위를 지정하는 등 유연하게 사용할 수 있습니다.
+
+혹은 `minSize()` 또는 `maxSize()`를 사용하여 최소 또는 최대 컨테이너 크기만 설정할 수도 있습니다. (디폴트 설정은 0 ~ 3 입니다.)
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .size("options", 5); // size:5
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .size("options", 3, 5); // minSize:3, maxSize:5
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .minSize("options", 3); // minSize:3
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .maxSize("options", 5); // maxSize:5
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .sizeExp(Product::options, 5) // size:5
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .sizeExp(Product::options, 3, 5) // minSize:3, maxSize:5
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .minSizeExp(Product::options, 3) // minSize:3
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .maxSizeExp(Product::options, 5) // maxSize:5
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### setNull(), setNotNull()
+
+때로는 속성을 항상 null로 설정하거나 항상 값이 있도록 보장하고 싶을 수 있습니다.
+이러한 상황에서는 `setNull()` 또는 `setNotNull()`을 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .setNull("id");
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .setNotNull("id");
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .setNullExp(Product::id)
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .setNotNullExp(Product::id)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### setInner()
+
+`setInner()`를 사용하면 `InnerSpec` 인스턴스에 정의된 커스텀을 빌더에 적용할 수 있습니다.
+`InnerSpec` 은 타입에 독립적으로 사용 가능한 커스텀 명세입니다.
+
+`InnerSpec` 인스턴스를 재사용하여 중첩 프로퍼티를 일관되고 쉽게 구성할 수 있습니다.
+특히 Map의 속성을 커스텀할 때 유용합니다.
+
+자세한 내용은 [InnerSpec](../innerspec) 을 참고하세요.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+InnerSpec innerSpec = new InnerSpec()
+    .property("merchantInfo", it -> it.entry(1000, "ABC Store"));
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .setInner(innerSpec)
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val innerSpec = InnerSpec()
+    .property("merchantInfo") { it.entry(1000, "ABC Store") }
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .setInner(innerSpec)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### setLazy()
+
+The `setLazy()` 함수는 Supplier에서 얻은 값을 프로퍼티에 할당합니다.
+이 Supplier은 ArbitraryBuilder가 샘플링(`sample()`)될 때마다 실행됩니다.
+
+이 함수는 고유한 순차 ID를 생성하거나 가장 최근 값을 설정해야 할 때 특히 유용합니다.
+
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+AtomicReference<Long> variable = new AtomicReference<>(0L);
+ArbitraryBuilder<Long> builder = fixtureMonkey.giveMeBuilder(Long.class)
+    .setLazy("$", () -> variable.getAndSet(variable.get() + 1));
+
+Long actual1 = builder.sample(); // actual1 == 0
+Long actual2 = builder.sample(); // actual2 == 1
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+var variable = 0L
+val builder = fixtureMonkey.giveMeBuilder(Long::class.java)
+    .setLazy("$") { variable++ }
+
+val actual1 = builder.sample() // actual1 == 0
+val actual2 = builder.sample() // actual2 == 1
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### setPostCondition()
+
+`setPostCondition()`은 픽스처가 특정 조건을 준수해야 할 때 사용할 수 있습니다.
+이 조건은 predicate를 전달하여 정의할 수 있습니다.
+
+
+{{< alert icon="🚨" text="까다로운 조건에서 setPostCondition을 사용할 경우 비용이 더 많이 발생할 수 있습니다. 이러한 경우에는 대신 set를 사용하는 것이 좋습니다." />}}
+
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .setPostCondition("id", Long.class, it -> it > 0)
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder(Product::class.java)
+    .setPostConditionExp(Product::id, Long::class.java) { it: Long -> it > 0 }
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### fixed()
+
+`fixed()` 는 ArbitraryBuilder가 샘플링될 때마다 동일한 값의 인스턴스를 일관되게 반환하도록 할 때 사용합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .fixed()
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .fixed()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### limit
+
+`set()`, `setLazy()`, 및 `setPostCondition()` 메서드는 추가 매개변수를 통해 커스텀을 적용할 횟수를 제한할 수 있습니다.
+이것은 표현식이 여러 프로퍼티를 참조하는 경우에 유용합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+  .set("options[*]", "red", 2); // options에 "red"는 2개까지만 설정될 수 있습니다.
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .set("options[*]", "red", 2) // options에 "red"는 2개까지만 설정될 수 있습니다.
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+## Expanding Customization using Sampled Results
+
+### thenApply()
+
+`thenApply()` 메서드는 빌더의 샘플링된 결과를 기반으로 필드를 커스텀해야 할 때 편리합니다.
+예를 들어, 다음과 같이 `thenApply()`를 사용해 "productName" 필드를 생성된 Product의 "id"와 일치하도록 설정할 수 있습니다.
+
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .thenApply((it, builder) -> builder.set("productName", it.getId().toString()))
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder(Product::class.java)
+    .thenApply{it, builder -> builder.setExp(Product::productName, it.id.toString())}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### acceptIf()
+
+특정 조건에 따라 추가 커스텀을 수행해야 할 수도 있습니다.
+이러한 경우 predicate가 충족될 때만 커스텀을 적용하는 `acceptIf()` 메서드를 활용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .acceptIf(
+        it -> it.getProductType() == ProductType.CLOTHING,
+        builder -> builder.set("price", 1000)
+    )
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder<Product>()
+    .acceptIf(
+        { it.productType == ProductType.CLOTHING },
+        { builder -> builder.setExp(Product::price, 1000) }
+    )
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## Transforming the Type of ArbitraryBuilder 
+
+### map()
+
+`map()` 함수는 ArbitraryBuilder 의 타입을 다른 타입으로 변환하는 데 사용됩니다.
+
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+fixtureMonkey.giveMeBuilder(Product.class)
+    .map(Product::getId); // transforms to ArbitraryBuilder<Long>
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+fixtureMonkey.giveMeBuilder(Product::class.java)
+    .map(Product::id) // transforms to ArbitraryBuilder<Long>
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### zipWith()
+
+`zipWith()` 은 여러 ArbitraryBuilder를 병합하여 다른 타입의 ArbitraryBuilder를 만들 때 유용합니다.
+빌더들을 어떻게 결합할 지 명시해야 합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<String> stringBuilder = fixtureMonkey.giveMeBuilder(String.class);
+
+ArbitraryBuilder<String> zipped = fixtureMonkey.giveMeBuilder(Integer.class)
+    .zipWith(stringBuilder, (integer, string) -> integer + "" + string);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val stringBuilder = fixtureMonkey.giveMeBuilder<String>()
+
+val zipped = fixtureMonkey.giveMeBuilder<Int>()
+    .zipWith(stringBuilder) { int, string -> int.toString() + "" + string }
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/arbitrary.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/arbitrary.md
@@ -1,0 +1,10 @@
+---
+title: "Customizing random values with Arbitrary"
+weight: 43
+menu:
+docs:
+parent: "customizing-objects"
+identifier: "arbitrary"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/expressions.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/expressions.md
@@ -1,0 +1,10 @@
+---
+title: "Expressions"
+weight: 42
+menu:
+docs:
+parent: "customizing-objects"
+identifier: "expressions"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/customizing-objects/innerspec.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/innerspec.md
@@ -1,0 +1,10 @@
+---
+title: "InnerSpec"
+weight: 44
+menu:
+docs:
+parent: "customizing-objects"
+identifier: "innerspec"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/_index.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Fixture Monkey Options"
+images: []
+menu:
+docs:
+weight: 50
+---

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/concepts.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/concepts.md
@@ -1,0 +1,11 @@
+---
+title: "Concepts"
+images: []
+menu:
+docs:
+parent: "fixture-monkey-options"
+identifier: "concepts"
+weight: 51
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -8,4 +8,432 @@ identifier: "options"
 weight: 53
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도록 객체를 사용자 정의하거나 사용자 정의 프로퍼티 명을 사용할 수 있는 옵션도 제공합니다.
+
+## 프로퍼티 네임 리졸버
+> `defaultPropertyNameResolver`, `pushPropertyNameResolver`, `pushAssignableTypePropertyNameResolver`, `pushExactTypePropertyNameResolver`
+
+`PropertyNameResolver` 관련 옵션을 사용하면 프로퍼티를 참조하는 방법을 사용자 정의할 수 있습니다.
+
+`defaultPropertyNameResolver` 옵션은 모든 타입에 대해 프로퍼티 명을 알아내는 방식을 변경하는 데 사용됩니다.
+만약 특정 타입에 대해 특정한 변경을 수행하려면 `pushPropertyNameResolver` , `pushAssignableTypePropertyNameResolver` 또는 `pushExactTypePropertyNameResolver` 를 사용할 수 있습니다.
+
+기본적으로 프로퍼티는 원래 이름으로 참조됩니다. 다음 예시를 통해 프로퍼티 명을 사용자 정의하는 방법을 살펴봅시다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Data // getter, setter
+public class Product {
+String productName;
+}
+
+@Test
+void test() {
+// given
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.pushPropertyNameResolver(MatcherOperator.exactTypeMatchOperator(String.class, (property) -> "string"))
+.build();
+String expected = "test";
+
+    // when
+    String actual = fixtureMonkey.giveMeBuilder(Product.class)
+        .set("string", expected)
+        .sample()
+        .getProductName();
+
+    // then
+    then(actual).isEqualTo(expected);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+data class Product (
+val productName: String
+)
+
+@Test
+fun test() {
+// given
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(KotlinPlugin())
+.pushPropertyNameResolver(
+MatcherOperator.exactTypeMatchOperator(String::class.java, PropertyNameResolver { "string" })
+)
+.build()
+val expected = "test"
+
+    // when
+    val actual: String = fixtureMonkey.giveMeBuilder<Product>()
+        .set("string", expected)
+        .sample()
+        .productName
+
+    // then
+    then(actual).isEqualTo(expected)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+일반적으로, 프로퍼티 명은 원래 프로퍼티 명인 "productName" 으로 해석됩니다.
+그러나 `pushPropertyNameResolver` 를 사용하면 String 타입의 프로퍼티는 이제 "string"이라는 이름으로 참조됩니다.
+
+## 레지스터 옵션
+> `register`, `registerGroup`, `registerExactType`, `registerAssignableType`
+
+때로 클래스가 특정 제약 조건과 일관되게 일치해야 할 수 있습니다.
+사용자 정의 API를 사용해 항상 `ArbitraryBuilder` 를 수정해야 한다면 번거로울 수 있고 코드가 길어질 수 있습니다.
+이 경우, 모든 기본 제약 조건을 충족하는 클래스에 대해 기본 `ArbitraryBuilder` 를 설정할 수 있습니다.
+
+`register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
+
+For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
+예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
+이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.register(
+Product.class,
+fixture -> fixture.giveMeBuilder(Product.class)
+.set("id", Arbitraries.longs().greaterOrEqual(0))
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.register(Product::class.java) {
+it.giveMeBuilder<Product>()
+.set("id", Arbitraries.longs().greaterOrEqual(0))
+}
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+여러 ArbitraryBuilders를 한 번에 등록하려면 `registerGroup` 옵션을 사용할 수 있습니다.
+이 작업은 리플렉션 또는 `ArbitraryBuilderGroup` 인터페이스를 사용하여 수행할 수 있습니다.
+
+**Using reflection:**
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public class GenerateGroup {
+public ArbitraryBuilder<GenerateString> generateString(FixtureMonkey fixtureMonkey) {
+return fixtureMonkey.giveMeBuilder(GenerateString.class)
+.set("value", Arbitraries.strings().numeric());
+}
+
+    public ArbitraryBuilder<GenerateInt> generateInt(FixtureMonkey fixtureMonkey) {
+        return fixtureMonkey.giveMeBuilder(GenerateInt.class)
+            .set("value", Arbitraries.integers().between(1, 100));
+    }
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateGroup.class)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class GenerateGroup {
+fun generateString(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateString> {
+return fixtureMonkey.giveMeBuilder<GenerateString>()
+.set("value", Arbitraries.strings().numeric())
+}
+
+    fun generateInt(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateInt> {
+        return fixtureMonkey.giveMeBuilder<GenerateInt>()
+            .set("value", Arbitraries.integers().between(1, 100))
+    }
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateGroup::class.java)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+**Using ArbitraryBuilderGroup interface:**
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public class GenerateBuilderGroup implements ArbitraryBuilderGroup {
+@Override
+public ArbitraryBuilderCandidateList generateCandidateList() {
+return ArbitraryBuilderCandidateList.create()
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateString.class)
+.builder(
+arbitraryBuilder -> arbitraryBuilder
+.set("value", Arbitraries.strings().numeric())
+)
+)
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateInt.class)
+.builder(
+builder -> builder
+.set("value", Arbitraries.integers().between(1, 100))
+)
+);
+}
+}
+
+FixtureMonkey.builder()
+.registerGroup(new GenerateBuilderGroup())
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class GenerateBuilderGroup : ArbitraryBuilderGroup {
+override fun generateCandidateList(): ArbitraryBuilderCandidateList {
+return ArbitraryBuilderCandidateList.create()
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateString::class.java)
+.builder { it.set("value", Arbitraries.strings().numeric()) }
+)
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateInt::class.java)
+.builder { it.set("value", Arbitraries.integers().between(1, 100)) }
+)
+}
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateBuilderGroup())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## 표현식 엄격 모드
+> `useExpressionStrictMode`
+
+표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지고 있는지, 그리고 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
+`useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던질 것입니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build();
+
+    thenThrownBy(
+        () -> fixtureMonkey.giveMeBuilder(String.class)
+            .set("nonExistentField", 0)
+            .sample()
+    ).isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No matching results for given NodeResolvers.");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
+
+    assertThatThrownBy {
+        fixtureMonkey.giveMeBuilder<String>()
+            .set("nonExistentField", 0)
+            .sample()
+    }.isExactlyInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("No matching results for given NodeResolvers.")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## Java 타입 제한
+> `javaTypeArbitraryGenerator`, `javaTimeTypeArbitraryGenerator`
+
+사용자 정의 `JavaTypeArbitraryGenerator` 인터페이스를 구현하여 Java 기본 타입(string, integer, double 등)의 기본값을 수정할 수 있습니다.
+이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
+
+예를 들어, Fixture Monkey로 생성된 string 타입은 기본적으로 제어 블록이 문자열에 포함되어 있는 극단적인 경우를 고려하기 때문에 읽기 어렵습니다.
+
+알파벳 문자로만 구성된 문자열을 생성하려면 아래 예시처럼 `JavaTypeArbitraryGenerator` 를 재정의하면 됩니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.plugin(
+new JqwikPlugin()
+.javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
+@Override
+public StringArbitrary strings() {
+return Arbitraries.strings().alpha();
+}
+})
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.plugin(
+JqwikPlugin()
+.javaTypeArbitraryGenerator(object : JavaTypeArbitraryGenerator {
+override fun strings(): StringArbitrary = Arbitraries.strings().alpha()
+})
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For Java time types, you can use `javaTimeTypeArbitraryGenerator`.
+
+## 애노테이션을 사용한 Java 타입 제한
+> `javaArbitraryResolver`, `javaTimeArbitraryResolver`
+
+javax-validation 플러그인을 사용하여 Java 타입 프로퍼티에 제약 조건을 추가하는 것과 유사하게, 애노테이션을 사용하여 Java 타입에 제약 조건을 적용할 수 있습니다.
+이는 `JavaArbitraryResolver` 인터페이스를 구현하면 됩니다.
+이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
+
+예를 들어, 프로퍼티의 길이를 최대 10자로 제한해야 한다는 의미의 `MaxLengthOf10` 이라는 사용자 지정 애노테이션이 있는 경우 아래와 같이 `JavaArbitraryResolver` 를 생성할 수 있습니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.plugin(
+new JqwikPlugin()
+.javaArbitraryResolver(new JavaArbitraryResolver() {
+@Override
+public Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryGeneratorContext context) {
+if (context.findAnnotation(MaxLengthof10.class).isPresent()) {
+return stringArbitrary.ofMaxLength(10);
+}
+return stringArbitrary;
+}
+})
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.plugin(
+JqwikPlugin()
+.javaArbitraryResolver(object : JavaArbitraryResolver {
+override fun strings(stringArbitrary: StringArbitrary, context: ArbitraryGeneratorContext): Arbitrary<String> {
+if (context.findAnnotation(MaxLengthof10::class.java).isPresent) {
+return stringArbitrary.ofMaxLength(10)
+}
+return stringArbitrary
+}
+})
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## Null 옵션
+### defaultNotNull
+> `defaultNotNull`, `nullableContainer`, `nullableElement`
+
+인스턴스의 프로퍼티가 null이 아닌지 확인하려는 경우 아래에 언급된 옵션을 활용할 수 있습니다.
+
+- `defaultNotNull` null 프로퍼티의 생성 여부를 결정합니다. true라면 프로퍼티가 null이 **될 수 없습니다**.
+- `nullableContainer` 컨테이너 프로퍼티가 null이 될 수 있는지 여부를 결정합니다. true라면 컨테이너가 null이 될 수 있습니다.
+- `nullableElement` 컨테이너 프로퍼티 내의 요소가 null이 될 수 있는지 여부를 결정합니다. true라면 요소가 null이 될 수 있습니다.
+
+기본적으로 이 세 옵션은 false로 설정되어 있습니다. 필요에 따라 true로 변경할 수 있습니다.
+
+{{< alert icon="🚨" text="These options only apply to properties that do not have a nullable marker, such as @Nullable in Java or ? in Kotlin." />}}
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().defaultNotNull(true).build();
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().nullableContainer(true).build();
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build();
+
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder().defaultNotNull(true).build()
+
+val fixtureMonkey = FixtureMonkey.builder().nullableContainer(true).build()
+
+val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+---------------
+### NullInjectGenerator
+> `defaultNullInjectGenerator`, `pushNullInjectGenerator`, `pushExactTypeNullInjectGenerator`, `pushAssignableTypeNullInjectGenerator`
+
+특정 프로퍼티가 nullable 표시와 관계없이 null이어야 하는 경우, `NullInjectGenerator` 와 관련된 옵션을 사용할 수 있습니다.
+
+`defaultnullInjectGenerator` 옵션을 사용하면 프로퍼티가 null이 될 확률을 설정할 수 있습니다.
+
+기본적으로 프로퍼티가 null일 확률은 20%로 설정되어 있습니다.
+
+항상 null이 되길 원한다면 `1.0d` 로 설정할 수 있습니다. DefaultNullInjectGenerator에는 `NOT_NULL_INJECT(0.0d)` 와 `ALWAYS_NULL_INJECT(1.0d)` 와 같은 미리 정의된 값이 있습니다. 이를 가져와서 사용할 수 있습니다.
+
+보다 사용자 정의된 동작을 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // you can use NOT_NULL_INJECT or write your probability as 0.4
+.build()
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(KotlinPlugin())
+.defaultNullInjectGenerator { NOT_NULL_INJECT } // you can use NOT_NULL_INJECT or write your probability as 0.4
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+If you want to specifically change the probability of a certain type being null, you can use `pushNullInjectGenerator`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.pushNullInjectGenerator(MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context) -> NOT_NULL_INJECT))
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.pushNullInjectGenerator(
+exactTypeMatchOperator(
+Product::class.java,
+NullInjectGenerator { context -> NOT_NULL_INJECT }
+)
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+Registering an `ArbitraryBuilder` of a specific class with `register` that has the `.setNotNull("*")` setting will have the same effect.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -10,7 +10,7 @@ weight: 53
 
 Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도록 객체를 사용자 정의하거나 사용자 정의 프로퍼티 명을 사용할 수 있는 옵션도 제공합니다.
 
-## 프로퍼티 네임 리졸버
+## 프로퍼티네임 리졸버
 > `defaultPropertyNameResolver`, `pushPropertyNameResolver`, `pushAssignableTypePropertyNameResolver`, `pushExactTypePropertyNameResolver`
 
 `PropertyNameResolver` 관련 옵션을 사용하면 프로퍼티를 참조하는 방법을 사용자 정의할 수 있습니다.
@@ -80,7 +80,7 @@ val expected = "test"
 일반적으로, 프로퍼티 명은 원래 프로퍼티 명인 "productName" 으로 해석됩니다.
 그러나 `pushPropertyNameResolver` 를 사용하면 String 타입의 프로퍼티는 이제 "string"이라는 이름으로 참조됩니다.
 
-## 레지스터 옵션
+## 등록 옵션
 > `register`, `registerGroup`, `registerExactType`, `registerAssignableType`
 
 때로 클래스가 특정 제약 조건과 일관되게 일치해야 할 수 있습니다.
@@ -90,7 +90,7 @@ val expected = "test"
 `register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
 
 For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
-예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
+예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.-
 이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
 
 {{< tabpane persist=false >}}
@@ -219,7 +219,7 @@ FixtureMonkey.builder()
 ## 표현식 엄격 모드
 > `useExpressionStrictMode`
 
-표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지고 있는지, 그리고 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
+표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지는지, 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
 `useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던질 것입니다.
 
 {{< tabpane persist=false >}}
@@ -392,7 +392,7 @@ val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
 
 항상 null이 되길 원한다면 `1.0d` 로 설정할 수 있습니다. DefaultNullInjectGenerator에는 `NOT_NULL_INJECT(0.0d)` 와 `ALWAYS_NULL_INJECT(1.0d)` 와 같은 미리 정의된 값이 있습니다. 이를 가져와서 사용할 수 있습니다.
 
-보다 사용자 정의된 동작을 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
+사용자 정의된 동작을 더 추가하길 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -1,0 +1,11 @@
+---
+title: "Customization Options"
+images: []
+menu:
+docs:
+parent: "fixture-monkey-options"
+identifier: "options"
+weight: 53
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -8,4 +8,541 @@ identifier: "options"
 weight: 52
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기 위한 다양한 옵션을 제공합니다.
+
+이러한 옵션은 `FixtureMonkeyBuilder` 를 통해 접근할 수 있습니다.
+
+## Property Generation
+### PropertyGenerator
+> `defaultPropertyGenerator`, `pushPropertyGenerator`, `pushAssignableTypePropertyGenerator`, `pushExactTypePropertyGenerator`
+
+`PropertyGenerator` creates child properties of the given `ObjectProperty`.
+`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다. 
+The child property can be a field, JavaBeans property, method or constructor parameter within the parent `ObjectProperty`.
+자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 패러미터가 될 수 있습니다. 
+There are scenarios where you might want to customize how these child properties are generated.
+자식 프로퍼티들이 생성되는 방식을 사용자 정의하고자 하는 시나리오들이 있습니다.
+
+The `PropertyGenerator` options allow you to specify how child properties of each type are generated.
+`PropertyGenerator` 옵션으로 각 타입의 자식 프로퍼티가 어떻게 생성되는지 지정할 수 있습니다.
+This option is mainly used when you want to exclude generating some properties when the parent property has abnormal child properties.
+이 옵션은 주로 부모 프로퍼티가 비정상적인 자식 프로퍼티를 가질 때 일부 프로퍼티 생성을 제외하고자 할 때 사용됩니다.
+
+{{< alert icon="📖" text="Notable implementations: 'FieldPropertyGenerator', 'JavaBeansPropertyGenerator'" />}}
+
+### ObjectPropertyGenerator
+> `defaultObjectPropertyGenerator`, `pushObjectPropertyGenerator`, `pushAssignableTypeObjectPropertyGenerator`, `pushExactTypeObjectPropertyGenerator`
+
+`ObjectPropertyGenerator` generates the [`ObjectProperty`](../concepts/#objectProperty) based on a given context.
+`ObjectPropertyGenerator` 는 주어진 컨텍스트에 기반하여 [`ObjectProperty`](../concepts/#objectProperty)를 생성합니다.
+With options related to `ObjectPropertyGenerator` you can customize how the `ObjectProperty` is generated.
+`ObjectPropertyGenerator` 관련 옵션을 사용하면 `ObjectProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'DefaultObjectPropertyGenerator'" />}}
+
+### ContainerPropertyGenerator
+> `pushContainerPropertyGenerator`, `pushAssignableTypeContainerPropertyGenerator`, `pushExactTypeContainerPropertyGenerator`
+
+The `ContainerPropertyGenerator` determines how to generate [`ContainerProperty`](../concepts/#containerProperty) within a given context.
+`ContainerPropertyGenerator` 는 주어진 컨텍스트에서 [`ContainerProperty`](../concepts/#containerProperty) 를 생성하는 방법을 결정합니다.
+With options related to `ContainerPropertyGenerator` you can customize how the `ContainerProperty` is generated.
+`ContainerPropertyGenerator` 관련 옵션을 사용하면 `ContainerProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'ArrayContainerPropertyGenerator', 'MapContainerPropertyGenerator'" />}}
+
+-----------------
+
+## Arbitrary Generation
+An `Introspector` determines how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy based on the provided context(which includes information about generated properties).
+`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 적절한 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
+The object is then generated based on this arbitrary generated.
+이후 이 객체는 임의 생성된 기반으로 생성됩니다.
+You have the flexibility to create a custom `Introspector` by implementing your own `ArbitraryIntrospector`.
+
+### ObjectIntrospector
+> `objectIntrospcetor`
+
+The `objectIntrospector` option allows you to specify the default behavior when generating an object.
+객체 생성 시 기본 동작을 지정하는 `objectIntrospector` 관련 옵션을 사용하면 객체를 생성할 때 기본 동작을 지정할 수 있습니다.
+As discussed in the [introspector section](../../generating-objects/introspector), you can alter the default introspector to use predefined introspectors provided by Fixture Monkey or create your own custom introspector.
+[introspector section](../../generating-objects/introspector)에서 설명한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'BeanArbitraryIntrospector', 'BuilderArbitraryIntrospector'" />}}
+
+### ArbitraryIntrospector
+> `pushArbitraryIntrospector`, `pushAssignableTypeArbitraryIntrospector`, `pushExactTypeArbitraryIntrospector`
+
+If you need to change the `ArbitraryIntrospector` for a specific type you can use the above options.
+특정 유형에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'BooleanIntrospector', 'EnumIntrospector'" />}}
+
+### ContainerIntrospector
+> pushContainerIntrospector
+
+Especially for container types, you can change the `ArbitraryIntrospector` using the `pushContainerIntrospector` option.
+특히 컨테이너 타입의 경우, `pushContainerIntrospector` 옵션을 사용하여 `ArbitraryIntrospector` 를 변경할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'ListIntrospector', 'MapIntrospector'" />}}
+
+-----------------
+
+## Arbitrary Generation
+The `ArbitraryIntrospector` is responsible for defining how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy and generating an arbitrary.
+`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 개체를 생성하여 Fixture Monkey가 개체를 생성하는 방법을 정의하는 역할을 담당합니다.
+The actual creation of the final arbitrary(`CombinableArbitrary`) from the arbitrary is done by the `ArbitraryGenerator`, which handles the request by delegating to the `ArbitraryIntrospcetor`.
+임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator`에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor`에 요청을 위임하여 요청을 처리합니다.
+By using the `defaultArbitraryGenerator` option, you have the capability to customize the behavior of the `ArbitraryGenerator`.
+`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 커스터마이징할 수 있습니다.
+
+For instance, you can create an arbitrary generator that produces unique values, as shown in the example below:
+예를 들어 예시와 같이 고유한 값을 생성하는 임의의 생성기를 만들 수 있습니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public static class UniqueArbitraryGenerator implements ArbitraryGenerator {
+private static final Set<Object> UNIQUE = new HashSet<>();
+
+    private final ArbitraryGenerator delegate;
+
+    public UniqueArbitraryGenerator(ArbitraryGenerator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
+        return delegate.generate(context)
+            .filter(
+                obj -> {
+                    if (!UNIQUE.contains(obj)) {
+                        UNIQUE.add(obj);
+                        return true;
+                    }
+                    return false;
+                }
+          );
+    }
+}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class UniqueArbitraryGenerator(private val delegate: ArbitraryGenerator) : ArbitraryGenerator {
+companion object {
+private val UNIQUE = HashSet<Any>()
+}
+
+    override fun generate(context: ArbitraryGeneratorContext): CombinableArbitrary {
+        return delegate.generate(context)
+            .filter { obj ->
+                if (!UNIQUE.contains(obj)) {
+                    UNIQUE.add(obj)
+                    true
+                } else {
+                    false
+                }
+            }
+    }
+}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryGenerator { UniqueArbitraryGenerator(it) }
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+{{< alert icon="📖" text="Notable implementations: 'IntrospectedArbitraryGenerator', 'CompositeArbitraryGenerator'" />}}
+
+-----------------
+
+## Excluding Classes or Packages from Generation
+> `pushExceptGenerateType`, `addExceptGenerateClass`, `addExceptGenerateClasses`, `addExceptGeneratePackage`, `addExceptGeneratePackages`
+
+If you want to exclude the generation of certain types or packages, you can use these options.
+특정 유형이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void testExcludeClass() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.addExceptGenerateClass(String.class)
+.build();
+
+    String actual = sut.giveMeOne(Product.class)
+      .getProductName();
+
+    then(actual).isNull();
+}
+
+@Test
+void testExcludePackage() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.addExceptGeneratePackage("java.lang")
+.build();
+
+    String actual = sut.giveMeOne(String.class);
+
+    then(actual).isNull();
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun testExcludeClass() {
+val fixtureMonkey = FixtureMonkey.builder()
+.addExceptGenerateClass(String::class.java)
+.build()
+
+    val actual = fixtureMonkey.giveMeOne<Product>()
+        .productName
+
+    then(actual).isNull()
+}
+
+@Test
+fun testExcludePackage() {
+val fixtureMonkey = FixtureMonkey.builder()
+.addExceptGeneratePackage("java.lang")
+.build()
+
+    val actual = fixtureMonkey.giveMeOne<String>()
+
+    then(actual).isNull()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Container options
+
+### Container Size
+> `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
+
+`ArbitraryContainerInfo` holds information about the minimum and maximum sizes of a Container type.
+`ArbitraryContainerInfo`은 컨테이너 타입의 최소 및 최대 크기에 대한 정보를 보유합니다.
+You can change the behavior by modifying the `ArbitraryContainerInfoGenerator` using related options.
+관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정하여 동작을 변경할 수 있습니다.
+The following example demonstrates how to customize `ArbitraryContainerInfo` to set the size of all container types to 3.
+다음 예는 모든 컨테이너 타입의 크기를 3으로 설정하도록 `ArbitraryContainerInfo`를 사용자 정의하는 방법을 보여줍니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 3))
+.build();
+
+    List<String> actual = fixtureMonkey.giveMeOne();
+
+    then(actual).hasSize(3);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+val fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryContainerInfoGenerator { context -> ArbitraryContainerInfo(3, 3) }
+.build()
+
+    val actual: List<String> = fixtureMonkey.giveMeOne()
+
+    then(actual).hasSize(3)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### Adding Container type
+> `addContainerType`
+
+You can add a new custom Container type using the `addContainerType` option.
+`addContainerType` 옵션을 사용하여 새 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
+
+Let's say you made a new custom Pair class in Java.
+Java에서 새로운 사용자 지정 Pair 클래스를 만들었다고 가정해 보겠습니다.
+
+You can use this container type by implementing a custom `ContainerPropertyGenerator`, `Introspector` and `DecomposedContainerValueFactory`.
+이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector` 및 `DecomposedContainerValueFactory`를 구현하여 사용할 수 있습니다.
+
+```java
+FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
+    .addContainerType(
+        Pair.class,
+        new PairContainerPropertyGenerator(),
+        new PairIntrospector(),
+        new PairDecomposedContainerValueFactory()
+    )
+	.build();
+```
+
+**custom Introspector:**
+```java
+public class PairIntrospector implements ArbitraryIntrospector, Matcher {
+	private static final Matcher MATCHER = new AssignableTypeMatcher(Pair.class);
+
+	@Override
+	public boolean match(Property property) {
+		return MATCHER.match(property);
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		ArbitraryProperty property = context.getArbitraryProperty();
+		ArbitraryContainerInfo containerInfo = property.getContainerProperty().getContainerInfo();
+		if (containerInfo == null) {
+			return ArbitraryIntrospectorResult.EMPTY;
+		}
+
+		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
+		for (Arbitrary<?> childArbitrary : childrenArbitraries) {
+			builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {
+				list.add(element);
+				return list;
+			});
+		}
+
+		return new ArbitraryIntrospectorResult(
+			builderCombinator.build(it -> new Pair<>(it.get(0), it.get(1)))
+		);
+	}
+}
+```
+
+**custom `ContainerPropertyGenerator`:**
+```java
+public class PairContainerPropertyGenerator implements ContainerPropertyGenerator {
+	@Override
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
+		com.navercorp.fixturemonkey.api.property.Property property = context.getProperty();
+
+		List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
+		if (elementTypes.size() != 2) {
+			throw new IllegalArgumentException(
+				"Pair elementsTypes must be have 1 generics type for element. "
+					+ "propertyType: " + property.getType()
+					+ ", elementTypes: " + elementTypes
+			);
+		}
+
+		AnnotatedType firstElementType = elementTypes.get(0);
+		AnnotatedType secondElementType = elementTypes.get(1);
+		List<com.navercorp.fixturemonkey.api.property.Property> elementProperties = new ArrayList<>();
+		elementProperties.add(
+			new ElementProperty(
+				property,
+				firstElementType,
+				0,
+				0
+			)
+		);
+		elementProperties.add(
+			new ElementProperty(
+				property,
+				secondElementType,
+				1,
+				1
+			)
+		);
+
+		return new ContainerProperty(
+			elementProperties,
+			new ArbitraryContainerInfo(1, 1, false)
+		);
+	}
+}
+```
+
+**custom `DecomposedContainerValueFactory`:**
+```java
+public class PairDecomposedContainerValueFactory implements DecomposedContainerValueFactory {
+	@Override
+	public DecomposedContainerValue from(Object object) {
+		Pair<?, ?> pair = (Pair<?, ?>)obj;
+		List<Object> list = new ArrayList<>();
+		list.add(pair.getFirst());
+		list.add(pair.getSecond());
+		return new DecomposableContainerValue(list, 2);
+	}
+}
+```
+
+-----------------
+
+## Validating Arbitraries
+> `arbitraryValidator`
+
+The `arbitraryValidator` option allows you to replace the default `arbitraryValidator` with your own custom arbitrary validator.
+
+When an instance is `sampled`, the `arbitraryValidator` validates the arbitrary, and if it is invalid, it throws an exception.
+This process is repeated 1,000 times, and if the instance is still invalid, a `TooManyFilterMissesException` would be thrown.
+
+{{< alert icon="📖" text="Notable implementations: 'JakartaArbitraryValidator', 'JavaxArbitraryValidator'" />}}
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.arbitraryValidator(obj -> {
+throw new ValidationFailedException("thrown by custom ArbitraryValidator", new HashSet<>());
+})
+.build();
+
+thenThrownBy(() -> fixtureMonkey.giveMeOne(String.class))
+.isExactlyInstanceOf(FilterMissException.class);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.arbitraryValidator { obj ->
+throw ValidationFailedException("thrown by custom ArbitraryValidator", HashSet())
+}
+.build()
+
+assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
+.isExactlyInstanceOf(FilterMissException::class.java)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Arbitrary Generation Retry Limits
+> `generateMaxTries`, `generateUniqueMaxTries`
+
+The `generateMaxTries` option allows you to control the maximum number of attempts to generate a valid object from an arbitrary.
+If an object cannot be generated successfully after exceeding this limit (default is 1,000 attempts), a `TooManyFilterMissesException` will be thrown.
+
+Additionally, Fixture Monkey ensures the generation of unique values for map keys and set elements.
+The `generateUniqueMaxTries` option allows you to specify the maximum number of attempts (also defaults to 1,000) that will be made to generate this unique value.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.generateMaxTries(100)
+.generateUniqueMaxTries(100)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.generateMaxTries(100)
+.generateUniqueMaxTries(100)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Interface Implementations
+> `interfaceImplements`
+
+`interfaceImplements` is an option used to specify the available implementations for an interface.
+
+When you don't specify this option, an ArbitraryBuilder for an interface will always result in a null value when sampled.
+However, when you do specify this option, Fixture Monkey will randomly generate one of the specified implementations whenever an ArbitraryBuilder for the interface is sampled.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+interface FixedValue {
+Object get();
+}
+
+class IntegerFixedValue implements FixedValue {
+@Override
+public Object get() {
+return 1;
+}
+}
+
+class StringFixedValue implements FixedValue {
+@Override
+public Object get() {
+return "fixed";
+}
+}
+
+class GenericFixedValue<T> {
+T value;
+}
+
+@Test
+void sampleGenericInterface() {
+// given
+List<Class<? extends FixedValue>> implementations = new ArrayList<>();
+implementations.add(IntegerFixedValue.class);
+implementations.add(StringFixedValue.class);
+
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .interfaceImplements(FixedValue.class, implementations)
+        .build();
+
+    // when
+    Object actual = fixtureMonkey.giveMeBuilder(new TypeReference<GenericGetFixedValue<FixedValue>>() {})
+        .setNotNull("value")
+        .sample()
+        .getValue()
+        .get();
+
+    // then
+    then(actual).isIn(1, "fixed");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+interface FixedValue {
+fun get(): Any
+}
+
+class IntegerFixedValue : FixedValue {
+override fun get(): Any {
+return 1
+}
+}
+
+class StringFixedValue : FixedValue {
+override fun get(): Any {
+return "fixed"
+}
+}
+
+class GenericFixedValue<T> {
+val value: T
+}
+
+@Test
+fun sampleGenericInterface() {
+// given
+val implementations: MutableList<Class<out FixedValue>> = List.of(IntegerFixedValue::class.java, StringFixedValue::class.java)
+
+    val fixtureMonkey = FixtureMonkey.builder()
+        .interfaceImplements(FixedValue::class.java, implementations)
+        .build()
+
+    // when
+    val actual = fixtureMonkey.giveMeBuilder<GenericGetFixedValue<FixedValue>>()
+        .sample()
+        .getValue()
+        .get()
+
+    // then
+    then(actual).isIn(1, "fixed")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -1,0 +1,11 @@
+---
+title: "Generation Options"
+images: []
+menu:
+docs:
+parent: "fixture-monkey-options"
+identifier: "options"
+weight: 52
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -45,7 +45,7 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 ## 임의적인 생성
 `Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
-그런 다음 임의적으로 생성된 것을 기반으로 객체가 생성됩니다.
+그 다음에 임의 생성 전략을 기반으로 객체가 생성됩니다.
 사용자는 직접 `ArbitraryIntrospector` 를 구현하여 사용자 정의 `Introspector` 를 생성할 수 있는 유연성을 가지게 됩니다.
 
 ### ObjectIntrospector
@@ -251,7 +251,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 Java에서 새로운 사용자 정의 Pair 클래스를 만든다고 가정해 보겠습니다.
 
-이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
+이 컨테이너 타입은 사용자 정의 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
 
 ```java
 FixtureMonkey fixtureMonkey=FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -206,7 +206,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 ## 컨테이너 옵션
 
-### Container Size
+### 컨테이너 크기
 > `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
 
 `ArbitraryContainerInfo` 는 컨테이너 타입의 최소, 최대 크기에 대한 정보를 가집니다.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -12,20 +12,15 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 이러한 옵션은 `FixtureMonkeyBuilder` 를 통해 접근할 수 있습니다.
 
-## Property Generation
+## 프로퍼티 생성
 ### PropertyGenerator
 > `defaultPropertyGenerator`, `pushPropertyGenerator`, `pushAssignableTypePropertyGenerator`, `pushExactTypePropertyGenerator`
 
-`PropertyGenerator` creates child properties of the given `ObjectProperty`.
-`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다. 
-The child property can be a field, JavaBeans property, method or constructor parameter within the parent `ObjectProperty`.
+`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다.
 자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 패러미터가 될 수 있습니다. 
-There are scenarios where you might want to customize how these child properties are generated.
-자식 프로퍼티들이 생성되는 방식을 사용자 정의하고자 하는 시나리오들이 있습니다.
+이러한 자식 프로퍼티가 생성되는 방식을 사용자 정의하는 몇 가지 방법이 있습니다.
 
-The `PropertyGenerator` options allow you to specify how child properties of each type are generated.
-`PropertyGenerator` 옵션으로 각 타입의 자식 프로퍼티가 어떻게 생성되는지 지정할 수 있습니다.
-This option is mainly used when you want to exclude generating some properties when the parent property has abnormal child properties.
+`PropertyGenerator` 옵션은 각 타입의 자식 프로퍼티가 생성되는 방식을 지정할 수 있습니다.
 이 옵션은 주로 부모 프로퍼티가 비정상적인 자식 프로퍼티를 가질 때 일부 프로퍼티 생성을 제외하고자 할 때 사용됩니다.
 
 {{< alert icon="📖" text="Notable implementations: 'FieldPropertyGenerator', 'JavaBeansPropertyGenerator'" />}}
@@ -33,65 +28,56 @@ This option is mainly used when you want to exclude generating some properties w
 ### ObjectPropertyGenerator
 > `defaultObjectPropertyGenerator`, `pushObjectPropertyGenerator`, `pushAssignableTypeObjectPropertyGenerator`, `pushExactTypeObjectPropertyGenerator`
 
-`ObjectPropertyGenerator` generates the [`ObjectProperty`](../concepts/#objectProperty) based on a given context.
 `ObjectPropertyGenerator` 는 주어진 컨텍스트에 기반하여 [`ObjectProperty`](../concepts/#objectProperty)를 생성합니다.
-With options related to `ObjectPropertyGenerator` you can customize how the `ObjectProperty` is generated.
 `ObjectPropertyGenerator` 관련 옵션을 사용하면 `ObjectProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'DefaultObjectPropertyGenerator'" />}}
 
 ### ContainerPropertyGenerator
 > `pushContainerPropertyGenerator`, `pushAssignableTypeContainerPropertyGenerator`, `pushExactTypeContainerPropertyGenerator`
 
-The `ContainerPropertyGenerator` determines how to generate [`ContainerProperty`](../concepts/#containerProperty) within a given context.
 `ContainerPropertyGenerator` 는 주어진 컨텍스트에서 [`ContainerProperty`](../concepts/#containerProperty) 를 생성하는 방법을 결정합니다.
-With options related to `ContainerPropertyGenerator` you can customize how the `ContainerProperty` is generated.
 `ContainerPropertyGenerator` 관련 옵션을 사용하면 `ContainerProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'ArrayContainerPropertyGenerator', 'MapContainerPropertyGenerator'" />}}
 
 -----------------
 
-## Arbitrary Generation
-An `Introspector` determines how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy based on the provided context(which includes information about generated properties).
-`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 적절한 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
-The object is then generated based on this arbitrary generated.
-이후 이 객체는 임의 생성된 기반으로 생성됩니다.
-You have the flexibility to create a custom `Introspector` by implementing your own `ArbitraryIntrospector`.
+## 임의적인 생성
+`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
+그런 다음 임의적으로 생성된 것을 기반으로 객체가 생성됩니다.
+사용자는 직접 `ArbitraryIntrospector` 를 구현하여 사용자 정의 `Introspector` 를 생성할 수 있는 유연성을 가지게 됩니다.
 
 ### ObjectIntrospector
 > `objectIntrospcetor`
 
-The `objectIntrospector` option allows you to specify the default behavior when generating an object.
-객체 생성 시 기본 동작을 지정하는 `objectIntrospector` 관련 옵션을 사용하면 객체를 생성할 때 기본 동작을 지정할 수 있습니다.
-As discussed in the [introspector section](../../generating-objects/introspector), you can alter the default introspector to use predefined introspectors provided by Fixture Monkey or create your own custom introspector.
-[introspector section](../../generating-objects/introspector)에서 설명한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+`objectIntrospector` 관련 옵션을 사용하면 객체 생성 시 기본 동작을 지정할 수 있습니다.
+[introspector section](../../generating-objects/introspector)에서 언급한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'BeanArbitraryIntrospector', 'BuilderArbitraryIntrospector'" />}}
 
 ### ArbitraryIntrospector
 > `pushArbitraryIntrospector`, `pushAssignableTypeArbitraryIntrospector`, `pushExactTypeArbitraryIntrospector`
 
-If you need to change the `ArbitraryIntrospector` for a specific type you can use the above options.
-특정 유형에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+특정 타입에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'BooleanIntrospector', 'EnumIntrospector'" />}}
 
 ### ContainerIntrospector
 > pushContainerIntrospector
 
-Especially for container types, you can change the `ArbitraryIntrospector` using the `pushContainerIntrospector` option.
 특히 컨테이너 타입의 경우, `pushContainerIntrospector` 옵션을 사용하여 `ArbitraryIntrospector` 를 변경할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'ListIntrospector', 'MapIntrospector'" />}}
 
 -----------------
 
-## Arbitrary Generation
-The `ArbitraryIntrospector` is responsible for defining how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy and generating an arbitrary.
-`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 개체를 생성하여 Fixture Monkey가 개체를 생성하는 방법을 정의하는 역할을 담당합니다.
-The actual creation of the final arbitrary(`CombinableArbitrary`) from the arbitrary is done by the `ArbitraryGenerator`, which handles the request by delegating to the `ArbitraryIntrospcetor`.
-임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator`에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor`에 요청을 위임하여 요청을 처리합니다.
-By using the `defaultArbitraryGenerator` option, you have the capability to customize the behavior of the `ArbitraryGenerator`.
-`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 커스터마이징할 수 있습니다.
+## 임의적인 생성
+`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 객체를 생성하여 Fixture Monkey가 객체를 생성하는 방법을 정의하는 역할을 합니다.
+임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator` 에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor` 에 요청을 위임하여 요청을 처리합니다.
+`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 사용자 정의 할 수 있습니다.
 
-For instance, you can create an arbitrary generator that produces unique values, as shown in the example below:
-예를 들어 예시와 같이 고유한 값을 생성하는 임의의 생성기를 만들 수 있습니다:
+예를 들어, 아래의 예시와 같이 고유한 값을 생성하는 arbitrary generator를 만들 수 있습니다:
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -156,11 +142,10 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Excluding Classes or Packages from Generation
+## 클래스, 패키지 생성 제외 옵션
 > `pushExceptGenerateType`, `addExceptGenerateClass`, `addExceptGenerateClasses`, `addExceptGeneratePackage`, `addExceptGeneratePackages`
 
-If you want to exclude the generation of certain types or packages, you can use these options.
-특정 유형이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
+특정 타입이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -219,17 +204,14 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Container options
+## 컨테이너 옵션
 
 ### Container Size
 > `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
 
-`ArbitraryContainerInfo` holds information about the minimum and maximum sizes of a Container type.
-`ArbitraryContainerInfo`은 컨테이너 타입의 최소 및 최대 크기에 대한 정보를 보유합니다.
-You can change the behavior by modifying the `ArbitraryContainerInfoGenerator` using related options.
-관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정하여 동작을 변경할 수 있습니다.
-The following example demonstrates how to customize `ArbitraryContainerInfo` to set the size of all container types to 3.
-다음 예는 모든 컨테이너 타입의 크기를 3으로 설정하도록 `ArbitraryContainerInfo`를 사용자 정의하는 방법을 보여줍니다.
+`ArbitraryContainerInfo` 는 컨테이너 타입의 최소, 최대 크기에 대한 정보를 가집니다.
+관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정함으로써 동작 방식을 변경할 수 있습니다.
+다음 예시는 `ArbitraryContainerInfo` 의 모든 컨테이너 타입의 크기를 3으로 설정하도록 사용자 정의하는 방법을 설명합니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -262,17 +244,14 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-### Adding Container type
+### 컨테이너 타입 추가
 > `addContainerType`
 
-You can add a new custom Container type using the `addContainerType` option.
-`addContainerType` 옵션을 사용하여 새 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
+`addContainerType` 옵션을 사용하여 새로운 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
 
-Let's say you made a new custom Pair class in Java.
-Java에서 새로운 사용자 지정 Pair 클래스를 만들었다고 가정해 보겠습니다.
+Java에서 새로운 사용자 정의 Pair 클래스를 만든다고 가정해 보겠습니다.
 
-You can use this container type by implementing a custom `ContainerPropertyGenerator`, `Introspector` and `DecomposedContainerValueFactory`.
-이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector` 및 `DecomposedContainerValueFactory`를 구현하여 사용할 수 있습니다.
+이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
 
 ```java
 FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
@@ -379,13 +358,12 @@ public class PairDecomposedContainerValueFactory implements DecomposedContainerV
 
 -----------------
 
-## Validating Arbitraries
+## 임의성 유효성 검증
 > `arbitraryValidator`
 
-The `arbitraryValidator` option allows you to replace the default `arbitraryValidator` with your own custom arbitrary validator.
-
-When an instance is `sampled`, the `arbitraryValidator` validates the arbitrary, and if it is invalid, it throws an exception.
-This process is repeated 1,000 times, and if the instance is still invalid, a `TooManyFilterMissesException` would be thrown.
+`arbitraryValidator` 옵션을 사용하면 기본 `arbitraryValidator` 를 사용자 정의 임의의 유효성 검사기로 대체할 수 있습니다.
+인스턴스가 `sampled` 되면 `arbitraryValidator` 는 임의의 유효성을 검사하고 유효하지 않은 경우 예외를 던집니다.
+이 프로세스는 1,000회 반복되며, 인스턴스가 여전히 유효하지 않다면 `TooManyFilterMissesException` 예외를 던질 것입니다.
 
 {{< alert icon="📖" text="Notable implementations: 'JakartaArbitraryValidator', 'JavaxArbitraryValidator'" />}}
 
@@ -418,14 +396,14 @@ assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
 
 -----------------
 
-## Arbitrary Generation Retry Limits
+## 임의적인 생성 재시도 제한
 > `generateMaxTries`, `generateUniqueMaxTries`
 
-The `generateMaxTries` option allows you to control the maximum number of attempts to generate a valid object from an arbitrary.
-If an object cannot be generated successfully after exceeding this limit (default is 1,000 attempts), a `TooManyFilterMissesException` will be thrown.
+`generateMaxTries` 옵션을 사용하면 임의의 객체에서 유효한 객체를 생성하기 위한 최대 시도 횟수를 제한할 수 있습니다.
+제한(기본값 1,000회)을 초과하여 객체를 성공적으로 생성할 수 없는 경우, `TooManyFilterMissesException` 예외를 던질 것입니다.
 
-Additionally, Fixture Monkey ensures the generation of unique values for map keys and set elements.
-The `generateUniqueMaxTries` option allows you to specify the maximum number of attempts (also defaults to 1,000) that will be made to generate this unique value.
+추가적으로, Fixture Monkey는 Map의 키(key)와 Set의 요소(element)에 대한 고유한 값 생성을 보장합니다.
+`generateUniqueMaxTries` 옵션을 사용하면 이 고유한 값을 생성하기 위해 시도 최대 횟수(기본값 1,000회)를 지정할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -448,13 +426,13 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Interface Implementations
+## 인터페이스 구현
 > `interfaceImplements`
 
-`interfaceImplements` is an option used to specify the available implementations for an interface.
+`interfaceImplements` 은 인터페이스에 사용 가능한 구현체를 지정할 때 사용되는 옵션입니다.
 
-When you don't specify this option, an ArbitraryBuilder for an interface will always result in a null value when sampled.
-However, when you do specify this option, Fixture Monkey will randomly generate one of the specified implementations whenever an ArbitraryBuilder for the interface is sampled.
+이 옵션을 지정하지 않으면, 인터페이스에 대한 ArbitraryBuilder가 샘플링될 때 항상 null 값을 반환합니다.
+하지만 이 옵션을 지정하면 Fixture Monkey는 인터페이스에 대한 ArbitraryBuilder를 샘플링할 때마다 지정된 구현체 중 하나를 임의로 생성합니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
@@ -1,0 +1,11 @@
+---
+title: "Other Options"
+images: []
+menu:
+docs:
+parent: "fixture-monkey-options"
+identifier: "options"
+weight: 53
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
@@ -8,4 +8,29 @@ identifier: "options"
 weight: 53
 ---
 
-### 한국어 번역 필요
+이 섹션에서는 `FixtureMonkeyBuilder` 가 제공하는 몇 가지 추가 옵션을 설명합니다.
+
+### plugin
+
+Fixture Monkey는 플러그인을 통한 타사 라이브러리 지원 등 몇 가지 추가 기능을 제공합니다.
+플러그인 옵션을 사용하여 이 추가 기능을 사용할 수 있습니다.
+
+예시로 아래와 같이 Jackson 플러그인을 추가할 수 있습니다.
+이렇게 하면 `JacksonObjectArbitraryIntrospector` 그리고 Jackson annotation support와 같은 Jackson의 기능을 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.plugin(new JacksonPlugin())
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(JacksonPlugin())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/generating-objects/_index.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Generating Objects"
+images: []
+menu:
+docs:
+weight: 30
+---

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -8,5 +8,200 @@ identifier: "fixturemonkey"
 weight: 31
 ---
 
-### 한국어 번역 필요
+테스트 픽스처를 생성하기 위해서는 우선 `FixtureMonkey` 인스턴스를 생성해야 합니다. 해당 인스턴스는 테스트 픽스쳐 생성을 담당합니다.
+
+`FixtureMonkey` 인스턴스를 생성하기 위해서는 `create()` 메서드를 사용하면 됩니다. Kotlin 환경에서는 Kotlin 플러그인을 추가해야 합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.create();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey
+.plugin(KotlinPlugin())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+테스트 픽스처를 생성하거나 커스텀하기 위해서는 FixtureMonkey 빌더를 사용하여 옵션을 추가할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    + options...
+    .build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+    + options...
+    .build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+어떤 옵션을 사용할 수 있는지에 대한 정보는 [Fixture Monkey 옵션](../../fixture-monkey-options/options)을 참고해주세요.
+
+## 인스턴스 생성
+
+`FixtureMonkey` 클래스는 테스트에 필요한 객체 생성에 도움 되는 메서드를 제공합니다.
+
+### giveMeOne()
+특정 타입의 인스턴스가 필요하다면 `giveMeOne()`을 사용할 수 있습니다. 인자로 클래스 또는 타입을 전달해주세요.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = fixtureMonkey.giveMeOne(Product.class);
+
+List<String> strList = fixtureMonkey.giveMeOne(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product: Product = fixtureMonkey.giveMeOne()
+
+val strList: List<String> = fixtureMonkey.giveMeOne()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### giveMe()
+특정한 타입으로 고정된 두 개 이상의 인스턴스가 필요하다면 `giveMe()`를 사용할 수 있습니다. 원하는 크기를 지정하여 인스턴스의 스트림 또는 리스트를 생성할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Stream<Product> productStream = fixtureMonkey.giveMe(Product.class);
+
+Stream<List<String>> strListStream = fixtureMonkey.giveMe(new TypeReference<List<String>>() {});
+
+List<Product> productList = fixtureMonkey.giveMe(Product.class, 3);
+
+List<List<String>> strListList = fixtureMonkey.giveMe(new TypeReference<List<String>>() {}, 3);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productSequence: Sequence<Product> = fixtureMonkey.giveMe()
+
+val strListSequence: Sequence<List<String>> = fixtureMonkey.giveMe()
+
+val productList: List<Product> = fixtureMonkey.giveMe(3)
+
+val strListList: List<List<String>> = fixtureMonkey.giveMe(3)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeBuilder()
+인스턴스를 커스텀 할 경우 `giveMeBuilder()`를 사용할 수 있습니다. 이는 주어진 타입의 `ArbitraryBuilder`를 반환합니다.
+`ArbitraryBuilder`는 주어진 클래스의 [`Arbitrary`](../arbitrary) 객체를 빌드하는 데 사용되는 Fixture Monkey의 클래스입니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+ArbitraryBuilder<List<String>> strListBuilder = fixtureMonkey.giveMeBuilder(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val strListBuilder: ArbitraryBuilder<List<String>> = fixtureMonkey.giveMeBuilder()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+이미 생성된 인스턴에 추가로 커스텀하는 경우 `giveMeBuilder()`를 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Product product = new Product(1L, "Book", ...);
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(product);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val product = Product(1L, "Book", ...)
+
+val productBuilder = fixtureMonkey.giveMeBuilder(product)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+`ArbitraryBuilder`는 픽스처를 커스텀하는 데 사용될 수 있습니다. 커스텀 옵션에 대한 자세한 내용은 [커스텀 객체](../../customizing-objects/apis)를 참고하십시오.
+
+`ArbitraryBuilder`에서 인스턴스를 얻기 위해 `ArbitraryBuilder`의 `sample()`, `sampleList()`, `sampleStream()` 메서드를 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Product product = productBuilder.sample();
+List<Product> productList = productBuilder.sampleList(3);
+Stream<Product> productStream = productBuilder.sampleStream();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val product = productBuilder.sample()
+val productList = productBuilder.sampleList(3)
+val productStream = productBuilder.sampleStream()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+인스턴스가 아닌 임의 객체(`Arbitrary`)만 필요한 경우 옵션을 추가하지 않고 `build()` 메서드만 호출하면 됩니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+ArbitraryBuilder<Product> productBuilder = fixtureMonkey.giveMeBuilder(Product.class);
+
+Arbitrary<Product> productArbitrary = productBuilder.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productBuilder: ArbitraryBuilder<Product> = fixtureMonkey.giveMeBuilder()
+
+val productArbitrary = productBuilder.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### giveMeArbitrary()
+특정한 유형의 `Arbitrary`를 얻으려면 `giveMeArbitrary()` 메서드를 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+Arbitrary<Product> productArbitrary = fixtureMonkey.giveMeArbitrary(Product.class);
+
+Arbitrary<List<String>> strListArbitrary = fixtureMonkey.giveMeArbitrary(new TypeReference<List<String>>() {});
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val productArbitrary: Arbitrary<Product> = fixtureMonkey.giveMeArbitrary()
+
+val strListArbitrary: Arbitrary<List<String>> = fixtureMonkey.giveMeArbitrary()
+
+{{< /tab >}}
+{{< /tabpane>}}
 

--- a/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/fixture-monkey.md
@@ -1,0 +1,12 @@
+---
+title: "FixtureMonkey"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "fixturemonkey"
+weight: 31
+---
+
+### 한국어 번역 필요
+

--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -8,4 +8,120 @@ identifier: "generating-complex-types"
 weight: 32
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 직접 생성하기 어려운 복잡한 객체도 테스트 픽스처로 쉽게 생성할 수 있습니다.
+
+이 페이지는 생성할 수 있는 다양한 타입의 객체를 보여줍니다.
+
+## Java
+### Generic Objects
+```java
+@Value
+public static class GenericObject<T> {
+   T foo;
+}
+
+@Value
+public static class GenericArrayObject<T> {
+   GenericObject<T>[] foo;
+}
+
+@Value
+public static class TwoGenericObject<T, U> {
+   T foo;
+   U bar;
+}
+
+@Value
+public static class ThreeGenericObject<T, U, V> {
+   T foo;
+   U bar;
+   V baz;
+}
+```
+
+### Generic Interfaces
+```java
+public interface GenericInterface<T> {
+}
+
+@Value
+public static class GenericInterfaceImpl<T> implements GenericInterface<T> {
+   T foo;
+}
+
+public interface TwoGenericInterface<T, U> {
+}
+
+@Value
+public static class TwoGenericImpl<T, U> implements TwoGenericInterface<T, U> {
+   T foo;
+
+   U bar;
+}
+```
+
+### SelfReference
+```java
+@Value
+public class SelfReference {
+   String foo;
+   SelfReference bar;
+}
+
+@Value
+public class SelfReferenceList {
+   String foo;
+   List<SelfReferenceList> bar;
+}
+```
+
+### Interface
+```java
+public interface Interface {
+   String foo();
+
+   Integer bar();
+}
+
+public interface InheritedInterface extends Interface {
+   String foo();
+}
+
+public interface InheritedInterfaceWithSameNameMethod extends Interface {
+   String foo();
+}
+
+public interface ContainerInterface {
+   List<String> baz();
+
+   Map<String, Integer> qux();
+}
+
+public interface InheritedTwoInterface extends Interface, ContainerInterface {
+}
+```
+
+## Kotlin
+### Generic Objects
+```kotlin
+class Generic<T>(val foo: T)
+
+class GenericImpl(val foo: Generic<String>)
+```
+
+### SelfReference
+```kotlin
+class SelfReference(val foo: String, val bar: SelfReference?)
+```
+
+### Sealed class, Value class
+```kotlin
+sealed class SealedClass
+
+object ObjectSealedClass : SealedClass()
+
+class SealedClassImpl(val foo: String) : SealedClass()
+
+@JvmInline
+value class ValueClass(val foo: String)
+```

--- a/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/generating-complex-types.md
@@ -1,0 +1,11 @@
+---
+title: "Generating Complex Types"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "generating-complex-types"
+weight: 32
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/generating-objects/instantiate-methods.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/instantiate-methods.md
@@ -1,5 +1,5 @@
 ---
-title: "Instantiate Methods"
+title: "객체 생성 방법 지정하기"
 images: []
 menu:
 docs:
@@ -8,4 +8,658 @@ identifier: "instantiate-methods"
 weight: 32
 ---
 
-### 한국어 번역 필요
+각 테스트마다 객체 생성을 다르게 하고 싶을 수 있습니다.
+예를 들어, 같은 클래스에서도 첫 테스트에서는 생성자로 객체를 생성하고, 다른 테스트에서는 팩터리 메서드로 객체를 생성하고 싶을 수 있습니다
+
+Fixture Monkey는 `instantiate()` 메서드를 통해 객체 생성 방법을 선택할 수 있습니다.
+{{< alert icon="💡" text="Kotlin Plugin을 추가한다면 커스텀 DSL에서 instantiateBy() 메서드를 사용할 수 있습니다." />}}
+
+`ArbitraryBuilder`에서 원하는 인스턴스 생성 방법(생성자 또는 팩토리 메서드)으로 객체를 생성할 수 있습니다.
+
+그러나 `ArbitraryBuilder`를 사용할 때마다 매번 객체 생성 방법을 지정해야 하는 것은 아닙니다.
+전역 옵션으로 FixtureMonkey 인스턴스에서 객체 생성 방식을 지정해주고 싶다면, [Introspector](../introspector) 페이지를 참고해주세요.
+
+`instantiate()` 메서드는 `ArbitraryBuilder`를 사용할 때 객체를 편리하게 생성할 수 있도록 도와주는 메서드일 뿐입니다.
+
+## 생성자
+몇몇 다른 생성자를 가진 커스텀 클래스가 있다고 가정해보겠습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Value
+public class Product {
+    long id;
+
+    String productName;
+
+    long price;
+
+    List<String> options;
+
+    Instant createdAt;
+
+    public Product() {
+        this.id = 0;
+        this.productName = null;
+        this.price = 0;
+        this.options = null;
+        this.createdAt = null;
+    }
+
+    public Product(
+        String str,
+        long id,
+        long price
+    ) {
+        this.id = id;
+        this.productName = str;
+        this.price = price;
+        this.options = Collections.emptyList();
+        this.createdAt = Instant.now();
+    }
+
+    public Product(
+        long id,
+        long price,
+        List<String> options
+    ) {
+        this.id = id;
+        this.productName = "defaultProductName";
+        this.price = price;
+        this.options = options;
+        this.createdAt = Instant.now();
+    }
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class Product(
+    val id: Long,
+    val productName: String,
+    val price: Long,
+    val options: List<String>,
+    val createdAt: Instant
+) {
+    constructor() : this(
+        id = 0,
+        productName = "",
+        price = 0,
+        options = emptyList(),
+        createdAt = Instant.now()
+    )
+
+    constructor(str: String, id: Long, price: Long) : this(
+        id = id,
+        productName = str,
+        price = price,
+        options = emptyList(),
+        createdAt = Instant.now()
+    )
+
+    constructor(id: Long, price: Long, options: List<String>) : this(
+        id = id,
+        productName = "defaultProductName",
+        price = price,
+        options = options,
+        createdAt = Instant.now()
+    )
+
+    companion object {
+        fun from(id: Long, price: Long): Product = Product("product", id, price)
+    }
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+Fixture Monkey를 사용하면 여러 생성자 중 원하는 생성자를 선택하여 객체를 만들 수 있습니다.
+
+### 인자가 없는 생성자 또는 기본 생성자
+`instantiate` 메서드를 사용하여 생성자에게 객체를 생성할 수 있도록 `ArbitraryBuilder`에 지시하는 기본적인 방법은 다음과 같습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    Product product = fixtureMonkey.giveMeBuilder(Product.class)
+        .instantiate(constructor())
+        .sample();
+
+    then(product.getId()).isEqualTo(0);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            constructor()
+        }
+        .sample()
+
+    then(product.productName).isEqualTo("")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+생성자 메서드를 사용하도록 지정하려면 `constructor()` 옵션을 전달하면 됩니다.
+만약 인자가 없는 생성자가 있다면 해당 생성자를 사용하고, 없다면 첫 번째로 작성된 생성자를 사용합니다.
+
+### 특정 생성자 지정
+클래스가 두 개 이상의 생성자를 가진다면 필요한 파라미터 정보를 제공하여 원하는 생성자를 지정할 수 있습니다.
+다음 두 개의 생성자를 가진 Product 클래스를 살펴봅시다.
+
+options를 비어있는 리스트로 초기화해주는 생성자를 사용하려면 다음과 같이 매개 변수를 지정합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    Product product = fixtureMonkey.giveMeBuilder(Product.class)
+        .instantiate(
+            constructor()
+                .parameter(String.class)
+                .parameter(long.class)
+                .parameter(long.class)
+        )
+    .sample();
+
+    then(product.getOptions()).isEmpty();
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@RepeatedTest(TEST_COUNT)
+fun test() {
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            constructor<Product> {
+                parameter<String>()
+                parameter<Long>()
+                parameter<Long>()
+        }
+    }
+    .sample()
+
+    then(product.options).isEmpty()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+productName을 "defaultProductName"으로 하는 다른 생성자를 사용하려면 다음처럼 매개 변수 정보만 변경하면 됩니다.
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+constructor()
+    .parameter(long.class)
+    .parameter(long.class)
+    .parameter(new TypeReference<List<String>>(){})
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+constructor<Product> {
+    parameter<Long>()
+    parameter<Long>()
+    parameter<List<String>>()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+참고로 private 생성자를 사용하는 것도 가능합니다.
+
+### 매개변수 이름으로 힌트 제공
+생성자에 특정 값을 전달하려는 경우 매개변수 이름으로 힌트를 추가할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    Product product = fixtureMonkey.giveMeBuilder(Product.class)
+        .instantiate(
+            constructor()
+                .parameter(String.class, "str")
+                .parameter(long.class)
+                .parameter(long.class)
+            )
+        .set("str", "book")
+        .sample();
+
+    then(product.getProductName()).isEqualTo("book");
+    then(product.getOptions()).isEmpty();
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            constructor<Product> {
+                parameter<String>("str")
+                parameter<Long>()
+                parameter<Long>()
+        }
+    }
+    .set("str", "book")
+    .sample()
+
+    then(product.productName).isEqualTo("book")
+    then(product.options).isEmpty()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+이 예제에서는 제품 이름에 대한 매개 변수 이름 힌트를 "str"으로 제공합니다.
+이를 통해 `set()` 함수를 사용하여 제품 이름을 원하는 값(이 경우 "책"을 의미합니다.)으로 설정할 수 있습니다.
+
+힌트를 어떤 이름으로든 설정할 수 있지만, 혼동을 피하기 위해 생성자 매개변수에 이름을 사용하는 것이 좋습니다.
+또한 매개변수 이름 힌트를 사용하여 이름을 변경한 후에는 더 이상 필드 이름 "productName"을 사용하여 설정할 수 없습니다.
+
+### 기본 인자 설정 (Kotlin)
+Kotlin에서는 생성자 매개 변수 옵션에 추가 값을 전달할 수 있는 유연성이 있어 기본 인수를 사용할 경우 사용 여부를 결정할 수 있습니다.
+
+```kotlin
+@Test
+fun test() {
+    class Product(val productName: String = "defaultProductName")
+
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            constructor {
+                parameter<String>(useDefaultArgument = true)
+            }
+        }
+        .sample()
+
+    then(product.productName).isEqualTo("defaultProductName")
+}
+```
+
+### 제네릭 객체
+제네릭 객체도 비슷한 방식으로 객체를 생성할 수 있습니다.
+샘플 클래스 `GenericObject`를 살펴보겠습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Value
+public class GenericObject<T> {
+    T value;
+
+    public GenericObject(T value) {
+        this.value = value;
+    }
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class GenericObject<T>(var value: T)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    ConstructorTestSpecs.GenericObject<String> genericObject = fixtureMonkey.giveMeBuilder(
+        new TypeReference<ConstructorTestSpecs.GenericObject<String>>() {
+        })
+        .instantiate(
+            constructor()
+                .parameter(String.class)
+        )
+        .sample();
+
+    then(genericObject).isNotNull();
+    then(genericObject.getValue()).isNotNull();
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val genericObject = fixtureMonkey.giveMeBuilder<GenericObject<String>>()
+        .instantiateBy {
+            constructor() {
+                parameter<String>()
+            }
+        }
+        .sample()
+
+    then(genericObject).isNotNull()
+    then(genericObject.value).isNotNull()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+제네릭 객체로 작업할 때 생성자를 실제 타입으로 사용하도록 지정할 수 있습니다.
+
+### 중첩된 객체가 포함된 생성자
+중첩된 객체와 관련된 시나리오에서 생성자를 사용하여 두 객체 생성하는 경우 각 타입을 지정하거나 사용할 생성자를 지정할 수 있습니다.
+
+예를 들어 `Product` 클래스를 사용하는 `ProductList` 클래스를 생각해 보겠습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Value
+public class ProductList {
+    String listName;
+    List<Product> list;
+
+    public ProductList(List<Product> list) {
+        this.listName = "defaultProductListName";
+        this.list = list;
+    }
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class ProductList(val listName: String, val list: List<Product>) {
+    constructor(list: List<Product>) : this("defaultProductListName", list)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+다음과 같이 생성자와 함께 `ProductList`와 `Product` 모두에 특정 생성자를 사용하도록 지정할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    ProductList productList = fixtureMonkey.giveMeBuilder(ProductList.class)
+        .instantiate(
+            ProductList.class,
+            constructor()
+                .parameter(new TypeReference<List<Product>>() {}, "list")
+        )
+        .instantiate(
+            Product.class,
+            constructor()
+                .parameter(long.class)
+                .parameter(long.class)
+                .parameter(new TypeReference<List<String>>(){})
+        )
+        .size("list", 1)
+        .sample();
+
+    then(productList.getListName()).isEqualTo("defaultProductListName");
+    then(productList.getList()).hasSize(1);
+    then(productList.getList().get(0).getProductName()).isEqualTo("defaultProductName");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val productList = fixtureMonkey.giveMeBuilder<ProductList>()
+        .instantiateBy {
+            constructor<ProductList> {
+                parameter<List<Product>>("list")
+            }
+            constructor<Product> {
+                parameter<Long>()
+                parameter<Long>()
+                parameter<List<String>>()
+            }
+        }
+        .size("list", 1)
+        .sample()
+
+    then(productList.listName).isEqualTo("defaultProductListName")
+    then(productList.list).hasSize(1)
+    then(productList.list[0].productName).isEqualTo("defaultProductName")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+{{< alert icon="💡" text="객체를 생성하는 메서드 내에서 서로 다른 프로퍼티에 대해 생성자 메서드와 팩토리 메서드 접근 방식을 모두 결합할 수도 있습니다. 위의 예제에서 ProductList는 팩토리 메서드를 사용하여 초기화할 수 있고, Product는 생성자를 사용하여 인스턴스화할 수 있습니다." />}}
+
+## 팩토리 메서드
+객체를 생성하는 두 번째 방법은 팩토리 메서드를 사용하는 것입니다.
+
+'from'이라는 팩토리 메서드가 포함된 위의 동일한 Product 클래스를 생각해 보겠습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Value
+public class Product {
+    long id;
+
+    String productName;
+
+    long price;
+
+    List<String> options;
+
+    Instant createdAt;
+
+    public Product(
+      String productName,
+      long id,
+      long price
+    ) {
+        this.id = id;
+        this.productName = productName;
+        this.price = price;
+        this.options = Collections.emptyList();
+        this.createdAt = Instant.now();
+    }
+
+    public static Product from(long id, long price) {
+        return new Product("product", id, price);
+    }
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class Product(
+    val id: Long,
+    val productName: String,
+    val price: Long,
+    val options: List<String> = emptyList(),
+    val createdAt: Instant = Instant.now()
+) {
+    companion object {
+        fun from(id: Long, price: Long): Product {
+            return Product("product", id, price)
+        }
+    }
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+
+### 특정 팩토리 메서드 사용
+메서드 이름을 제공하여 사용할 팩토리 메서드를 지정할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    Product product = fixtureMonkey.giveMeBuilder(Product.class)
+        .instantiate(
+            factoryMethod("from")
+        )
+        .sample();
+
+    then(product.getProductName()).isEqualTo("product");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            factory<Product>("from")
+        }
+        .sample()
+
+    then(product.productName).isEqualTo("product")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+이름이 같은 팩토리 메서드가 여러 개 있는 경우 `constructor()` 메서드에서와 마찬가지로 매개변수 유형 정보로 메서드를 구분할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+factoryMethod("from")
+    .parameter(String.class)
+    .parameter(Long.class)
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+factory<Product>("from") {
+    parameter<String>()
+    parameter<Long>()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### 팩토리 메서드에서 매개변수 이름으로 힌트 제공
+매개변수 이름으로 힌트를 제공하는 방법은 `factory()`를 사용할 때도 추가할 수 있으며, `constructor()`에서 매개변수 이름으로 힌트 제공하는 방법과 동일하게 동작합니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+    Product product = fixtureMonkey.giveMeBuilder(Product.class)
+        .instantiate(
+            factoryMethod("from")
+                .parameter(long.class, "productId")
+                .parameter(long.class)
+        )
+        .set("productId", 100L)
+        .sample();
+
+    then(product.getProductName()).isEqualTo("product");
+    then(product.getId()).isEqualTo(100L);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+    val product = fixtureMonkey.giveMeBuilder<Product>()
+        .instantiateBy {
+            factory<Product>("from") {
+                parameter<String>("productId")
+                parameter<Long>()
+            }
+        }
+        .set("productId", 100L)
+        .sample()
+
+    then(product.productName).isEqualTo("product")
+    then(product.id).isEqualTo(100L)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## 필드와 자바 빈 프로퍼티
+각 객체를 생성하는 메서드(`constructor()`와 `factory()`)에서 필드 또는 자바 빈 프로퍼티(getter & setter) 기반 중 하나의 방법으로 프로퍼티 생성 여부를 선택할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+.instantiate(constructor().field()) // generate based on fields
+
+.instantiate(constructor().javaBeansProperty()) // generate based on JavaBeans Property
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+.instantiateBy {
+    constructor {
+        javaField()
+    }
+}
+
+.instantiateBy {
+    constructor {
+        javaBeansProperty()
+    }
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+필드를 사용하는 경우 필드에 대한 값이 생성됩니다.
+자바 빈 프로퍼티를 사용하는 경우 클래스에 게터와 세터가 있으면 충분하며, 임의 값이 생성됩니다.
+
+### 프로퍼티 제외
+일부 프로퍼티가 생성되지 않도록 제외하기 위해 `filter()` 메서드를 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+.instantiate(
+    constructor()
+        .field(it -> it.filter(field -> !Modifier.isPrivate(field.getModifiers())))
+)
+
+.instantiate(
+    constructor()
+        .javaBeansProperty(it -> it.filter(property -> !"string".equals(property.getName())))
+)
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+.instantiateBy {
+    constructor {
+        javaField {
+            filter { !Modifier.isPrivate(it.modifiers) }
+        }
+    }
+}
+
+.instantiateBy {
+    constructor {
+        javaBeansProperty {
+            filter { "string" != it.name }
+        }
+    }
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+예를 들어 첫 번째 예시와 같이 private 필드가 생성되지 않도록 제외하거나 두 번째 예시와 같이 특정 속성을 이름별로 필터링할 수 있습니다.

--- a/docs/content/v1.0.x-kor/docs/generating-objects/instantiate-methods.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/instantiate-methods.md
@@ -1,0 +1,11 @@
+---
+title: "Instantiate Methods"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "instantiate-methods"
+weight: 32
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -8,4 +8,74 @@ identifier: "introspector"
 weight: 33
 ---
 
-### 한국어 번역 필요
+[`instantiate`](../instantiate-methods)를 사용하여 `ArbitraryBuilder`에서 객체를 생성하는 방법을 변경할 수 있지만, 전역적으로 객체를 생성하는 방법을 변경하고 싶은 경우가 있을 수 있습니다.
+Fixture Monkey는 다양한 `Introspector`로 객체를 생성하는 방법을 제공합니다.
+
+`Introspector`는 Fixture Monkey가 객체를 생성하는 기본 방법을 정의합니다.
+각 introspector는 클래스의 인스턴스를 생성할 수 있는 몇 가지 제약 조건이 있습니다.
+
+사용하려는 introspector를 `FixtureMonkey`의 `objectIntrospector` 옵션을 사용하여 변경할 수 있습니다.
+
+## BeanArbitraryIntrospector
+`BeanArbitraryIntrospector`는 Fixture Monkey가 객체 생성에 사용하는 기본 introspector입니다.
+리플렉션과 setter 메서드를 사용하여 새 인스턴스를 생성하므로 생성할 클래스에는 인자가 없는 생성자(또는 기본생성자)와 setter가 있어야 합니다.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BeanArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## ConstructorPropertiesArbitraryIntrospector
+주어진 생성자로 객체를 생성하려면 `ConstructorPropertiesArbitraryIntrospector`를 사용해야 합니다.
+
+`ConstructorPropertiesArbitraryIntrospector`인 경우 클래스 생성자에 `@ConstructorProperties`가 있거나 없으면 클래스가 레코드 타입이어야 합니다.
+(또는 Lombok을 사용하는 경우 lombok.config 파일에 `lombok.anyConstructor.addConstructorProperties=true`를 추가할 수 있습니다.)
+
+레코드 클래스를 생성할 때 여러 생성자를 가질 경우 `@ConstructorProperties` 주석이 있는 생성자가 우선 선택됩니다.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FieldReflectionArbitraryIntrospector
+`FieldReflectionArbitraryIntrospector`는 리플렉션을 사용하여 새 인스턴스를 생성하고 필드를 설정합니다.
+따라서 생성할 클래스는 인자가 없는 생성자(또는 기본 생성자)와 getter 또는 setter 중 하나를 가져야 합니다.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## BuilderArbitraryIntrospector
+클래스 빌더를 사용하여 클래스를 생성하려면 `BuilderArbitraryIntrospector`를 사용할 수 있습니다.
+이런 경우 클래스에 빌더가 있어야 합니다.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+## FailoverArbitraryIntrospector
+프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.
+이 경우 `FailoverArbitraryIntrospector`를 사용할 수 있습니다.
+`FailoverArbitraryIntrospector`를 사용하면 두 개 이상의 introspector를 사용할 수 있으며, introspector 중 하나가 생성에 실패하더라도 `FailoverArbitraryIntrospector`는 계속 다음 introspector로 객체 생성을 시도합니다.
+
+```java
+FixtureMonkey sut = FixtureMonkey.builder()
+    .objectIntrospector(new FailoverIntrospector(
+        Arrays.asList(
+            FieldReflectionArbitraryIntrospector.INSTANCE,
+            ConstructorPropertiesArbitraryIntrospector.INSTANCE
+        )
+    ))
+    .build();
+```
+
+----------------
+
+플러그인 별로 관련된 introspector도 존재합니다. 예를들어 [`JacksonObjectArbitraryIntrospector`](../../plugins/jackson-plugin/jackson-object-arbitrary-introspector)와 [`PrimaryConstructorArbitraryIntrospector`](../../plugins/kotlin-plugin/introspectors-for-kotlin)가 존재합니다.

--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -1,0 +1,11 @@
+---
+title: "Introspector"
+images: []
+menu:
+docs:
+parent: "generating-objects"
+identifier: "introspector"
+weight: 33
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/_index.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Getting Started"
+images: []
+menu:
+docs:
+weight: 20
+---

--- a/docs/content/v1.0.x-kor/docs/get-started/_index.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "시작하기"
 images: []
 menu:
 docs:

--- a/docs/content/v1.0.x-kor/docs/get-started/adding-bean-validation.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/adding-bean-validation.md
@@ -1,0 +1,10 @@
+---
+title: "Adding Bean Validation"
+weight: 24
+menu:
+docs:
+  parent: "get-started"
+  identifier: "adding-bean-validation"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/adding-bean-validation.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/adding-bean-validation.md
@@ -7,4 +7,86 @@ docs:
   identifier: "adding-bean-validation"
 ---
 
-### 한국어 번역 필요
+때로는 클래스의 Bean 유효성 검사 어노테이션에 지정된 제약조건을 준수하는 유효한 테스트 객체를 생성하고 싶을 수 있습니다.
+
+Fixture Monkey는 `jakarta.validation.constraints` 및 `javax.validation.constraints` 패키지의 제약 어노테이션을 지원합니다.
+
+이 기능을 사용하려면 다음과 같이 프로젝트에 `fixture-monkey-jakarta-validation` 종속성을 추가해야 합니다.
+<br/>
+
+javax.validation.constraints를 사용하는 경우 `fixture-monkey-javax-validation`을 추가해야 합니다.
+
+##### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
+```
+
+##### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-jakarta-validation</artifactId>
+  <version>{{< fixture-monkey-version >}}</version>
+  <scope>test</scope>
+</dependency>
+```
+Bean 유효성 검사 어노테이션을 기반으로 객체를 생성하려면 아래 그림과 같이 FixtureMonkey에 `JakartaValidationPlugin` (`javax.validation.constraints`를 사용하는 경우 `JavaxValidationPlugin`) 옵션을 추가해야 합니다.
+<br />
+
+`fixture-monkey-starter` 종속성을 추가했다면 이미 포함되어 있을 것입니다.
+
+```java
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+    .plugin(new JakartaValidationPlugin()) // or new JavaxValidationPlugin()
+    .build();
+```
+
+이전 `Product`클래스에 몇 가지 유효성 검사 어노테이션을 추가했다고 가정해 보겠습니다.
+
+```java
+@Value
+public class Product {
+    @Min(1)
+    long id;
+
+    @NotBlank
+    String productName;
+
+    @Max(100000)
+    long price;
+
+    @Size(min = 3)
+    List<@NotBlank String> options;
+
+    @Past
+    Instant createdAt;
+}
+```
+
+앞서 생성한 FixtureMonkey 인스턴스로 이제 유효한 객체를 생성할 수 있습니다.
+
+```
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+        .plugin(new JakartaValidationPlugin())
+        .build();
+
+    // when
+    Product actual = fixtureMonkey.giveMeOne(Product.class);
+
+    // then
+    then(actual).isNotNull();
+    then(actual.getId()).isGreaterThan(0);
+    then(actual.getProductName()).isNotBlank();
+    then(actual.getPrice()).isLessThanOrEqualTo(100000);
+    then(actual.getOptions().size()).isGreaterThanOrEqualTo(3);
+    then(actual.getOptions()).allSatisfy(it -> then(it).isNotEmpty());
+    then(actual.getCreatedAt()).isNotNull().isLessThanOrEqualTo(Instant.now());
+}
+```
+
+Assertions에서 `FixtureMonkey`로 생성된 객체가 모든 유효성 검사 어노테이션 요구 사항을 충족한다는 것을 알 수 있습니다.
+

--- a/docs/content/v1.0.x-kor/docs/get-started/creating-objects-in-kotlin.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/creating-objects-in-kotlin.md
@@ -1,0 +1,10 @@
+---
+title: "Creating objects in Kotlin"
+weight: 26
+menu:
+docs:
+parent: "get-started"
+identifier: "creating-objects-in-kotlin"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects-without-lombok.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects-without-lombok.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating test objects without Lombok"
+title: "Lombok 없이 테스트 객체 생성하기"
 linkTitle: "Java"
 weight: 23
 menu:
@@ -8,4 +8,84 @@ docs:
   identifier: "creating-test-objects"
 ---
 
-### 한국어 번역 필요
+{{< alert icon="💡" text="만약 프로젝트에서 Lombok 을 사용하고 있다면 다음 페이지로 넘어가주세요." />}}
+
+아래처럼 Product 클래스를 테스트하기 위해 테스트 픽스처가 필요한 시나리오를 생각해보세요.
+
+```java
+public class Product {
+    private long id;
+
+    private String productName;
+
+    private long price;
+
+    private List<String> options;
+
+    private Instant createdAt;
+
+    private ProductType productType;
+
+    private Map<Integer, String> merchantInfo;
+
+    public Product() {
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public void setPrice(long price) {
+        this.price = price;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setProductType(ProductType productType) {
+        this.productType = productType;
+    }
+
+    public void setMerchantInfo(Map<Integer, String> merchantInfo) {
+        this.merchantInfo = merchantInfo;
+    }
+}
+```
+
+Fixture Monkey 를 사용하면, 단 몇 줄의 코드만으로도 Product 인스턴스를 생성할 수 있습니다.
+
+```java
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.create();
+
+    // when
+    Product actual = fixtureMonkey.giveMeOne(Product.class);
+
+    // then
+    then(actual).isNotNull();
+}
+```
+
+먼저, 테스트 픽스처를 쉽게 만들 수 있는 FixtureMonkey 인스턴스를 생성합니다.
+Fixture Monkey 에는 여러 사용자 정의 옵션이 있어서 특정 요구 사항에 따라 인스턴스를 생성할 수 있습니다.
+
+Fixture Monkey 는 객체를 생성하기 위한 기본 방법으로 `BeanArbitraryIntrospector` 를 사용합니다.
+`Introspector` 는 Fixture Monkey 가 객체를 생성하는 방법을 정의합니다.
+
+`BeanArbitraryIntrospector` 를 사용하려면, 생성될 클래스에는 no-args 생성자와 setter 가 있어야 합니다.
+(다른 Introspector 도 사용할 수 있습니다. 각각의 요구 사항은 [`Introspectors` section](../../generating-objects/introspector) 을 참고하세요.)
+
+다음으로, `giveMeOne()` 메서드를 사용하여 지정된 타입의 인스턴스를 생성합니다.
+
+then 절에서 확인할 수 있듯이, Product 클래스의 인스턴스가 생성됩니다.

--- a/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects-without-lombok.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects-without-lombok.md
@@ -1,0 +1,11 @@
+---
+title: "Creating test objects without Lombok"
+linkTitle: "Java"
+weight: 23
+menu:
+docs:
+  parent: "get-started"
+  identifier: "creating-test-objects"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating test objects"
+title: "테스트 객체 생성하기"
 weight: 22
 menu:
 docs:
@@ -7,4 +7,63 @@ docs:
   identifier: "creating-test-objects"
 ---
 
-### 한국어 번역 필요
+> Fixture Monkey 는 Java 와 Kotlin 모두에서 사용할 수 있습니다.
+> 각 환경에 맞는 '시작하기' 페이지가 있습니다: [Java](../creating-test-objects), [Java without Lombok](../creating-test-objects-without-lombok), and [Kotlin](../creating-objects-in-kotlin).
+> 
+> 이 페이지는 Java 환경을 기준으로 설명합니다. 사용 중인 환경에 맞는 페이지를 참고해주세요.
+
+아래처럼 Product 클래스를 테스트하기 위해 테스트 픽스처가 필요한 시나리오를 생각해보세요.
+
+{{< alert icon="💡" text="lombok.anyConstructor.addConstructorProperties=true 가 lombok.config 파일에 추가되어 있어야 합니다." />}}
+
+```java
+@Value
+public class Product {
+    long id;
+
+    String productName;
+
+    long price;
+
+    List<String> options;
+
+    Instant createdAt;
+
+    ProductType productType;
+
+    Map<Integer, String> merchantInfo;
+}
+```
+
+(Lombok 의 어노테이션인 `@Value` 는 불변 클래스를 만들기 위해 사용됩니다. 만약 Lombok 을 사용하지 않는다면, [creating test objects without lombok](../creating-test-objects-without-lombok) 으로 이동하세요.)
+
+Fixture Monkey 를 사용하면, 단 몇 줄의 코드만으로도 Product 인스턴스를 생성할 수 있습니다.
+
+```java
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+        .build();
+
+    // when
+    Product actual = fixtureMonkey.giveMeOne(Product.class);
+
+    // then
+    then(actual).isNotNull();
+}
+```
+
+먼저, 테스트 픽스처를 쉽게 만들 수 있는 FixtureMonkey 인스턴스를 생성합니다.
+Fixture Monkey 에는 여러 사용자 정의 옵션이 있어서 특정 요구 사항에 따라 인스턴스를 생성할 수 있습니다.
+
+여기서는 `objectIntrospector` 를 `ConstructorPropertiesArbitraryIntrospector` 로 설정했습니다. 이는 @ConstructorProperties 어노테이션이 달린 생성자를 사용하여 객체를 생성한다는 것을 의미합니다.
+`Introspector` 는 Fixture Monkey 가 객체를 생성하는 방법을 정의합니다.
+
+`ConstructorPropertiesArbitraryIntrospector` 를 사용하려면, 생성될 클래스에는 @ConstructorProperties 가 달린 생성자가 있거나, lombok.config 파일에 `lombok.anyConstructor.addConstructorProperties=true` 가 추가되어 있어야 합니다.
+(다른 Introspector 도 사용할 수 있습니다. 각각의 요구 사항은 [`Introspectors` section](../../generating-objects/introspector) 을 참고하세요.)
+
+다음으로, `giveMeOne()` 메서드를 사용하여 지정된 타입의 인스턴스를 생성합니다.
+
+then 절에서 확인할 수 있듯이, Product 클래스의 인스턴스가 생성됩니다.

--- a/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/creating-test-objects.md
@@ -1,0 +1,10 @@
+---
+title: "Creating test objects"
+weight: 22
+menu:
+docs:
+  parent: "get-started"
+  identifier: "creating-test-objects"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/customizing objects.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/customizing objects.md
@@ -1,0 +1,10 @@
+---
+title: "Customizing objects"
+weight: 25
+menu:
+docs:
+parent: "get-started"
+identifier: "customizing objects"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/customizing objects.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/customizing objects.md
@@ -1,5 +1,5 @@
 ---
-title: "Customizing objects"
+title: "사용자 정의 객체 생성하기"
 weight: 25
 menu:
 docs:
@@ -7,4 +7,76 @@ parent: "get-started"
 identifier: "customizing objects"
 ---
 
-### 한국어 번역 필요
+특정 단위 테스트에 맞게 테스트 픽스처를 조정해야 한다고 가정해 보세요.
+이 경우 Fixture Monkey 를 사용하여 빌더를 생성하고 추가로 사용자 정의할 수 있습니다.
+
+```java
+@Value
+public class Product {
+    long id;
+
+    String productName;
+
+    long price;
+
+    List<String> options;
+
+    Instant createdAt;
+}
+```
+
+예를 들면, 특정 테스트에서 id 가 1,000 인 Product 인스턴스가 필요할 수 있습니다.
+
+이를 위해 `giveMeBuilder` 메서드를 사용하여 픽스처 몽키에서 타입 빌더를 가져올 수 있습니다.
+빌더를 사용하면 추가 메서드 호출을 연결하여 픽스처를 사용자 정의할 수 있습니다.
+이 경우 `set()` 함수를 사용하여 id를 1,000으로 설정할 수 있습니다.
+빌더에서 `sample()`을 사용하여 인스턴스를 생성합니다.
+
+```java
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+        .build();
+    long id = 1000;
+
+    // when
+    Product actual = fixtureMonkey.giveMeBuilder(Product.class)
+        .set("id", id)
+        .sample();
+
+    // then
+    then(actual.getId()).isEqualTo(1000);
+}
+```
+
+위의 예시에서 필드 `id`가 원하는 값으로 설정되어 있는 것을 볼 수 있습니다.
+
+컬렉션을 사용하는 경우에도 Fixture Monkey 를 사용할 수 있습니다.
+예를 들어, "options" 리스트가 특정 크기를 가져야 하고, 리스트의 특정 요소가 특정 값을 가져야 할 수 있습니다.
+
+```java
+@Test
+void test() {
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+        .build();
+
+    // when
+    Product actual = fixtureMonkey.giveMeBuilder(Product.class)
+        .size("options", 3)
+        .set("options[1]", "red")
+        .sample();
+
+    // then
+    then(actual.getOptions()).hasSize(3);
+    then(actual.getOptions().get(1)).isEqualTo("red");
+}
+```
+
+`set()` 함수를 사용하여 특정 컬렉션 (list, set, map)의 크기를 지정하고 요소를 특정 값으로 설정한 다음,
+`sample()` 메서드를 호출하여 인스턴스를 생성할 수 있습니다.
+
+표현식을 사용하여 프로퍼티를 선택하고 프로퍼티 값을 설정하는 방법에 대한 자세한 예제는 [customizing section](../../customizing-objects/apis) 을 참고하세요.

--- a/docs/content/v1.0.x-kor/docs/get-started/requirements.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/requirements.md
@@ -1,5 +1,5 @@
 ---
-title: "Requirements"
+title: "요구사항"
 images: []
 menu:
 docs:
@@ -8,4 +8,56 @@ docs:
 weight: 21
 ---
 
-### 한국어 번역 필요
+{{< alert icon="💡" text="Fixture Monkey 는 테스트 환경용으로 설계되었습니다. 운영 코드에는 포함하지 않는 것을 권장합니다." />}}
+
+## 전제 조건
+
+* JDK 1.8 이상 (또는 Kotlin 1.8 이상)
+* JUnit 5 platform
+* jqwik 1.7.3
+
+--------
+
+## 종속성
+
+| Dependency                    | Description                                  |
+|-------------------------------|----------------------------------------------|
+| fixture-monkey                | Core library                                 |
+| fixture-monkey-starter        | Starter dependency for fixture monkey        |
+| fixture-monkey-kotlin         | Kotlin support                               |
+| fixture-monkey-starter-kotlin | Starter dependency for fixture monkey kotlin |
+
+**fixture-monkey-starter** 는 Fixture Monkey 를 시작하는 데 도움이 되도록 fixture-monkey-jakarta-validation과 같은 플러그인들이 함께 제공되는 스타터 패키지입니다.
+
+Kotlin 환경에서는 **fixture-monkey-starter-kotlin** 을 대신 사용할 수 있습니다.
+
+#### Gradle
+
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:{{< fixture-monkey-version >}}")
+```
+
+#### Maven
+
+```xml
+
+<dependency>
+    <groupId>com.navercorp.fixturemonkey</groupId>
+    <artifactId>fixture-monkey-starter</artifactId>
+    <version>{{< fixture-monkey-version>}}
+    </version>
+    <scope>test</scope>
+</dependency>
+```
+
+--------
+
+## 서드파티 라이브러리 지원
+
+| Dependency                        | Description                |
+|-----------------------------------|----------------------------|
+| fixture-monkey-jackson            | Jackson support            |
+| fixture-monkey-jakarta-validation | Jakarta validation support |
+| fixture-monkey-javax-validation   | Javax validation support   |
+| fixture-monkey-mockito            | Mockito support            |
+| fixture-monkey-autoparams         | Autoparams support         |

--- a/docs/content/v1.0.x-kor/docs/get-started/requirements.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/requirements.md
@@ -1,0 +1,11 @@
+---
+title: "Requirements"
+images: []
+menu:
+docs:
+  parent: "get-started"
+  identifier: "requirements"
+weight: 21
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/get-started/requirements.md
+++ b/docs/content/v1.0.x-kor/docs/get-started/requirements.md
@@ -3,8 +3,8 @@ title: "요구사항"
 images: []
 menu:
 docs:
-  parent: "get-started"
-  identifier: "requirements"
+parent: "get-started"
+identifier: "requirements"
 weight: 21
 ---
 
@@ -20,14 +20,15 @@ weight: 21
 
 ## 종속성
 
-| Dependency                    | Description                                  |
-|-------------------------------|----------------------------------------------|
-| fixture-monkey                | Core library                                 |
-| fixture-monkey-starter        | Starter dependency for fixture monkey        |
-| fixture-monkey-kotlin         | Kotlin support                               |
-| fixture-monkey-starter-kotlin | Starter dependency for fixture monkey kotlin |
+| 종속성                           | 설명                      |
+|-------------------------------|-------------------------|
+| fixture-monkey                | fixture monkey 코어 라이브러리 |
+| fixture-monkey-starter        | fixture monkey 시작 패키지   |
+| fixture-monkey-kotlin         | Kotlin 지원               |
+| fixture-monkey-starter-kotlin | Kotlin 환경을 위한 시작 패키지    |
 
-**fixture-monkey-starter** 는 Fixture Monkey 를 시작하는 데 도움이 되도록 fixture-monkey-jakarta-validation과 같은 플러그인들이 함께 제공되는 스타터 패키지입니다.
+**fixture-monkey-starter** 는 Fixture Monkey 를 시작하는 데 도움이 되도록 fixture-monkey-jakarta-validation과 같은 플러그인들이 함께 제공되는 스타터
+패키지입니다.
 
 Kotlin 환경에서는 **fixture-monkey-starter-kotlin** 을 대신 사용할 수 있습니다.
 
@@ -44,7 +45,7 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:{{< fixtu
 <dependency>
     <groupId>com.navercorp.fixturemonkey</groupId>
     <artifactId>fixture-monkey-starter</artifactId>
-    <version>{{< fixture-monkey-version>}}
+    <version>{{<fixture-monkey-version>}}
     </version>
     <scope>test</scope>
 </dependency>
@@ -54,10 +55,10 @@ testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:{{< fixtu
 
 ## 서드파티 라이브러리 지원
 
-| Dependency                        | Description                |
-|-----------------------------------|----------------------------|
-| fixture-monkey-jackson            | Jackson support            |
-| fixture-monkey-jakarta-validation | Jakarta validation support |
-| fixture-monkey-javax-validation   | Javax validation support   |
-| fixture-monkey-mockito            | Mockito support            |
-| fixture-monkey-autoparams         | Autoparams support         |
+| 종속성                               | 설명                    |
+|-----------------------------------|-----------------------|
+| fixture-monkey-jackson            | Jackson 지원            |
+| fixture-monkey-jakarta-validation | Jakarta validation 지원 |
+| fixture-monkey-javax-validation   | Javax validation 지원   |
+| fixture-monkey-mockito            | Mockito 지원            |
+| fixture-monkey-autoparams         | Autoparams 지원         |

--- a/docs/content/v1.0.x-kor/docs/intellij-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/intellij-plugin/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Intellij Plugin"
+images: []
+menu:
+docs:
+weight: 90
+---

--- a/docs/content/v1.0.x-kor/docs/intellij-plugin/fixture-monkey-helper.md
+++ b/docs/content/v1.0.x-kor/docs/intellij-plugin/fixture-monkey-helper.md
@@ -1,0 +1,11 @@
+---
+title: "Fixture Monkey Helper"
+images: []
+menu:
+docs:
+parent: "intellij-plugin"
+identifier: "fixture-monkey-helper"
+weight: 91
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/introduction/_index.md
+++ b/docs/content/v1.0.x-kor/docs/introduction/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Introduction"
+images: []
+menu:
+docs:
+weight: 10
+---

--- a/docs/content/v1.0.x-kor/docs/introduction/overview.md
+++ b/docs/content/v1.0.x-kor/docs/introduction/overview.md
@@ -1,0 +1,10 @@
+---
+title: "Overview"
+weight: 11
+menu:
+docs:
+  parent: "introduction"
+  identifier: "overview"
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Plugins"
+images: []
+menu:
+docs:
+  identifier: "plugins"
+weight: 60
+---

--- a/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Jackson Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "jackson-plugin"
+weight: 70
+---

--- a/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/features.md
@@ -1,0 +1,11 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-plugin-features"
+weight: 71
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/jackson-annotations.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/jackson-annotations.md
@@ -1,0 +1,11 @@
+---
+title: "Jackson Annotations"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-annotations"
+weight: 73
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jackson-plugin/jackson-object-arbitrary-introspector.md
@@ -1,0 +1,11 @@
+---
+title: "JacksonObjectArbitraryIntrospector"
+images: []
+menu:
+docs:
+parent: "jackson-plugin"
+identifier: "jackson-object-arbitrary-introspector"
+weight: 72
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Jakarta Validation Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "jakarta-validation-plugin"
+weight: 80
+---

--- a/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/bean-validation.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/bean-validation.md
@@ -1,0 +1,11 @@
+---
+title: "Bean Validation"
+images: []
+menu:
+docs:
+parent: "jakarta-validation-plugin"
+identifier: "bean-validation"
+weight: 82
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
@@ -1,0 +1,11 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "jakarta-validation-plugin"
+identifier: "jakarta-validation-plugin-features"
+weight: 81
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Kotest Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "kotest-plugin"
+weight: 90
+---

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
@@ -1,0 +1,11 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "kotest-plugin"
+identifier: "kotest-plugin-features"
+weight: 91
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
@@ -1,0 +1,11 @@
+---
+title: "Kotest Property Based Testing"
+images: []
+menu:
+docs:
+parent: "kotest-plugin"
+identifier: "kotest-property-based-testing"
+weight: 92
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Kotlin Plugin"
+images: []
+menu:
+  docs:
+    parent: "plugins"
+    identifier: "kotlin-plugin"
+weight: 60
+---

--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/features.md
@@ -1,0 +1,11 @@
+---
+title: "Features"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "kotlin-plugin-features"
+weight: 61
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
@@ -1,0 +1,11 @@
+---
+title: "Introspectors for Kotlin"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "introspectors-for-kotlin"
+weight: 62
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/kotlin-exp.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/kotlin-exp.md
@@ -1,0 +1,11 @@
+---
+title: "Kotlin DSL Exp"
+images: []
+menu:
+docs:
+parent: "kotlin-plugin"
+identifier: "kotlin-dsl-exp"
+weight: 63
+---
+
+### 한국어 번역 필요

--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Release Notes"
+images: []
+menu:
+docs:
+weight: 100
+---
+
+### 한국어 번역 필요

--- a/docs/layouts/partials/header/header.html
+++ b/docs/layouts/partials/header/header.html
@@ -81,7 +81,7 @@
 
           {{ with .Site }}
             {{ with .Language }}
-              {{ if and (eq .LanguageName "v1.0.x") .Params.options.flexSearch }}
+              {{ if and (eq .Lang "v1-0-0") .Params.options.flexSearch }}
                 {{ if and (isset .Params.options "searchsectionsshow") (not (eq .Params.options.searchSectionsShow "ALL")) }}
                   {{ if or (eq (len .Params.options.searchSectionsShow) 0) (in .Params.options.searchSectionsShow .Section) (and .IsHome (in .Params.options.searchSectionsShow "HomePage")) }}
                     {{- $showFlexSearch = true -}}
@@ -130,44 +130,31 @@
             <li><a class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Language.LanguageName }}</a></li>
 
             <li><hr class="dropdown-divider"></li>
-
-            {{ if .IsTranslated -}}
-              {{ range .Translations }}
-                <li><a class="dropdown-item" rel="alternate" href="{{ .RelPermalink }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
-              {{ end -}}
-            {{ else -}}
               {{ range .Site.Languages -}}
-                {{ if ne $.Site.Language.Lang .Lang }}
-                  <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+                {{ if and (ne $.Site.Language.LanguageName .LanguageName) (eq .Params.translation true) }}
+                    <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
                 {{ end -}}
               {{ end -}}
-            {{ end -}}
-              <!--
-              <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="/docs/contributing/how-to-contribute/">Help Translate</a></li>
-              -->
           </ul>
         </div>
         {{ end -}}
 
-        {{ if eq .Site.Params.options.docsVersioning true -}}
         <hr class="text-black-50 my-4 d-lg-none">
         <div class="dropdown">
           <button class="btn btn-doks-light dropdown-toggle" id="doks-versions" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static" aria-label="Toggle version menu">
-            <span class="d-none">Doks</span> v{{ .Site.Params.docsVersion }}
+            <span class="d-none">Doks</span> {{ .Site.Params.languageCode }}
             <span class="dropdown-caret"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
           </button>
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-versions">
-            <li><a class="dropdown-item current" aria-current="true" href="/docs/get-started/requirements/">Latest ({{ .Site.Params.docsVersion }})</a></li>
+            <li><a class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Params.languageCode }}</a></li>
             <li><hr class="dropdown-divider"></li>
-<!--            <li><a class="dropdown-item" href="/docs/v0.5">v0.5.x</a></li>-->
-<!--            <li><a class="dropdown-item" href="/docs/v0.4">v0.4.x</a></li>-->
-<!--            <li><a class="dropdown-item" href="/docs/v0.3">v0.3.x</a></li>-->
-<!--            <li><hr class="dropdown-divider"></li>-->
-<!--            <li><a class="dropdown-item" href="/docs/versions/">All versions</a></li>-->
+              {{ range .Site.Languages -}}
+                {{ if and (eq $.Site.Language.LanguageName .LanguageName) (ne $.Lang .Lang) }}
+                  <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Params.languageCode }}</a></li>
+                {{ end -}}
+              {{ end -}}
           </ul>
         </div>
-        {{ end -}}
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
related to #864
`Fixture Monkey Options`의 `Generation Options`, `Customization Options`, `Other Options` page 한국어 번역

## Description
1. Arbitrary Generation에서 Arbitrary의 해석을 임의적인, 임의 -> 어떤 표현이 적절한지 의견을 구합니다.

2. `Generation Options` page의 [46번 째](https://naver.github.io/fixture-monkey/docs/fixture-monkey-options/generation-options/#arbitrary-generation), [75번 째 줄](https://naver.github.io/fixture-monkey/docs/fixture-monkey-options/generation-options/#arbitrary-generation-1)의 Arbitrary Generation 파트 제목이 중복되는 것 같습니다.

추가적으로 어색한 부분이나 개선할 점 있으면 comment 부탁드립니다. 감사합니다 :)