### PR TITLE
Add 'Fixture Monkey Options' section for kor doc

### DIFF
--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -8,4 +8,432 @@ identifier: "options"
 weight: 53
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도록 객체를 사용자 정의하거나 사용자 정의 프로퍼티 명을 사용할 수 있는 옵션도 제공합니다.
+
+## 프로퍼티 네임 리졸버
+> `defaultPropertyNameResolver`, `pushPropertyNameResolver`, `pushAssignableTypePropertyNameResolver`, `pushExactTypePropertyNameResolver`
+
+`PropertyNameResolver` 관련 옵션을 사용하면 프로퍼티를 참조하는 방법을 사용자 정의할 수 있습니다.
+
+`defaultPropertyNameResolver` 옵션은 모든 타입에 대해 프로퍼티 명을 알아내는 방식을 변경하는 데 사용됩니다.
+만약 특정 타입에 대해 특정한 변경을 수행하려면 `pushPropertyNameResolver` , `pushAssignableTypePropertyNameResolver` 또는 `pushExactTypePropertyNameResolver` 를 사용할 수 있습니다.
+
+기본적으로 프로퍼티는 원래 이름으로 참조됩니다. 다음 예시를 통해 프로퍼티 명을 사용자 정의하는 방법을 살펴봅시다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Data // getter, setter
+public class Product {
+String productName;
+}
+
+@Test
+void test() {
+// given
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.pushPropertyNameResolver(MatcherOperator.exactTypeMatchOperator(String.class, (property) -> "string"))
+.build();
+String expected = "test";
+
+    // when
+    String actual = fixtureMonkey.giveMeBuilder(Product.class)
+        .set("string", expected)
+        .sample()
+        .getProductName();
+
+    // then
+    then(actual).isEqualTo(expected);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+data class Product (
+val productName: String
+)
+
+@Test
+fun test() {
+// given
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(KotlinPlugin())
+.pushPropertyNameResolver(
+MatcherOperator.exactTypeMatchOperator(String::class.java, PropertyNameResolver { "string" })
+)
+.build()
+val expected = "test"
+
+    // when
+    val actual: String = fixtureMonkey.giveMeBuilder<Product>()
+        .set("string", expected)
+        .sample()
+        .productName
+
+    // then
+    then(actual).isEqualTo(expected)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+일반적으로, 프로퍼티 명은 원래 프로퍼티 명인 "productName" 으로 해석됩니다.
+그러나 `pushPropertyNameResolver` 를 사용하면 String 타입의 프로퍼티는 이제 "string"이라는 이름으로 참조됩니다.
+
+## 레지스터 옵션
+> `register`, `registerGroup`, `registerExactType`, `registerAssignableType`
+
+때로 클래스가 특정 제약 조건과 일관되게 일치해야 할 수 있습니다.
+사용자 정의 API를 사용해 항상 `ArbitraryBuilder` 를 수정해야 한다면 번거로울 수 있고 코드가 길어질 수 있습니다.
+이 경우, 모든 기본 제약 조건을 충족하는 클래스에 대해 기본 `ArbitraryBuilder` 를 설정할 수 있습니다.
+
+`register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
+
+For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
+예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
+이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.register(
+Product.class,
+fixture -> fixture.giveMeBuilder(Product.class)
+.set("id", Arbitraries.longs().greaterOrEqual(0))
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.register(Product::class.java) {
+it.giveMeBuilder<Product>()
+.set("id", Arbitraries.longs().greaterOrEqual(0))
+}
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+여러 ArbitraryBuilders를 한 번에 등록하려면 `registerGroup` 옵션을 사용할 수 있습니다.
+이 작업은 리플렉션 또는 `ArbitraryBuilderGroup` 인터페이스를 사용하여 수행할 수 있습니다.
+
+**Using reflection:**
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public class GenerateGroup {
+public ArbitraryBuilder<GenerateString> generateString(FixtureMonkey fixtureMonkey) {
+return fixtureMonkey.giveMeBuilder(GenerateString.class)
+.set("value", Arbitraries.strings().numeric());
+}
+
+    public ArbitraryBuilder<GenerateInt> generateInt(FixtureMonkey fixtureMonkey) {
+        return fixtureMonkey.giveMeBuilder(GenerateInt.class)
+            .set("value", Arbitraries.integers().between(1, 100));
+    }
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateGroup.class)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class GenerateGroup {
+fun generateString(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateString> {
+return fixtureMonkey.giveMeBuilder<GenerateString>()
+.set("value", Arbitraries.strings().numeric())
+}
+
+    fun generateInt(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateInt> {
+        return fixtureMonkey.giveMeBuilder<GenerateInt>()
+            .set("value", Arbitraries.integers().between(1, 100))
+    }
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateGroup::class.java)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+**Using ArbitraryBuilderGroup interface:**
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public class GenerateBuilderGroup implements ArbitraryBuilderGroup {
+@Override
+public ArbitraryBuilderCandidateList generateCandidateList() {
+return ArbitraryBuilderCandidateList.create()
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateString.class)
+.builder(
+arbitraryBuilder -> arbitraryBuilder
+.set("value", Arbitraries.strings().numeric())
+)
+)
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateInt.class)
+.builder(
+builder -> builder
+.set("value", Arbitraries.integers().between(1, 100))
+)
+);
+}
+}
+
+FixtureMonkey.builder()
+.registerGroup(new GenerateBuilderGroup())
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class GenerateBuilderGroup : ArbitraryBuilderGroup {
+override fun generateCandidateList(): ArbitraryBuilderCandidateList {
+return ArbitraryBuilderCandidateList.create()
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateString::class.java)
+.builder { it.set("value", Arbitraries.strings().numeric()) }
+)
+.add(
+ArbitraryBuilderCandidateFactory.of(GenerateInt::class.java)
+.builder { it.set("value", Arbitraries.integers().between(1, 100)) }
+)
+}
+}
+
+FixtureMonkey.builder()
+.registerGroup(GenerateBuilderGroup())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## 표현식 엄격 모드
+> `useExpressionStrictMode`
+
+표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지고 있는지, 그리고 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
+`useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던질 것입니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build();
+
+    thenThrownBy(
+        () -> fixtureMonkey.giveMeBuilder(String.class)
+            .set("nonExistentField", 0)
+            .sample()
+    ).isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No matching results for given NodeResolvers.");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
+
+    assertThatThrownBy {
+        fixtureMonkey.giveMeBuilder<String>()
+            .set("nonExistentField", 0)
+            .sample()
+    }.isExactlyInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("No matching results for given NodeResolvers.")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## Java 타입 제한
+> `javaTypeArbitraryGenerator`, `javaTimeTypeArbitraryGenerator`
+
+사용자 정의 `JavaTypeArbitraryGenerator` 인터페이스를 구현하여 Java 기본 타입(string, integer, double 등)의 기본값을 수정할 수 있습니다.
+이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
+
+예를 들어, Fixture Monkey로 생성된 string 타입은 기본적으로 제어 블록이 문자열에 포함되어 있는 극단적인 경우를 고려하기 때문에 읽기 어렵습니다.
+
+알파벳 문자로만 구성된 문자열을 생성하려면 아래 예시처럼 `JavaTypeArbitraryGenerator` 를 재정의하면 됩니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.plugin(
+new JqwikPlugin()
+.javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
+@Override
+public StringArbitrary strings() {
+return Arbitraries.strings().alpha();
+}
+})
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.plugin(
+JqwikPlugin()
+.javaTypeArbitraryGenerator(object : JavaTypeArbitraryGenerator {
+override fun strings(): StringArbitrary = Arbitraries.strings().alpha()
+})
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+For Java time types, you can use `javaTimeTypeArbitraryGenerator`.
+
+## 애노테이션을 사용한 Java 타입 제한
+> `javaArbitraryResolver`, `javaTimeArbitraryResolver`
+
+javax-validation 플러그인을 사용하여 Java 타입 프로퍼티에 제약 조건을 추가하는 것과 유사하게, 애노테이션을 사용하여 Java 타입에 제약 조건을 적용할 수 있습니다.
+이는 `JavaArbitraryResolver` 인터페이스를 구현하면 됩니다.
+이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
+
+예를 들어, 프로퍼티의 길이를 최대 10자로 제한해야 한다는 의미의 `MaxLengthOf10` 이라는 사용자 지정 애노테이션이 있는 경우 아래와 같이 `JavaArbitraryResolver` 를 생성할 수 있습니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey.builder()
+.plugin(
+new JqwikPlugin()
+.javaArbitraryResolver(new JavaArbitraryResolver() {
+@Override
+public Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryGeneratorContext context) {
+if (context.findAnnotation(MaxLengthof10.class).isPresent()) {
+return stringArbitrary.ofMaxLength(10);
+}
+return stringArbitrary;
+}
+})
+)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+FixtureMonkey.builder()
+.plugin(
+JqwikPlugin()
+.javaArbitraryResolver(object : JavaArbitraryResolver {
+override fun strings(stringArbitrary: StringArbitrary, context: ArbitraryGeneratorContext): Arbitrary<String> {
+if (context.findAnnotation(MaxLengthof10::class.java).isPresent) {
+return stringArbitrary.ofMaxLength(10)
+}
+return stringArbitrary
+}
+})
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+## Null 옵션
+### defaultNotNull
+> `defaultNotNull`, `nullableContainer`, `nullableElement`
+
+인스턴스의 프로퍼티가 null이 아닌지 확인하려는 경우 아래에 언급된 옵션을 활용할 수 있습니다.
+
+- `defaultNotNull` null 프로퍼티의 생성 여부를 결정합니다. true라면 프로퍼티가 null이 **될 수 없습니다**.
+- `nullableContainer` 컨테이너 프로퍼티가 null이 될 수 있는지 여부를 결정합니다. true라면 컨테이너가 null이 될 수 있습니다.
+- `nullableElement` 컨테이너 프로퍼티 내의 요소가 null이 될 수 있는지 여부를 결정합니다. true라면 요소가 null이 될 수 있습니다.
+
+기본적으로 이 세 옵션은 false로 설정되어 있습니다. 필요에 따라 true로 변경할 수 있습니다.
+
+{{< alert icon="🚨" text="These options only apply to properties that do not have a nullable marker, such as @Nullable in Java or ? in Kotlin." />}}
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().defaultNotNull(true).build();
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().nullableContainer(true).build();
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build();
+
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder().defaultNotNull(true).build()
+
+val fixtureMonkey = FixtureMonkey.builder().nullableContainer(true).build()
+
+val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+---------------
+### NullInjectGenerator
+> `defaultNullInjectGenerator`, `pushNullInjectGenerator`, `pushExactTypeNullInjectGenerator`, `pushAssignableTypeNullInjectGenerator`
+
+특정 프로퍼티가 nullable 표시와 관계없이 null이어야 하는 경우, `NullInjectGenerator` 와 관련된 옵션을 사용할 수 있습니다.
+
+`defaultnullInjectGenerator` 옵션을 사용하면 프로퍼티가 null이 될 확률을 설정할 수 있습니다.
+
+기본적으로 프로퍼티가 null일 확률은 20%로 설정되어 있습니다.
+
+항상 null이 되길 원한다면 `1.0d` 로 설정할 수 있습니다. DefaultNullInjectGenerator에는 `NOT_NULL_INJECT(0.0d)` 와 `ALWAYS_NULL_INJECT(1.0d)` 와 같은 미리 정의된 값이 있습니다. 이를 가져와서 사용할 수 있습니다.
+
+보다 사용자 정의된 동작을 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // you can use NOT_NULL_INJECT or write your probability as 0.4
+.build()
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(KotlinPlugin())
+.defaultNullInjectGenerator { NOT_NULL_INJECT } // you can use NOT_NULL_INJECT or write your probability as 0.4
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+If you want to specifically change the probability of a certain type being null, you can use `pushNullInjectGenerator`.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.pushNullInjectGenerator(MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context) -> NOT_NULL_INJECT))
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.pushNullInjectGenerator(
+exactTypeMatchOperator(
+Product::class.java,
+NullInjectGenerator { context -> NOT_NULL_INJECT }
+)
+)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+Registering an `ArbitraryBuilder` of a specific class with `register` that has the `.setNotNull("*")` setting will have the same effect.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -30,11 +30,11 @@ public class Product {
 
 @Test
 void test() {
-// given
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.pushPropertyNameResolver(MatcherOperator.exactTypeMatchOperator(String.class, (property) -> "string"))
-.build();
-String expected = "test";
+    // given
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .pushPropertyNameResolver(MatcherOperator.exactTypeMatchOperator(String.class, (property) -> "string"))
+        .build();
+    String expected = "test";
 
     // when
     String actual = fixtureMonkey.giveMeBuilder(Product.class)
@@ -96,22 +96,22 @@ val expected = "test"
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey.builder()
-.register(
-Product.class,
-fixture -> fixture.giveMeBuilder(Product.class)
-.set("id", Arbitraries.longs().greaterOrEqual(0))
-)
-.build();
+    .register(
+        Product.class,
+        fixture -> fixture.giveMeBuilder(Product.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(0))
+    )
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 FixtureMonkey.builder()
-.register(Product::class.java) {
-it.giveMeBuilder<Product>()
-.set("id", Arbitraries.longs().greaterOrEqual(0))
-}
-.build()
+    .register(Product::class.java) {
+        it.giveMeBuilder<Product>()
+            .set("id", Arbitraries.longs().greaterOrEqual(0))
+    }
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -124,9 +124,9 @@ ArbitraryBuilders들을 한 번에 등록하려면 `registerGroup` 옵션을 사
 {{< tab header="Java" lang="java">}}
 
 public class GenerateGroup {
-public ArbitraryBuilder<GenerateString> generateString(FixtureMonkey fixtureMonkey) {
-return fixtureMonkey.giveMeBuilder(GenerateString.class)
-.set("value", Arbitraries.strings().numeric());
+    public ArbitraryBuilder<GenerateString> generateString(FixtureMonkey fixtureMonkey) {
+        return fixtureMonkey.giveMeBuilder(GenerateString.class)
+            .set("value", Arbitraries.strings().numeric());
 }
 
     public ArbitraryBuilder<GenerateInt> generateInt(FixtureMonkey fixtureMonkey) {
@@ -136,17 +136,17 @@ return fixtureMonkey.giveMeBuilder(GenerateString.class)
 }
 
 FixtureMonkey.builder()
-.registerGroup(GenerateGroup.class)
-.build();
+    .registerGroup(GenerateGroup.class)
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 class GenerateGroup {
-fun generateString(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateString> {
-return fixtureMonkey.giveMeBuilder<GenerateString>()
-.set("value", Arbitraries.strings().numeric())
-}
+    fun generateString(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateString> {
+        return fixtureMonkey.giveMeBuilder<GenerateString>()
+            .set("value", Arbitraries.strings().numeric())
+    }
 
     fun generateInt(fixtureMonkey: FixtureMonkey): ArbitraryBuilder<GenerateInt> {
         return fixtureMonkey.giveMeBuilder<GenerateInt>()
@@ -155,8 +155,8 @@ return fixtureMonkey.giveMeBuilder<GenerateString>()
 }
 
 FixtureMonkey.builder()
-.registerGroup(GenerateGroup::class.java)
-.build()
+    .registerGroup(GenerateGroup::class.java)
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -167,50 +167,50 @@ FixtureMonkey.builder()
 {{< tab header="Java" lang="java">}}
 
 public class GenerateBuilderGroup implements ArbitraryBuilderGroup {
-@Override
-public ArbitraryBuilderCandidateList generateCandidateList() {
-return ArbitraryBuilderCandidateList.create()
-.add(
-ArbitraryBuilderCandidateFactory.of(GenerateString.class)
-.builder(
-arbitraryBuilder -> arbitraryBuilder
-.set("value", Arbitraries.strings().numeric())
-)
-)
-.add(
-ArbitraryBuilderCandidateFactory.of(GenerateInt.class)
-.builder(
-builder -> builder
-.set("value", Arbitraries.integers().between(1, 100))
-)
-);
-}
+    @Override
+    public ArbitraryBuilderCandidateList generateCandidateList() {
+        return ArbitraryBuilderCandidateList.create()
+            .add(
+                ArbitraryBuilderCandidateFactory.of(GenerateString.class)
+                    .builder(
+                        arbitraryBuilder -> arbitraryBuilder
+                            .set("value", Arbitraries.strings().numeric())
+                    )
+            )
+            .add(
+                ArbitraryBuilderCandidateFactory.of(GenerateInt.class)
+                    .builder(
+                        builder -> builder
+                            .set("value", Arbitraries.integers().between(1, 100))
+                        )
+            );
+    }
 }
 
 FixtureMonkey.builder()
-.registerGroup(new GenerateBuilderGroup())
-.build();
+    .registerGroup(new GenerateBuilderGroup())
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 class GenerateBuilderGroup : ArbitraryBuilderGroup {
-override fun generateCandidateList(): ArbitraryBuilderCandidateList {
-return ArbitraryBuilderCandidateList.create()
-.add(
-ArbitraryBuilderCandidateFactory.of(GenerateString::class.java)
-.builder { it.set("value", Arbitraries.strings().numeric()) }
-)
-.add(
-ArbitraryBuilderCandidateFactory.of(GenerateInt::class.java)
-.builder { it.set("value", Arbitraries.integers().between(1, 100)) }
-)
-}
+    override fun generateCandidateList(): ArbitraryBuilderCandidateList {
+        return ArbitraryBuilderCandidateList.create()
+            .add(
+                ArbitraryBuilderCandidateFactory.of(GenerateString::class.java)
+                    .builder { it.set("value", Arbitraries.strings().numeric()) }
+            )
+            .add(
+                ArbitraryBuilderCandidateFactory.of(GenerateInt::class.java)
+                    .builder { it.set("value", Arbitraries.integers().between(1, 100)) }
+            )
+    }
 }
 
 FixtureMonkey.builder()
-.registerGroup(GenerateBuilderGroup())
-.build()
+    .registerGroup(GenerateBuilderGroup())
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -226,7 +226,7 @@ FixtureMonkey.builder()
 
 @Test
 void test() {
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build();
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build();
 
     thenThrownBy(
         () -> fixtureMonkey.giveMeBuilder(String.class)
@@ -241,7 +241,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().
 
 @Test
 fun test() {
-val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
+    val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
 
     assertThatThrownBy {
         fixtureMonkey.giveMeBuilder<String>()
@@ -268,28 +268,28 @@ val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey.builder()
-.plugin(
-new JqwikPlugin()
-.javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
-@Override
-public StringArbitrary strings() {
-return Arbitraries.strings().alpha();
-}
-})
-)
-.build();
+    .plugin(
+        new JqwikPlugin()
+            .javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
+                @Override
+                public StringArbitrary strings() {
+                    return Arbitraries.strings().alpha();
+                }
+            })
+    )
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 FixtureMonkey.builder()
-.plugin(
-JqwikPlugin()
-.javaTypeArbitraryGenerator(object : JavaTypeArbitraryGenerator {
-override fun strings(): StringArbitrary = Arbitraries.strings().alpha()
-})
-)
-.build()
+    .plugin(
+        JqwikPlugin()
+            .javaTypeArbitraryGenerator(object : JavaTypeArbitraryGenerator {
+                override fun strings(): StringArbitrary = Arbitraries.strings().alpha()
+            })
+    )
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -309,36 +309,36 @@ javax-validation 플러그인을 사용하여 Java 타입 프로퍼티에 제약
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey.builder()
-.plugin(
-new JqwikPlugin()
-.javaArbitraryResolver(new JavaArbitraryResolver() {
-@Override
-public Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryGeneratorContext context) {
-if (context.findAnnotation(MaxLengthof10.class).isPresent()) {
-return stringArbitrary.ofMaxLength(10);
-}
-return stringArbitrary;
-}
-})
-)
-.build();
+    .plugin(
+        new JqwikPlugin()
+            .javaArbitraryResolver(new JavaArbitraryResolver() {
+            @Override
+            public Arbitrary<String> strings(StringArbitrary stringArbitrary, ArbitraryGeneratorContext context) {
+                if (context.findAnnotation(MaxLengthof10.class).isPresent()) {
+                    return stringArbitrary.ofMaxLength(10);
+                }
+                return stringArbitrary;
+            }
+        })
+    )
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 FixtureMonkey.builder()
-.plugin(
-JqwikPlugin()
-.javaArbitraryResolver(object : JavaArbitraryResolver {
-override fun strings(stringArbitrary: StringArbitrary, context: ArbitraryGeneratorContext): Arbitrary<String> {
-if (context.findAnnotation(MaxLengthof10::class.java).isPresent) {
-return stringArbitrary.ofMaxLength(10)
-}
-return stringArbitrary
-}
-})
-)
-.build()
+    .plugin(
+        JqwikPlugin()
+            .javaArbitraryResolver(object : JavaArbitraryResolver {
+                override fun strings(stringArbitrary: StringArbitrary, context: ArbitraryGeneratorContext): Arbitrary<String> {
+                    if (context.findAnnotation(MaxLengthof10::class.java).isPresent) {
+                        return stringArbitrary.ofMaxLength(10)
+                    }
+                return stringArbitrary
+                }
+            })
+    )
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -397,16 +397,16 @@ val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
-.build()
+    .defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
+    .build()
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-.plugin(KotlinPlugin())
-.defaultNullInjectGenerator { NOT_NULL_INJECT } // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
-.build()
+    .plugin(KotlinPlugin())
+    .defaultNullInjectGenerator { NOT_NULL_INJECT } // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -417,20 +417,20 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.pushNullInjectGenerator(MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context) -> NOT_NULL_INJECT))
-.build();
+    .pushNullInjectGenerator(MatcherOperator.exactTypeMatchOperator(SimpleObject.class, (context) -> NOT_NULL_INJECT))
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-.pushNullInjectGenerator(
-exactTypeMatchOperator(
-Product::class.java,
-NullInjectGenerator { context -> NOT_NULL_INJECT }
-)
-)
-.build()
+    .pushNullInjectGenerator(
+        exactTypeMatchOperator(
+            Product::class.java,
+            NullInjectGenerator { context -> NOT_NULL_INJECT }
+        )
+    )
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -90,7 +90,7 @@ val expected = "test"
 `register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
 
 For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
-예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.-
+예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
 이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
 
 {{< tabpane persist=false >}}
@@ -412,7 +412,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-If you want to specifically change the probability of a certain type being null, you can use `pushNullInjectGenerator`.
+특정 타입이 null이 될 확률을 구체적으로 변경하려면 `pushNullInjectGenerator` 를 사용하면 됩니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -436,4 +436,4 @@ NullInjectGenerator { context -> NOT_NULL_INJECT }
 {{< /tab >}}
 {{< /tabpane>}}
 
-Registering an `ArbitraryBuilder` of a specific class with `register` that has the `.setNotNull("*")` setting will have the same effect.
+특정 클래스의 `ArbitraryBuilder` 를 `register` 로 등록하면 `.setNotNull("*")` 설정과 동일한 결과를 얻을 수 있습니다.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -16,7 +16,7 @@ Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도�
 `PropertyNameResolver` 관련 옵션을 사용하면 프로퍼티를 참조하는 방법을 사용자 정의할 수 있습니다.
 
 `defaultPropertyNameResolver` 옵션은 모든 타입에 대해 프로퍼티 명을 알아내는 방식을 변경하는 데 사용됩니다.
-만약 특정 타입에 대해 특정한 변경을 수행하려면 `pushPropertyNameResolver` , `pushAssignableTypePropertyNameResolver` 또는 `pushExactTypePropertyNameResolver` 를 사용할 수 있습니다.
+만약 특정 타입에 대해 변경을 수행하려면 `pushPropertyNameResolver` , `pushAssignableTypePropertyNameResolver` 또는 `pushExactTypePropertyNameResolver` 를 사용할 수 있습니다.
 
 기본적으로 프로퍼티는 원래 이름으로 참조됩니다. 다음 예시를 통해 프로퍼티 명을 사용자 정의하는 방법을 살펴봅시다:
 
@@ -25,7 +25,7 @@ Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도�
 
 @Data // getter, setter
 public class Product {
-String productName;
+    String productName;
 }
 
 @Test
@@ -77,19 +77,18 @@ val expected = "test"
 {{< /tab >}}
 {{< /tabpane>}}
 
-일반적으로, 프로퍼티 명은 원래 프로퍼티 명인 "productName" 으로 해석됩니다.
+일반적으로, 프로퍼티 명은 기존 프로퍼티 명인 "productName" 으로 해석됩니다.
 그러나 `pushPropertyNameResolver` 를 사용하면 String 타입의 프로퍼티는 이제 "string"이라는 이름으로 참조됩니다.
 
 ## 등록 옵션
 > `register`, `registerGroup`, `registerExactType`, `registerAssignableType`
 
-때로 클래스가 특정 제약 조건과 일관되게 일치해야 할 수 있습니다.
+때로는 클래스가 특정 제약 조건을 항상 지켜야할 수 있습니다.
 사용자 정의 API를 사용해 항상 `ArbitraryBuilder` 를 수정해야 한다면 번거로울 수 있고 코드가 길어질 수 있습니다.
-이 경우, 모든 기본 제약 조건을 충족하는 클래스에 대해 기본 `ArbitraryBuilder` 를 설정할 수 있습니다.
+이 경우, 기본 제약 조건을 충족하는 클래스들에 대해서 기본 `ArbitraryBuilder` 를 설정할 수 있습니다.
 
-`register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
+`register` 옵션은 특정 타입에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
 
-For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
 예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
 이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
 
@@ -117,10 +116,10 @@ it.giveMeBuilder<Product>()
 {{< /tab >}}
 {{< /tabpane>}}
 
-여러 ArbitraryBuilders를 한 번에 등록하려면 `registerGroup` 옵션을 사용할 수 있습니다.
+ArbitraryBuilders들을 한 번에 등록하려면 `registerGroup` 옵션을 사용할 수 있습니다.
 이 작업은 리플렉션 또는 `ArbitraryBuilderGroup` 인터페이스를 사용하여 수행할 수 있습니다.
 
-**Using reflection:**
+**리플렉션 사용:**
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
 
@@ -162,7 +161,7 @@ FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-**Using ArbitraryBuilderGroup interface:**
+**ArbitraryBuilderGroup 인터페이스 사용:**
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -219,8 +218,8 @@ FixtureMonkey.builder()
 ## 표현식 엄격 모드
 > `useExpressionStrictMode`
 
-표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지는지, 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
-`useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던질 것입니다.
+표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지는지, 프로퍼티가 올바르게 선택되었는지를 파악하기 어려울 수 있습니다.
+`useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던집니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -261,7 +260,7 @@ val fixtureMonkey = FixtureMonkey.builder().useExpressionStrictMode().build()
 사용자 정의 `JavaTypeArbitraryGenerator` 인터페이스를 구현하여 Java 기본 타입(string, integer, double 등)의 기본값을 수정할 수 있습니다.
 이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
 
-예를 들어, Fixture Monkey로 생성된 string 타입은 기본적으로 제어 블록이 문자열에 포함되어 있는 극단적인 경우를 고려하기 때문에 읽기 어렵습니다.
+예를 들어, Fixture Monkey로 생성된 string 타입은 기본적으로 제어 블록이 문자열에 포함되어 있는 극단적인 경우를 고려하여 생성하기 때문에 읽기 어렵습니다.
 
 알파벳 문자로만 구성된 문자열을 생성하려면 아래 예시처럼 `JavaTypeArbitraryGenerator` 를 재정의하면 됩니다:
 
@@ -295,16 +294,16 @@ override fun strings(): StringArbitrary = Arbitraries.strings().alpha()
 {{< /tab >}}
 {{< /tabpane>}}
 
-For Java time types, you can use `javaTimeTypeArbitraryGenerator`.
+Java time 타입의 경우, `javaTimeTypeArbitraryGenerator` 를 사용할 수 있습니다.
 
-## 애노테이션을 사용한 Java 타입 제한
+## 어노테이션을 사용한 Java 타입 제한
 > `javaArbitraryResolver`, `javaTimeArbitraryResolver`
 
-javax-validation 플러그인을 사용하여 Java 타입 프로퍼티에 제약 조건을 추가하는 것과 유사하게, 애노테이션을 사용하여 Java 타입에 제약 조건을 적용할 수 있습니다.
+javax-validation 플러그인을 사용하여 Java 타입 프로퍼티에 제약 조건을 추가하는 것과 유사하게, 어노테이션을 사용하여 Java 타입에 제약 조건을 적용할 수 있습니다.
 이는 `JavaArbitraryResolver` 인터페이스를 구현하면 됩니다.
 이 옵션은 `JqwikPlugin` 을 통해 적용할 수 있습니다.
 
-예를 들어, 프로퍼티의 길이를 최대 10자로 제한해야 한다는 의미의 `MaxLengthOf10` 이라는 사용자 지정 애노테이션이 있는 경우 아래와 같이 `JavaArbitraryResolver` 를 생성할 수 있습니다:
+예를 들어, 프로퍼티의 길이를 최대 10자로 제한해야 한다는 의미의 `MaxLengthOf10` 이라는 사용자 지정 어노테이션이 있는 경우 아래와 같이 `JavaArbitraryResolver` 를 생성할 수 있습니다:
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -398,7 +397,7 @@ val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // you can use NOT_NULL_INJECT or write your probability as 0.4
+.defaultNullInjectGenerator((context) -> NOT_NULL_INJECT) // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
 .build()
 
 {{< /tab >}}
@@ -406,7 +405,7 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 
 val fixtureMonkey = FixtureMonkey.builder()
 .plugin(KotlinPlugin())
-.defaultNullInjectGenerator { NOT_NULL_INJECT } // you can use NOT_NULL_INJECT or write your probability as 0.4
+.defaultNullInjectGenerator { NOT_NULL_INJECT } // NOT_NULL_INJECT를 사용하거나 확률을 0.4로 설정할 수 있습니다.
 .build()
 
 {{< /tab >}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -10,7 +10,7 @@ weight: 53
 
 Fixture Monkey는 `FixtureMonkeyBuilder` 를 통해 원하는 값을 가지도록 객체를 사용자 정의하거나 사용자 정의 프로퍼티 명을 사용할 수 있는 옵션도 제공합니다.
 
-## 프로퍼티 네임 리졸버
+## 프로퍼티네임 리졸버
 > `defaultPropertyNameResolver`, `pushPropertyNameResolver`, `pushAssignableTypePropertyNameResolver`, `pushExactTypePropertyNameResolver`
 
 `PropertyNameResolver` 관련 옵션을 사용하면 프로퍼티를 참조하는 방법을 사용자 정의할 수 있습니다.
@@ -80,7 +80,7 @@ val expected = "test"
 일반적으로, 프로퍼티 명은 원래 프로퍼티 명인 "productName" 으로 해석됩니다.
 그러나 `pushPropertyNameResolver` 를 사용하면 String 타입의 프로퍼티는 이제 "string"이라는 이름으로 참조됩니다.
 
-## 레지스터 옵션
+## 등록 옵션
 > `register`, `registerGroup`, `registerExactType`, `registerAssignableType`
 
 때로 클래스가 특정 제약 조건과 일관되게 일치해야 할 수 있습니다.
@@ -90,7 +90,7 @@ val expected = "test"
 `register` 옵션은 특정 유형에 대한 `ArbitraryBuilder` 를 등록하는 것을 돕습니다.
 
 For example, the following code demonstrates how to register an `ArbitraryBuilder` for a Product class.
-예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.
+예시의 다음 코드는 Product 클래스에 대한 `ArbitraryBuilder` 를 등록하는 방법을 보여줍니다.-
 이를 등록함으로써 `FixtureMonkey` 에 의해 생성된 모든 Product 인스턴스는 "0"보다 크거나 같은 id 값을 가질 것입니다.
 
 {{< tabpane persist=false >}}
@@ -219,7 +219,7 @@ FixtureMonkey.builder()
 ## 표현식 엄격 모드
 > `useExpressionStrictMode`
 
-표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지고 있는지, 그리고 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
+표현식(특히 문자열 표현식)을 사용할 때 작성한 표현식이 일치하는 프로퍼티를 가지는지, 프로퍼티가 올바르게 적용되었는지를 파악하기 어려울 수 있습니다.
 `useExpressionStrictMode` 옵션을 사용하면 작성한 표현식이 일치하는 프로퍼티를 가지고 있지 않으면 IllegalArgumentException 예외를 던질 것입니다.
 
 {{< tabpane persist=false >}}
@@ -392,7 +392,7 @@ val fixtureMonkey = FixtureMonkey.builder().nullableElement(true).build()
 
 항상 null이 되길 원한다면 `1.0d` 로 설정할 수 있습니다. DefaultNullInjectGenerator에는 `NOT_NULL_INJECT(0.0d)` 와 `ALWAYS_NULL_INJECT(1.0d)` 와 같은 미리 정의된 값이 있습니다. 이를 가져와서 사용할 수 있습니다.
 
-보다 사용자 정의된 동작을 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
+사용자 정의된 동작을 더 추가하길 원하는 경우, 자체적으로 NullInjectGenerator를 구현할 수도 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -50,19 +50,19 @@ void test() {
 {{< tab header="Kotlin" lang="kotlin">}}
 
 data class Product (
-val productName: String
+    val productName: String
 )
 
 @Test
 fun test() {
-// given
-val fixtureMonkey = FixtureMonkey.builder()
-.plugin(KotlinPlugin())
-.pushPropertyNameResolver(
-MatcherOperator.exactTypeMatchOperator(String::class.java, PropertyNameResolver { "string" })
-)
-.build()
-val expected = "test"
+    // given
+    val fixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+        .pushPropertyNameResolver(
+            MatcherOperator.exactTypeMatchOperator(String::class.java, PropertyNameResolver { "string" })
+        )
+        .build()
+        val expected = "test"
 
     // when
     val actual: String = fixtureMonkey.giveMeBuilder<Product>()

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/customization-options.md
@@ -127,7 +127,7 @@ public class GenerateGroup {
     public ArbitraryBuilder<GenerateString> generateString(FixtureMonkey fixtureMonkey) {
         return fixtureMonkey.giveMeBuilder(GenerateString.class)
             .set("value", Arbitraries.strings().numeric());
-}
+    }
 
     public ArbitraryBuilder<GenerateInt> generateInt(FixtureMonkey fixtureMonkey) {
         return fixtureMonkey.giveMeBuilder(GenerateInt.class)

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -8,4 +8,541 @@ identifier: "options"
 weight: 52
 ---
 
-### 한국어 번역 필요
+Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기 위한 다양한 옵션을 제공합니다.
+
+이러한 옵션은 `FixtureMonkeyBuilder` 를 통해 접근할 수 있습니다.
+
+## Property Generation
+### PropertyGenerator
+> `defaultPropertyGenerator`, `pushPropertyGenerator`, `pushAssignableTypePropertyGenerator`, `pushExactTypePropertyGenerator`
+
+`PropertyGenerator` creates child properties of the given `ObjectProperty`.
+`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다. 
+The child property can be a field, JavaBeans property, method or constructor parameter within the parent `ObjectProperty`.
+자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 패러미터가 될 수 있습니다. 
+There are scenarios where you might want to customize how these child properties are generated.
+자식 프로퍼티들이 생성되는 방식을 사용자 정의하고자 하는 시나리오들이 있습니다.
+
+The `PropertyGenerator` options allow you to specify how child properties of each type are generated.
+`PropertyGenerator` 옵션으로 각 타입의 자식 프로퍼티가 어떻게 생성되는지 지정할 수 있습니다.
+This option is mainly used when you want to exclude generating some properties when the parent property has abnormal child properties.
+이 옵션은 주로 부모 프로퍼티가 비정상적인 자식 프로퍼티를 가질 때 일부 프로퍼티 생성을 제외하고자 할 때 사용됩니다.
+
+{{< alert icon="📖" text="Notable implementations: 'FieldPropertyGenerator', 'JavaBeansPropertyGenerator'" />}}
+
+### ObjectPropertyGenerator
+> `defaultObjectPropertyGenerator`, `pushObjectPropertyGenerator`, `pushAssignableTypeObjectPropertyGenerator`, `pushExactTypeObjectPropertyGenerator`
+
+`ObjectPropertyGenerator` generates the [`ObjectProperty`](../concepts/#objectProperty) based on a given context.
+`ObjectPropertyGenerator` 는 주어진 컨텍스트에 기반하여 [`ObjectProperty`](../concepts/#objectProperty)를 생성합니다.
+With options related to `ObjectPropertyGenerator` you can customize how the `ObjectProperty` is generated.
+`ObjectPropertyGenerator` 관련 옵션을 사용하면 `ObjectProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'DefaultObjectPropertyGenerator'" />}}
+
+### ContainerPropertyGenerator
+> `pushContainerPropertyGenerator`, `pushAssignableTypeContainerPropertyGenerator`, `pushExactTypeContainerPropertyGenerator`
+
+The `ContainerPropertyGenerator` determines how to generate [`ContainerProperty`](../concepts/#containerProperty) within a given context.
+`ContainerPropertyGenerator` 는 주어진 컨텍스트에서 [`ContainerProperty`](../concepts/#containerProperty) 를 생성하는 방법을 결정합니다.
+With options related to `ContainerPropertyGenerator` you can customize how the `ContainerProperty` is generated.
+`ContainerPropertyGenerator` 관련 옵션을 사용하면 `ContainerProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'ArrayContainerPropertyGenerator', 'MapContainerPropertyGenerator'" />}}
+
+-----------------
+
+## Arbitrary Generation
+An `Introspector` determines how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy based on the provided context(which includes information about generated properties).
+`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 적절한 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
+The object is then generated based on this arbitrary generated.
+이후 이 객체는 임의 생성된 기반으로 생성됩니다.
+You have the flexibility to create a custom `Introspector` by implementing your own `ArbitraryIntrospector`.
+
+### ObjectIntrospector
+> `objectIntrospcetor`
+
+The `objectIntrospector` option allows you to specify the default behavior when generating an object.
+객체 생성 시 기본 동작을 지정하는 `objectIntrospector` 관련 옵션을 사용하면 객체를 생성할 때 기본 동작을 지정할 수 있습니다.
+As discussed in the [introspector section](../../generating-objects/introspector), you can alter the default introspector to use predefined introspectors provided by Fixture Monkey or create your own custom introspector.
+[introspector section](../../generating-objects/introspector)에서 설명한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'BeanArbitraryIntrospector', 'BuilderArbitraryIntrospector'" />}}
+
+### ArbitraryIntrospector
+> `pushArbitraryIntrospector`, `pushAssignableTypeArbitraryIntrospector`, `pushExactTypeArbitraryIntrospector`
+
+If you need to change the `ArbitraryIntrospector` for a specific type you can use the above options.
+특정 유형에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'BooleanIntrospector', 'EnumIntrospector'" />}}
+
+### ContainerIntrospector
+> pushContainerIntrospector
+
+Especially for container types, you can change the `ArbitraryIntrospector` using the `pushContainerIntrospector` option.
+특히 컨테이너 타입의 경우, `pushContainerIntrospector` 옵션을 사용하여 `ArbitraryIntrospector` 를 변경할 수 있습니다.
+{{< alert icon="📖" text="Notable implementations: 'ListIntrospector', 'MapIntrospector'" />}}
+
+-----------------
+
+## Arbitrary Generation
+The `ArbitraryIntrospector` is responsible for defining how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy and generating an arbitrary.
+`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 개체를 생성하여 Fixture Monkey가 개체를 생성하는 방법을 정의하는 역할을 담당합니다.
+The actual creation of the final arbitrary(`CombinableArbitrary`) from the arbitrary is done by the `ArbitraryGenerator`, which handles the request by delegating to the `ArbitraryIntrospcetor`.
+임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator`에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor`에 요청을 위임하여 요청을 처리합니다.
+By using the `defaultArbitraryGenerator` option, you have the capability to customize the behavior of the `ArbitraryGenerator`.
+`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 커스터마이징할 수 있습니다.
+
+For instance, you can create an arbitrary generator that produces unique values, as shown in the example below:
+예를 들어 예시와 같이 고유한 값을 생성하는 임의의 생성기를 만들 수 있습니다:
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+public static class UniqueArbitraryGenerator implements ArbitraryGenerator {
+private static final Set<Object> UNIQUE = new HashSet<>();
+
+    private final ArbitraryGenerator delegate;
+
+    public UniqueArbitraryGenerator(ArbitraryGenerator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public CombinableArbitrary generate(ArbitraryGeneratorContext context) {
+        return delegate.generate(context)
+            .filter(
+                obj -> {
+                    if (!UNIQUE.contains(obj)) {
+                        UNIQUE.add(obj);
+                        return true;
+                    }
+                    return false;
+                }
+          );
+    }
+}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+class UniqueArbitraryGenerator(private val delegate: ArbitraryGenerator) : ArbitraryGenerator {
+companion object {
+private val UNIQUE = HashSet<Any>()
+}
+
+    override fun generate(context: ArbitraryGeneratorContext): CombinableArbitrary {
+        return delegate.generate(context)
+            .filter { obj ->
+                if (!UNIQUE.contains(obj)) {
+                    UNIQUE.add(obj)
+                    true
+                } else {
+                    false
+                }
+            }
+    }
+}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryGenerator { UniqueArbitraryGenerator(it) }
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+{{< alert icon="📖" text="Notable implementations: 'IntrospectedArbitraryGenerator', 'CompositeArbitraryGenerator'" />}}
+
+-----------------
+
+## Excluding Classes or Packages from Generation
+> `pushExceptGenerateType`, `addExceptGenerateClass`, `addExceptGenerateClasses`, `addExceptGeneratePackage`, `addExceptGeneratePackages`
+
+If you want to exclude the generation of certain types or packages, you can use these options.
+특정 유형이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void testExcludeClass() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.addExceptGenerateClass(String.class)
+.build();
+
+    String actual = sut.giveMeOne(Product.class)
+      .getProductName();
+
+    then(actual).isNull();
+}
+
+@Test
+void testExcludePackage() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.addExceptGeneratePackage("java.lang")
+.build();
+
+    String actual = sut.giveMeOne(String.class);
+
+    then(actual).isNull();
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun testExcludeClass() {
+val fixtureMonkey = FixtureMonkey.builder()
+.addExceptGenerateClass(String::class.java)
+.build()
+
+    val actual = fixtureMonkey.giveMeOne<Product>()
+        .productName
+
+    then(actual).isNull()
+}
+
+@Test
+fun testExcludePackage() {
+val fixtureMonkey = FixtureMonkey.builder()
+.addExceptGeneratePackage("java.lang")
+.build()
+
+    val actual = fixtureMonkey.giveMeOne<String>()
+
+    then(actual).isNull()
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Container options
+
+### Container Size
+> `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
+
+`ArbitraryContainerInfo` holds information about the minimum and maximum sizes of a Container type.
+`ArbitraryContainerInfo`은 컨테이너 타입의 최소 및 최대 크기에 대한 정보를 보유합니다.
+You can change the behavior by modifying the `ArbitraryContainerInfoGenerator` using related options.
+관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정하여 동작을 변경할 수 있습니다.
+The following example demonstrates how to customize `ArbitraryContainerInfo` to set the size of all container types to 3.
+다음 예는 모든 컨테이너 타입의 크기를 3으로 설정하도록 `ArbitraryContainerInfo`를 사용자 정의하는 방법을 보여줍니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+@Test
+void test() {
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 3))
+.build();
+
+    List<String> actual = fixtureMonkey.giveMeOne();
+
+    then(actual).hasSize(3);
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+@Test
+fun test() {
+val fixtureMonkey = FixtureMonkey.builder()
+.defaultArbitraryContainerInfoGenerator { context -> ArbitraryContainerInfo(3, 3) }
+.build()
+
+    val actual: List<String> = fixtureMonkey.giveMeOne()
+
+    then(actual).hasSize(3)
+}
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+### Adding Container type
+> `addContainerType`
+
+You can add a new custom Container type using the `addContainerType` option.
+`addContainerType` 옵션을 사용하여 새 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
+
+Let's say you made a new custom Pair class in Java.
+Java에서 새로운 사용자 지정 Pair 클래스를 만들었다고 가정해 보겠습니다.
+
+You can use this container type by implementing a custom `ContainerPropertyGenerator`, `Introspector` and `DecomposedContainerValueFactory`.
+이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector` 및 `DecomposedContainerValueFactory`를 구현하여 사용할 수 있습니다.
+
+```java
+FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
+    .addContainerType(
+        Pair.class,
+        new PairContainerPropertyGenerator(),
+        new PairIntrospector(),
+        new PairDecomposedContainerValueFactory()
+    )
+	.build();
+```
+
+**custom Introspector:**
+```java
+public class PairIntrospector implements ArbitraryIntrospector, Matcher {
+	private static final Matcher MATCHER = new AssignableTypeMatcher(Pair.class);
+
+	@Override
+	public boolean match(Property property) {
+		return MATCHER.match(property);
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		ArbitraryProperty property = context.getArbitraryProperty();
+		ArbitraryContainerInfo containerInfo = property.getContainerProperty().getContainerInfo();
+		if (containerInfo == null) {
+			return ArbitraryIntrospectorResult.EMPTY;
+		}
+
+		List<Arbitrary<?>> childrenArbitraries = context.getChildrenArbitraryContexts().getArbitraries();
+		BuilderCombinator<List<Object>> builderCombinator = Builders.withBuilder(ArrayList::new);
+		for (Arbitrary<?> childArbitrary : childrenArbitraries) {
+			builderCombinator = builderCombinator.use(childArbitrary).in((list, element) -> {
+				list.add(element);
+				return list;
+			});
+		}
+
+		return new ArbitraryIntrospectorResult(
+			builderCombinator.build(it -> new Pair<>(it.get(0), it.get(1)))
+		);
+	}
+}
+```
+
+**custom `ContainerPropertyGenerator`:**
+```java
+public class PairContainerPropertyGenerator implements ContainerPropertyGenerator {
+	@Override
+	public ContainerProperty generate(ContainerPropertyGeneratorContext context) {
+		com.navercorp.fixturemonkey.api.property.Property property = context.getProperty();
+
+		List<AnnotatedType> elementTypes = Types.getGenericsTypes(property.getAnnotatedType());
+		if (elementTypes.size() != 2) {
+			throw new IllegalArgumentException(
+				"Pair elementsTypes must be have 1 generics type for element. "
+					+ "propertyType: " + property.getType()
+					+ ", elementTypes: " + elementTypes
+			);
+		}
+
+		AnnotatedType firstElementType = elementTypes.get(0);
+		AnnotatedType secondElementType = elementTypes.get(1);
+		List<com.navercorp.fixturemonkey.api.property.Property> elementProperties = new ArrayList<>();
+		elementProperties.add(
+			new ElementProperty(
+				property,
+				firstElementType,
+				0,
+				0
+			)
+		);
+		elementProperties.add(
+			new ElementProperty(
+				property,
+				secondElementType,
+				1,
+				1
+			)
+		);
+
+		return new ContainerProperty(
+			elementProperties,
+			new ArbitraryContainerInfo(1, 1, false)
+		);
+	}
+}
+```
+
+**custom `DecomposedContainerValueFactory`:**
+```java
+public class PairDecomposedContainerValueFactory implements DecomposedContainerValueFactory {
+	@Override
+	public DecomposedContainerValue from(Object object) {
+		Pair<?, ?> pair = (Pair<?, ?>)obj;
+		List<Object> list = new ArrayList<>();
+		list.add(pair.getFirst());
+		list.add(pair.getSecond());
+		return new DecomposableContainerValue(list, 2);
+	}
+}
+```
+
+-----------------
+
+## Validating Arbitraries
+> `arbitraryValidator`
+
+The `arbitraryValidator` option allows you to replace the default `arbitraryValidator` with your own custom arbitrary validator.
+
+When an instance is `sampled`, the `arbitraryValidator` validates the arbitrary, and if it is invalid, it throws an exception.
+This process is repeated 1,000 times, and if the instance is still invalid, a `TooManyFilterMissesException` would be thrown.
+
+{{< alert icon="📖" text="Notable implementations: 'JakartaArbitraryValidator', 'JavaxArbitraryValidator'" />}}
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.arbitraryValidator(obj -> {
+throw new ValidationFailedException("thrown by custom ArbitraryValidator", new HashSet<>());
+})
+.build();
+
+thenThrownBy(() -> fixtureMonkey.giveMeOne(String.class))
+.isExactlyInstanceOf(FilterMissException.class);
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.arbitraryValidator { obj ->
+throw ValidationFailedException("thrown by custom ArbitraryValidator", HashSet())
+}
+.build()
+
+assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
+.isExactlyInstanceOf(FilterMissException::class.java)
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Arbitrary Generation Retry Limits
+> `generateMaxTries`, `generateUniqueMaxTries`
+
+The `generateMaxTries` option allows you to control the maximum number of attempts to generate a valid object from an arbitrary.
+If an object cannot be generated successfully after exceeding this limit (default is 1,000 attempts), a `TooManyFilterMissesException` will be thrown.
+
+Additionally, Fixture Monkey ensures the generation of unique values for map keys and set elements.
+The `generateUniqueMaxTries` option allows you to specify the maximum number of attempts (also defaults to 1,000) that will be made to generate this unique value.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.generateMaxTries(100)
+.generateUniqueMaxTries(100)
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.generateMaxTries(100)
+.generateUniqueMaxTries(100)
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}
+
+-----------------
+
+## Interface Implementations
+> `interfaceImplements`
+
+`interfaceImplements` is an option used to specify the available implementations for an interface.
+
+When you don't specify this option, an ArbitraryBuilder for an interface will always result in a null value when sampled.
+However, when you do specify this option, Fixture Monkey will randomly generate one of the specified implementations whenever an ArbitraryBuilder for the interface is sampled.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+interface FixedValue {
+Object get();
+}
+
+class IntegerFixedValue implements FixedValue {
+@Override
+public Object get() {
+return 1;
+}
+}
+
+class StringFixedValue implements FixedValue {
+@Override
+public Object get() {
+return "fixed";
+}
+}
+
+class GenericFixedValue<T> {
+T value;
+}
+
+@Test
+void sampleGenericInterface() {
+// given
+List<Class<? extends FixedValue>> implementations = new ArrayList<>();
+implementations.add(IntegerFixedValue.class);
+implementations.add(StringFixedValue.class);
+
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .interfaceImplements(FixedValue.class, implementations)
+        .build();
+
+    // when
+    Object actual = fixtureMonkey.giveMeBuilder(new TypeReference<GenericGetFixedValue<FixedValue>>() {})
+        .setNotNull("value")
+        .sample()
+        .getValue()
+        .get();
+
+    // then
+    then(actual).isIn(1, "fixed");
+}
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+interface FixedValue {
+fun get(): Any
+}
+
+class IntegerFixedValue : FixedValue {
+override fun get(): Any {
+return 1
+}
+}
+
+class StringFixedValue : FixedValue {
+override fun get(): Any {
+return "fixed"
+}
+}
+
+class GenericFixedValue<T> {
+val value: T
+}
+
+@Test
+fun sampleGenericInterface() {
+// given
+val implementations: MutableList<Class<out FixedValue>> = List.of(IntegerFixedValue::class.java, StringFixedValue::class.java)
+
+    val fixtureMonkey = FixtureMonkey.builder()
+        .interfaceImplements(FixedValue::class.java, implementations)
+        .build()
+
+    // when
+    val actual = fixtureMonkey.giveMeBuilder<GenericGetFixedValue<FixedValue>>()
+        .sample()
+        .getValue()
+        .get()
+
+    // then
+    then(actual).isIn(1, "fixed")
+}
+
+{{< /tab >}}
+{{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -45,7 +45,7 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 ## 임의적인 생성
 `Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
-그런 다음 임의적으로 생성된 것을 기반으로 객체가 생성됩니다.
+그 다음에 임의 생성 전략을 기반으로 객체가 생성됩니다.
 사용자는 직접 `ArbitraryIntrospector` 를 구현하여 사용자 정의 `Introspector` 를 생성할 수 있는 유연성을 가지게 됩니다.
 
 ### ObjectIntrospector
@@ -251,7 +251,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 Java에서 새로운 사용자 정의 Pair 클래스를 만든다고 가정해 보겠습니다.
 
-이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
+이 컨테이너 타입은 사용자 정의 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
 
 ```java
 FixtureMonkey fixtureMonkey=FixtureMonkey.builder()

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -206,7 +206,7 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 ## 컨테이너 옵션
 
-### Container Size
+### 컨테이너 크기
 > `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
 
 `ArbitraryContainerInfo` 는 컨테이너 타입의 최소, 최대 크기에 대한 정보를 가집니다.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -83,7 +83,7 @@ Arbitrary 객체에서 최종 Arbitrary 객체(`CombinableArbitrary`)를 실제�
 {{< tab header="Java" lang="java">}}
 
 public static class UniqueArbitraryGenerator implements ArbitraryGenerator {
-private static final Set<Object> UNIQUE = new HashSet<>();
+    private static final Set<Object> UNIQUE = new HashSet<>();
 
     private final ArbitraryGenerator delegate;
 
@@ -107,16 +107,16 @@ private static final Set<Object> UNIQUE = new HashSet<>();
 }
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
-.build();
+    .defaultArbitraryGenerator(UniqueArbitraryGenerator::new)
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 class UniqueArbitraryGenerator(private val delegate: ArbitraryGenerator) : ArbitraryGenerator {
-companion object {
-private val UNIQUE = HashSet<Any>()
-}
+    companion object {
+    private val UNIQUE = HashSet<Any>()
+    }
 
     override fun generate(context: ArbitraryGeneratorContext): CombinableArbitrary {
         return delegate.generate(context)
@@ -132,8 +132,8 @@ private val UNIQUE = HashSet<Any>()
 }
 
 val fixtureMonkey = FixtureMonkey.builder()
-.defaultArbitraryGenerator { UniqueArbitraryGenerator(it) }
-.build()
+    .defaultArbitraryGenerator { UniqueArbitraryGenerator(it) }
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -152,9 +152,9 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 void testExcludeClass() {
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.addExceptGenerateClass(String.class)
-.build();
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .addExceptGenerateClass(String.class)
+        .build();
 
     String actual = sut.giveMeOne(Product.class)
       .getProductName();
@@ -164,9 +164,9 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 void testExcludePackage() {
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.addExceptGeneratePackage("java.lang")
-.build();
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .addExceptGeneratePackage("java.lang")
+        .build();
 
     String actual = sut.giveMeOne(String.class);
 
@@ -178,9 +178,9 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 fun testExcludeClass() {
-val fixtureMonkey = FixtureMonkey.builder()
-.addExceptGenerateClass(String::class.java)
-.build()
+    val fixtureMonkey = FixtureMonkey.builder()
+        .addExceptGenerateClass(String::class.java)
+        .build()
 
     val actual = fixtureMonkey.giveMeOne<Product>()
         .productName
@@ -190,9 +190,9 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 fun testExcludePackage() {
-val fixtureMonkey = FixtureMonkey.builder()
-.addExceptGeneratePackage("java.lang")
-.build()
+    val fixtureMonkey = FixtureMonkey.builder()
+        .addExceptGeneratePackage("java.lang")
+        .build()
 
     val actual = fixtureMonkey.giveMeOne<String>()
 
@@ -218,9 +218,9 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 void test() {
-FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 3))
-.build();
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+        .defaultArbitraryContainerInfoGenerator(context -> new ArbitraryContainerInfo(3, 3))
+        .build();
 
     List<String> actual = fixtureMonkey.giveMeOne();
 
@@ -232,9 +232,9 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
 
 @Test
 fun test() {
-val fixtureMonkey = FixtureMonkey.builder()
-.defaultArbitraryContainerInfoGenerator { context -> ArbitraryContainerInfo(3, 3) }
-.build()
+    val fixtureMonkey = FixtureMonkey.builder()
+        .defaultArbitraryContainerInfoGenerator { context -> ArbitraryContainerInfo(3, 3) }
+        .build()
 
     val actual: List<String> = fixtureMonkey.giveMeOne()
 
@@ -252,7 +252,6 @@ val fixtureMonkey = FixtureMonkey.builder()
 Java에서 새로운 사용자 정의 Pair 클래스를 만든다고 가정해 보겠습니다.
 
 이 컨테이너 타입은 사용자 정의 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
-
 ```java
 FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
     .addContainerType(
@@ -371,25 +370,25 @@ public class PairDecomposedContainerValueFactory implements DecomposedContainerV
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.arbitraryValidator(obj -> {
-throw new ValidationFailedException("thrown by custom ArbitraryValidator", new HashSet<>());
-})
-.build();
+    .arbitraryValidator(obj -> {
+        throw new ValidationFailedException("thrown by custom ArbitraryValidator", new HashSet<>());
+    })
+    .build();
 
 thenThrownBy(() -> fixtureMonkey.giveMeOne(String.class))
-.isExactlyInstanceOf(FilterMissException.class);
+    .isExactlyInstanceOf(FilterMissException.class);
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-.arbitraryValidator { obj ->
-throw ValidationFailedException("thrown by custom ArbitraryValidator", HashSet())
-}
-.build()
+    .arbitraryValidator { obj ->
+        throw ValidationFailedException("thrown by custom ArbitraryValidator", HashSet())
+    }
+    .build()
 
 assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
-.isExactlyInstanceOf(FilterMissException::class.java)
+    .isExactlyInstanceOf(FilterMissException::class.java)
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -409,17 +408,17 @@ assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.generateMaxTries(100)
-.generateUniqueMaxTries(100)
-.build();
+    .generateMaxTries(100)
+    .generateUniqueMaxTries(100)
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-.generateMaxTries(100)
-.generateUniqueMaxTries(100)
-.build()
+    .generateMaxTries(100)
+    .generateUniqueMaxTries(100)
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}
@@ -437,33 +436,33 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
 interface FixedValue {
-Object get();
+    Object get();
 }
 
 class IntegerFixedValue implements FixedValue {
-@Override
-public Object get() {
-return 1;
-}
+    @Override
+    public Object get() {
+        return 1;
+    }
 }
 
 class StringFixedValue implements FixedValue {
-@Override
-public Object get() {
-return "fixed";
-}
+    @Override
+    public Object get() {
+        return "fixed";
+    }
 }
 
 class GenericFixedValue<T> {
-T value;
+    T value;
 }
 
 @Test
 void sampleGenericInterface() {
-// given
-List<Class<? extends FixedValue>> implementations = new ArrayList<>();
-implementations.add(IntegerFixedValue.class);
-implementations.add(StringFixedValue.class);
+    // given
+    List<Class<? extends FixedValue>> implementations = new ArrayList<>();
+    implementations.add(IntegerFixedValue.class);
+    implementations.add(StringFixedValue.class);
 
     FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
         .interfaceImplements(FixedValue.class, implementations)
@@ -484,29 +483,29 @@ implementations.add(StringFixedValue.class);
 {{< tab header="Kotlin" lang="kotlin">}}
 
 interface FixedValue {
-fun get(): Any
+    fun get(): Any
 }
 
 class IntegerFixedValue : FixedValue {
-override fun get(): Any {
-return 1
-}
+    override fun get(): Any { 
+        return 1
+    }
 }
 
 class StringFixedValue : FixedValue {
-override fun get(): Any {
-return "fixed"
-}
+    override fun get(): Any {
+        return "fixed"
+    }
 }
 
 class GenericFixedValue<T> {
-val value: T
+    val value: T
 }
 
 @Test
 fun sampleGenericInterface() {
-// given
-val implementations: MutableList<Class<out FixedValue>> = List.of(IntegerFixedValue::class.java, StringFixedValue::class.java)
+    // given
+    val implementations: MutableList<Class<out FixedValue>> = List.of(IntegerFixedValue::class.java, StringFixedValue::class.java)
 
     val fixtureMonkey = FixtureMonkey.builder()
         .interfaceImplements(FixedValue::class.java, implementations)

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -12,20 +12,15 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 이러한 옵션은 `FixtureMonkeyBuilder` 를 통해 접근할 수 있습니다.
 
-## Property Generation
+## 프로퍼티 생성
 ### PropertyGenerator
 > `defaultPropertyGenerator`, `pushPropertyGenerator`, `pushAssignableTypePropertyGenerator`, `pushExactTypePropertyGenerator`
 
-`PropertyGenerator` creates child properties of the given `ObjectProperty`.
-`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다. 
-The child property can be a field, JavaBeans property, method or constructor parameter within the parent `ObjectProperty`.
+`PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다.
 자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 패러미터가 될 수 있습니다. 
-There are scenarios where you might want to customize how these child properties are generated.
-자식 프로퍼티들이 생성되는 방식을 사용자 정의하고자 하는 시나리오들이 있습니다.
+이러한 자식 프로퍼티가 생성되는 방식을 사용자 정의하는 몇 가지 방법이 있습니다.
 
-The `PropertyGenerator` options allow you to specify how child properties of each type are generated.
-`PropertyGenerator` 옵션으로 각 타입의 자식 프로퍼티가 어떻게 생성되는지 지정할 수 있습니다.
-This option is mainly used when you want to exclude generating some properties when the parent property has abnormal child properties.
+`PropertyGenerator` 옵션은 각 타입의 자식 프로퍼티가 생성되는 방식을 지정할 수 있습니다.
 이 옵션은 주로 부모 프로퍼티가 비정상적인 자식 프로퍼티를 가질 때 일부 프로퍼티 생성을 제외하고자 할 때 사용됩니다.
 
 {{< alert icon="📖" text="Notable implementations: 'FieldPropertyGenerator', 'JavaBeansPropertyGenerator'" />}}
@@ -33,65 +28,56 @@ This option is mainly used when you want to exclude generating some properties w
 ### ObjectPropertyGenerator
 > `defaultObjectPropertyGenerator`, `pushObjectPropertyGenerator`, `pushAssignableTypeObjectPropertyGenerator`, `pushExactTypeObjectPropertyGenerator`
 
-`ObjectPropertyGenerator` generates the [`ObjectProperty`](../concepts/#objectProperty) based on a given context.
 `ObjectPropertyGenerator` 는 주어진 컨텍스트에 기반하여 [`ObjectProperty`](../concepts/#objectProperty)를 생성합니다.
-With options related to `ObjectPropertyGenerator` you can customize how the `ObjectProperty` is generated.
 `ObjectPropertyGenerator` 관련 옵션을 사용하면 `ObjectProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'DefaultObjectPropertyGenerator'" />}}
 
 ### ContainerPropertyGenerator
 > `pushContainerPropertyGenerator`, `pushAssignableTypeContainerPropertyGenerator`, `pushExactTypeContainerPropertyGenerator`
 
-The `ContainerPropertyGenerator` determines how to generate [`ContainerProperty`](../concepts/#containerProperty) within a given context.
 `ContainerPropertyGenerator` 는 주어진 컨텍스트에서 [`ContainerProperty`](../concepts/#containerProperty) 를 생성하는 방법을 결정합니다.
-With options related to `ContainerPropertyGenerator` you can customize how the `ContainerProperty` is generated.
 `ContainerPropertyGenerator` 관련 옵션을 사용하면 `ContainerProperty` 가 생성되는 방식을 사용자 정의할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'ArrayContainerPropertyGenerator', 'MapContainerPropertyGenerator'" />}}
 
 -----------------
 
-## Arbitrary Generation
-An `Introspector` determines how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy based on the provided context(which includes information about generated properties).
-`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 적절한 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
-The object is then generated based on this arbitrary generated.
-이후 이 객체는 임의 생성된 기반으로 생성됩니다.
-You have the flexibility to create a custom `Introspector` by implementing your own `ArbitraryIntrospector`.
+## 임의적인 생성
+`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
+그런 다음 임의적으로 생성된 것을 기반으로 객체가 생성됩니다.
+사용자는 직접 `ArbitraryIntrospector` 를 구현하여 사용자 정의 `Introspector` 를 생성할 수 있는 유연성을 가지게 됩니다.
 
 ### ObjectIntrospector
 > `objectIntrospcetor`
 
-The `objectIntrospector` option allows you to specify the default behavior when generating an object.
-객체 생성 시 기본 동작을 지정하는 `objectIntrospector` 관련 옵션을 사용하면 객체를 생성할 때 기본 동작을 지정할 수 있습니다.
-As discussed in the [introspector section](../../generating-objects/introspector), you can alter the default introspector to use predefined introspectors provided by Fixture Monkey or create your own custom introspector.
-[introspector section](../../generating-objects/introspector)에서 설명한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+`objectIntrospector` 관련 옵션을 사용하면 객체 생성 시 기본 동작을 지정할 수 있습니다.
+[introspector section](../../generating-objects/introspector)에서 언급한 대로 기본 introspector를 변경하여 Fixture Monkey에서 제공하는 미리 정의된 introspector를 사용하거나 사용자 정의 introspector를 만들 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'BeanArbitraryIntrospector', 'BuilderArbitraryIntrospector'" />}}
 
 ### ArbitraryIntrospector
 > `pushArbitraryIntrospector`, `pushAssignableTypeArbitraryIntrospector`, `pushExactTypeArbitraryIntrospector`
 
-If you need to change the `ArbitraryIntrospector` for a specific type you can use the above options.
-특정 유형에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+특정 타입에 대한 `ArbitraryIntrospector` 를 변경해야 하는 경우 위의 옵션을 사용할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'BooleanIntrospector', 'EnumIntrospector'" />}}
 
 ### ContainerIntrospector
 > pushContainerIntrospector
 
-Especially for container types, you can change the `ArbitraryIntrospector` using the `pushContainerIntrospector` option.
 특히 컨테이너 타입의 경우, `pushContainerIntrospector` 옵션을 사용하여 `ArbitraryIntrospector` 를 변경할 수 있습니다.
+
 {{< alert icon="📖" text="Notable implementations: 'ListIntrospector', 'MapIntrospector'" />}}
 
 -----------------
 
-## Arbitrary Generation
-The `ArbitraryIntrospector` is responsible for defining how Fixture Monkey creates objects by selecting the appropriate arbitrary generation strategy and generating an arbitrary.
-`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 개체를 생성하여 Fixture Monkey가 개체를 생성하는 방법을 정의하는 역할을 담당합니다.
-The actual creation of the final arbitrary(`CombinableArbitrary`) from the arbitrary is done by the `ArbitraryGenerator`, which handles the request by delegating to the `ArbitraryIntrospcetor`.
-임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator`에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor`에 요청을 위임하여 요청을 처리합니다.
-By using the `defaultArbitraryGenerator` option, you have the capability to customize the behavior of the `ArbitraryGenerator`.
-`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 커스터마이징할 수 있습니다.
+## 임의적인 생성
+`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 객체를 생성하여 Fixture Monkey가 객체를 생성하는 방법을 정의하는 역할을 합니다.
+임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator` 에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor` 에 요청을 위임하여 요청을 처리합니다.
+`defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 사용자 정의 할 수 있습니다.
 
-For instance, you can create an arbitrary generator that produces unique values, as shown in the example below:
-예를 들어 예시와 같이 고유한 값을 생성하는 임의의 생성기를 만들 수 있습니다:
+예를 들어, 아래의 예시와 같이 고유한 값을 생성하는 arbitrary generator를 만들 수 있습니다:
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -156,11 +142,10 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Excluding Classes or Packages from Generation
+## 클래스, 패키지 생성 제외 옵션
 > `pushExceptGenerateType`, `addExceptGenerateClass`, `addExceptGenerateClasses`, `addExceptGeneratePackage`, `addExceptGeneratePackages`
 
-If you want to exclude the generation of certain types or packages, you can use these options.
-특정 유형이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
+특정 타입이나 패키지의 생성을 제외하려면 다음 옵션을 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -219,17 +204,14 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Container options
+## 컨테이너 옵션
 
 ### Container Size
 > `defaultArbitraryContainerInfoGenerator`, `pushArbitraryContainerInfoGenerator`
 
-`ArbitraryContainerInfo` holds information about the minimum and maximum sizes of a Container type.
-`ArbitraryContainerInfo`은 컨테이너 타입의 최소 및 최대 크기에 대한 정보를 보유합니다.
-You can change the behavior by modifying the `ArbitraryContainerInfoGenerator` using related options.
-관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정하여 동작을 변경할 수 있습니다.
-The following example demonstrates how to customize `ArbitraryContainerInfo` to set the size of all container types to 3.
-다음 예는 모든 컨테이너 타입의 크기를 3으로 설정하도록 `ArbitraryContainerInfo`를 사용자 정의하는 방법을 보여줍니다.
+`ArbitraryContainerInfo` 는 컨테이너 타입의 최소, 최대 크기에 대한 정보를 가집니다.
+관련 옵션을 사용하여 `ArbitraryContainerInfoGenerator` 를 수정함으로써 동작 방식을 변경할 수 있습니다.
+다음 예시는 `ArbitraryContainerInfo` 의 모든 컨테이너 타입의 크기를 3으로 설정하도록 사용자 정의하는 방법을 설명합니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -262,17 +244,14 @@ val fixtureMonkey = FixtureMonkey.builder()
 {{< /tab >}}
 {{< /tabpane>}}
 
-### Adding Container type
+### 컨테이너 타입 추가
 > `addContainerType`
 
-You can add a new custom Container type using the `addContainerType` option.
-`addContainerType` 옵션을 사용하여 새 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
+`addContainerType` 옵션을 사용하여 새로운 사용자 정의 컨테이너 타입을 추가할 수 있습니다.
 
-Let's say you made a new custom Pair class in Java.
-Java에서 새로운 사용자 지정 Pair 클래스를 만들었다고 가정해 보겠습니다.
+Java에서 새로운 사용자 정의 Pair 클래스를 만든다고 가정해 보겠습니다.
 
-You can use this container type by implementing a custom `ContainerPropertyGenerator`, `Introspector` and `DecomposedContainerValueFactory`.
-이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector` 및 `DecomposedContainerValueFactory`를 구현하여 사용할 수 있습니다.
+이 컨테이너 타입은 커스텀 `ContainerPropertyGenerator`, `Introspector`, `DecomposedContainerValueFactory` 를 구현하여 사용할 수 있습니다.
 
 ```java
 FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
@@ -379,13 +358,12 @@ public class PairDecomposedContainerValueFactory implements DecomposedContainerV
 
 -----------------
 
-## Validating Arbitraries
+## 임의성 유효성 검증
 > `arbitraryValidator`
 
-The `arbitraryValidator` option allows you to replace the default `arbitraryValidator` with your own custom arbitrary validator.
-
-When an instance is `sampled`, the `arbitraryValidator` validates the arbitrary, and if it is invalid, it throws an exception.
-This process is repeated 1,000 times, and if the instance is still invalid, a `TooManyFilterMissesException` would be thrown.
+`arbitraryValidator` 옵션을 사용하면 기본 `arbitraryValidator` 를 사용자 정의 임의의 유효성 검사기로 대체할 수 있습니다.
+인스턴스가 `sampled` 되면 `arbitraryValidator` 는 임의의 유효성을 검사하고 유효하지 않은 경우 예외를 던집니다.
+이 프로세스는 1,000회 반복되며, 인스턴스가 여전히 유효하지 않다면 `TooManyFilterMissesException` 예외를 던질 것입니다.
 
 {{< alert icon="📖" text="Notable implementations: 'JakartaArbitraryValidator', 'JavaxArbitraryValidator'" />}}
 
@@ -418,14 +396,14 @@ assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
 
 -----------------
 
-## Arbitrary Generation Retry Limits
+## 임의적인 생성 재시도 제한
 > `generateMaxTries`, `generateUniqueMaxTries`
 
-The `generateMaxTries` option allows you to control the maximum number of attempts to generate a valid object from an arbitrary.
-If an object cannot be generated successfully after exceeding this limit (default is 1,000 attempts), a `TooManyFilterMissesException` will be thrown.
+`generateMaxTries` 옵션을 사용하면 임의의 객체에서 유효한 객체를 생성하기 위한 최대 시도 횟수를 제한할 수 있습니다.
+제한(기본값 1,000회)을 초과하여 객체를 성공적으로 생성할 수 없는 경우, `TooManyFilterMissesException` 예외를 던질 것입니다.
 
-Additionally, Fixture Monkey ensures the generation of unique values for map keys and set elements.
-The `generateUniqueMaxTries` option allows you to specify the maximum number of attempts (also defaults to 1,000) that will be made to generate this unique value.
+추가적으로, Fixture Monkey는 Map의 키(key)와 Set의 요소(element)에 대한 고유한 값 생성을 보장합니다.
+`generateUniqueMaxTries` 옵션을 사용하면 이 고유한 값을 생성하기 위해 시도 최대 횟수(기본값 1,000회)를 지정할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}
@@ -448,13 +426,13 @@ val fixtureMonkey = FixtureMonkey.builder()
 
 -----------------
 
-## Interface Implementations
+## 인터페이스 구현
 > `interfaceImplements`
 
-`interfaceImplements` is an option used to specify the available implementations for an interface.
+`interfaceImplements` 은 인터페이스에 사용 가능한 구현체를 지정할 때 사용되는 옵션입니다.
 
-When you don't specify this option, an ArbitraryBuilder for an interface will always result in a null value when sampled.
-However, when you do specify this option, Fixture Monkey will randomly generate one of the specified implementations whenever an ArbitraryBuilder for the interface is sampled.
+이 옵션을 지정하지 않으면, 인터페이스에 대한 ArbitraryBuilder가 샘플링될 때 항상 null 값을 반환합니다.
+하지만 이 옵션을 지정하면 Fixture Monkey는 인터페이스에 대한 ArbitraryBuilder를 샘플링할 때마다 지정된 구현체 중 하나를 임의로 생성합니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/generation-options.md
@@ -8,7 +8,7 @@ identifier: "options"
 weight: 52
 ---
 
-Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기 위한 다양한 옵션을 제공합니다.
+Fixture Monkey는 원하는 설정과 일치하는 복잡한 객체를 생성하기 위한 다양한 옵션을 제공합니다.
 
 이러한 옵션은 `FixtureMonkeyBuilder` 를 통해 접근할 수 있습니다.
 
@@ -17,7 +17,7 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 > `defaultPropertyGenerator`, `pushPropertyGenerator`, `pushAssignableTypePropertyGenerator`, `pushExactTypePropertyGenerator`
 
 `PropertyGenerator` 는 주어진 `ObjectProperty` 의 자식 프로퍼티를 생성합니다.
-자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 패러미터가 될 수 있습니다. 
+자식 프로퍼티는 부모 `ObjectProperty` 내의 필드, JavaBeans 프로퍼티, 메서드, 생성자 파라미터가 될 수 있습니다. 
 이러한 자식 프로퍼티가 생성되는 방식을 사용자 정의하는 몇 가지 방법이 있습니다.
 
 `PropertyGenerator` 옵션은 각 타입의 자식 프로퍼티가 생성되는 방식을 지정할 수 있습니다.
@@ -43,9 +43,9 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 -----------------
 
-## 임의적인 생성
-`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 임의 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
-그 다음에 임의 생성 전략을 기반으로 객체가 생성됩니다.
+## Arbitrary 생성
+`Introspector` 는 생성된 프로퍼티에 대한 정보를 포함한 컨텍스트를 기반으로 Arbitrary 생성 전략을 선택하여 Fixture Monkey가 객체를 생성하는 방법을 결정합니다.
+그 다음에 Arbitrary 생성 전략을 기반으로 객체가 생성됩니다.
 사용자는 직접 `ArbitraryIntrospector` 를 구현하여 사용자 정의 `Introspector` 를 생성할 수 있는 유연성을 가지게 됩니다.
 
 ### ObjectIntrospector
@@ -72,9 +72,9 @@ Fixture Monkey는 원하는 설정과 일치하는 복합 객체를 생성하기
 
 -----------------
 
-## 임의적인 생성
-`ArbitraryIntrospector` 는 적절한 임의 생성 전략을 선택하고 임의의 객체를 생성하여 Fixture Monkey가 객체를 생성하는 방법을 정의하는 역할을 합니다.
-임의 객체에서 최종 임의 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator` 에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor` 에 요청을 위임하여 요청을 처리합니다.
+## Arbitrary 생성
+`ArbitraryIntrospector` 는 적절한 Arbitrary 생성 전략을 선택하고 Arbitrary를 생성하여 Fixture Monkey가 객체를 생성하는 방법을 정의하는 역할을 합니다.
+Arbitrary 객체에서 최종 Arbitrary 객체(`CombinableArbitrary`)를 실제로 생성하는 것은 `ArbitraryGenerator` 에 의해 이루어지며, 이 객체는 `ArbitraryIntrospcetor` 에 요청을 위임하여 요청을 처리합니다.
 `defaultArbitraryGenerator` 옵션을 사용하면 `ArbitraryGenerator` 의 동작을 사용자 정의 할 수 있습니다.
 
 예를 들어, 아래의 예시와 같이 고유한 값을 생성하는 arbitrary generator를 만들 수 있습니다:
@@ -264,7 +264,7 @@ FixtureMonkey fixtureMonkey=FixtureMonkey.builder()
 	.build();
 ```
 
-**custom Introspector:**
+**사용자 정의 Introspector:**
 ```java
 public class PairIntrospector implements ArbitraryIntrospector, Matcher {
 	private static final Matcher MATCHER = new AssignableTypeMatcher(Pair.class);
@@ -298,7 +298,7 @@ public class PairIntrospector implements ArbitraryIntrospector, Matcher {
 }
 ```
 
-**custom `ContainerPropertyGenerator`:**
+**사용자 정의 `ContainerPropertyGenerator`:**
 ```java
 public class PairContainerPropertyGenerator implements ContainerPropertyGenerator {
 	@Override
@@ -342,7 +342,7 @@ public class PairContainerPropertyGenerator implements ContainerPropertyGenerato
 }
 ```
 
-**custom `DecomposedContainerValueFactory`:**
+**사용자 정의 `DecomposedContainerValueFactory`:**
 ```java
 public class PairDecomposedContainerValueFactory implements DecomposedContainerValueFactory {
 	@Override
@@ -358,11 +358,11 @@ public class PairDecomposedContainerValueFactory implements DecomposedContainerV
 
 -----------------
 
-## 임의성 유효성 검증
+## Arbitraries 유효성 검증
 > `arbitraryValidator`
 
-`arbitraryValidator` 옵션을 사용하면 기본 `arbitraryValidator` 를 사용자 정의 임의의 유효성 검사기로 대체할 수 있습니다.
-인스턴스가 `sampled` 되면 `arbitraryValidator` 는 임의의 유효성을 검사하고 유효하지 않은 경우 예외를 던집니다.
+`arbitraryValidator` 옵션을 사용하면 기본 `arbitraryValidator` 를 사용자 정의 Arbitrary 유효성 검사기로 대체할 수 있습니다.
+인스턴스가 `sampled` 되면 `arbitraryValidator` 는 Arbitrary의 유효성을 검사하고 유효하지 않은 경우 예외를 던집니다.
 이 프로세스는 1,000회 반복되며, 인스턴스가 여전히 유효하지 않다면 `TooManyFilterMissesException` 예외를 던질 것입니다.
 
 {{< alert icon="📖" text="Notable implementations: 'JakartaArbitraryValidator', 'JavaxArbitraryValidator'" />}}
@@ -396,10 +396,10 @@ assertThatThrownBy { fixtureMonkey.giveMeOne<String>() }
 
 -----------------
 
-## 임의적인 생성 재시도 제한
+## Arbitrary 생성 재시도 제한
 > `generateMaxTries`, `generateUniqueMaxTries`
 
-`generateMaxTries` 옵션을 사용하면 임의의 객체에서 유효한 객체를 생성하기 위한 최대 시도 횟수를 제한할 수 있습니다.
+`generateMaxTries` 옵션을 사용하면 Arbitrary 객체에서 유효한 객체를 생성하기 위한 최대 시도 횟수를 제한할 수 있습니다.
 제한(기본값 1,000회)을 초과하여 객체를 성공적으로 생성할 수 없는 경우, `TooManyFilterMissesException` 예외를 던질 것입니다.
 
 추가적으로, Fixture Monkey는 Map의 키(key)와 Set의 요소(element)에 대한 고유한 값 생성을 보장합니다.

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
@@ -16,7 +16,7 @@ Fixture Monkey는 플러그인을 통한 타사 라이브러리 지원 등 몇 �
 플러그인 옵션을 사용하여 이 추가 기능을 사용할 수 있습니다.
 
 예시로 아래와 같이 Jackson 플러그인을 추가할 수 있습니다.
-이렇게 하면 `JacksonObjectArbitraryIntrospector` 그리고 Jackson annotation support와 같은 Jackson의 기능을 사용할 수 있습니다.
+이렇게 하면 `JacksonObjectArbitraryIntrospector` 그리고 Jackson 어노테이션 지원과 같은 Jackson의 기능을 사용할 수 있습니다.
 
 {{< tabpane persist=false >}}
 {{< tab header="Java" lang="java">}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
@@ -22,15 +22,15 @@ Fixture Monkey는 플러그인을 통한 타사 라이브러리 지원 등 몇 �
 {{< tab header="Java" lang="java">}}
 
 FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
-.plugin(new JacksonPlugin())
-.build();
+    .plugin(new JacksonPlugin())
+    .build();
 
 {{< /tab >}}
 {{< tab header="Kotlin" lang="kotlin">}}
 
 val fixtureMonkey = FixtureMonkey.builder()
-.plugin(JacksonPlugin())
-.build()
+    .plugin(JacksonPlugin())
+    .build()
 
 {{< /tab >}}
 {{< /tabpane>}}

--- a/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
+++ b/docs/content/v1.0.x-kor/docs/fixture-monkey-options/other-options.md
@@ -8,4 +8,29 @@ identifier: "options"
 weight: 53
 ---
 
-### 한국어 번역 필요
+이 섹션에서는 `FixtureMonkeyBuilder` 가 제공하는 몇 가지 추가 옵션을 설명합니다.
+
+### plugin
+
+Fixture Monkey는 플러그인을 통한 타사 라이브러리 지원 등 몇 가지 추가 기능을 제공합니다.
+플러그인 옵션을 사용하여 이 추가 기능을 사용할 수 있습니다.
+
+예시로 아래와 같이 Jackson 플러그인을 추가할 수 있습니다.
+이렇게 하면 `JacksonObjectArbitraryIntrospector` 그리고 Jackson annotation support와 같은 Jackson의 기능을 사용할 수 있습니다.
+
+{{< tabpane persist=false >}}
+{{< tab header="Java" lang="java">}}
+
+FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+.plugin(new JacksonPlugin())
+.build();
+
+{{< /tab >}}
+{{< tab header="Kotlin" lang="kotlin">}}
+
+val fixtureMonkey = FixtureMonkey.builder()
+.plugin(JacksonPlugin())
+.build()
+
+{{< /tab >}}
+{{< /tabpane>}}


### PR DESCRIPTION
## Summary
related to https://github.com/naver/fixture-monkey/issues/864
`Fixture Monkey Options`의 `Generation Options`, `Customization Options`, `Other Options page` 한국어 번역

---

## Description

`Generation Options page`의 [46번 째](https://naver.github.io/fixture-monkey/docs/fixture-monkey-options/generation-options/#arbitrary-generation), [75번 째 줄](https://naver.github.io/fixture-monkey/docs/fixture-monkey-options/generation-options/#arbitrary-generation-1)의 Arbitrary Generation 파트 제목이 중복되는 것 같습니다.

추가적으로 어색한 부분이나 개선할 점 있으면 comment 부탁드립니다. 감사합니다 :)