### PR TITLE
Add CollectionIntrospector

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/JavaDefaultArbitraryGeneratorBuilder.java
@@ -31,6 +31,7 @@ import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult;
 import com.navercorp.fixturemonkey.api.introspector.ArrayIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.BooleanIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.CollectionIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.EnumIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IterableIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.IteratorIntrospector;
@@ -69,7 +70,8 @@ public final class JavaDefaultArbitraryGeneratorBuilder {
 			new MapIntrospector(),
 			new MapEntryIntrospector(),
 			new MapEntryElementIntrospector(),
-			new ArrayIntrospector()
+			new ArrayIntrospector(),
+			new CollectionIntrospector()
 		)
 	);
 	public static final ArbitraryIntrospector DEFAULT_FALLBACK_INTROSPECTOR =

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/CollectionIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/CollectionIntrospector.java
@@ -1,0 +1,64 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import static com.navercorp.fixturemonkey.api.matcher.SingleGenericTypeMatcher.SINGLE_GENERIC_TYPE_MATCHER;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
+import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher;
+import com.navercorp.fixturemonkey.api.matcher.Matcher;
+import com.navercorp.fixturemonkey.api.property.Property;
+
+@API(since = "1.0.14", status = Status.EXPERIMENTAL)
+public final class CollectionIntrospector implements ArbitraryIntrospector, Matcher {
+	private static final Logger LOGGER = LoggerFactory.getLogger(CollectionIntrospector.class);
+	private static final Matcher MATCHER = new AssignableTypeMatcher(Collection.class);
+
+	@Override
+	public boolean match(Property property) {
+		return SINGLE_GENERIC_TYPE_MATCHER.match(property) && MATCHER.match(property);
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		ArbitraryProperty property = context.getArbitraryProperty();
+		if (!property.isContainer() || !match(context.getResolvedProperty())) {
+			LOGGER.info("Given type {} is not Collection type.", context.getResolvedType());
+			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
+		}
+
+		List<CombinableArbitrary<?>> elementCombinableArbitraryList = context.getElementCombinableArbitraryList();
+		return new ArbitraryIntrospectorResult(
+			CombinableArbitrary.containerBuilder()
+				.elements(elementCombinableArbitraryList)
+				.build(ArrayList::new)
+		);
+	}
+}

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinInterfaceTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinInterfaceTest.kt
@@ -1,0 +1,85 @@
+package com.navercorp.fixturemonkey.tests.kotlin
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+
+class KotlinInterfaceTest {
+    private val sut: FixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+        .build()
+
+    @Test
+    fun parentTest() {
+        val actual = sut.giveMeOne<Parent>()
+
+        then(actual).isNotNull
+    }
+
+    @Test
+    fun childTest() {
+        val actual = sut.giveMeOne<Child>()
+
+        then(actual).isNotNull
+    }
+
+    @Test
+    fun parentWithChildCollectionTest() {
+        val actual = sut.giveMeOne<ParentWithChildCollection>()
+
+        then(actual).isNotNull
+    }
+
+    @Test
+    fun parentWithChildListTest() {
+        val actual = sut.giveMeOne<ParentWithChildList>()
+
+        then(actual).isNotNull
+    }
+
+    @Test
+    fun parentWithChildCollectionImplTest() {
+        val actual = sut.giveMeOne<ParentWithChildCollectionImpl>()
+
+        then(actual).isNotNull
+        then(actual.childCollection).isInstanceOf(List::class.java)
+    }
+
+    @Test
+    fun parentWithChildCollectionOverridedTypeImplTest() {
+        val actual = sut.giveMeOne<ParentWithChildCollectionOverridedTypeImpl>()
+
+        then(actual).isNotNull
+        then(actual.childCollection).isInstanceOf(List::class.java)
+    }
+
+    interface Parent {
+        val string: String
+        val integer: Int
+    }
+
+    interface Child {
+        val string: String
+        val integer: Int
+    }
+
+    interface ParentWithChildCollection {
+        val childCollection: Collection<Child>
+    }
+
+    interface ParentWithChildList {
+        val childList: List<Child>
+    }
+
+    data class ParentWithChildCollectionImpl(
+        override val childCollection: Collection<Child>,
+        val childList: List<Child>,
+        val string: String,
+    ) : ParentWithChildCollection
+
+    data class ParentWithChildCollectionOverridedTypeImpl(
+        override val childCollection: List<Child>,
+    ) : ParentWithChildCollection
+}


### PR DESCRIPTION
## Summary
*Describe what feature is implemented by this PR.*
*If there is a related issue, write the issue number and link*

kotlin에서 `Collection` 타입을 프로퍼티로 가진 interface의 구현체인 data class에 대한 픽스처 생성시 동작하지 않는 점을 수정했습니다.
`Collection` 타입일 경우 `List`, `Map`, `Set` 등 어떤것으로 정의해야할지 몰라서 우선 `List`를 사용했습니다.

## (Optional): Description
*Describe your changes in detail*

## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*

로컬 환경에서 테스트 코드 추가해서 확인했습니다.

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*
