### PR TITLE
Translate kotest-plugin section title and contents

### DIFF
--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
@@ -9,7 +9,7 @@ weight: 91
 ---
 
 Fixture Monkey에서 제공하는 Kotest 플러그인을 사용하면 더욱 향상된 테스트를 경험할 수 있습니다.
-- 기본 타입의 랜덤 값을 생성하는 기본 생성자를 Jqwik에서 Kotest의 프로퍼티 생성자(`Arb`)로 대체합니다. 빈(bean) 검증 어노테이션을 사용할 수도 있습니다.
+- 기본 타입의 랜덤 값을 생성하는 기본 생성기를 Jqwik에서 Kotest의 프로퍼티 생성기(`Arb`)로 대체합니다. 빈(bean) 검증 어노테이션을 사용할 수도 있습니다.
 - `forAll`, `checkAll`을 포함한 Kotest의 [property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)를 지원합니다.
 
 {{< alert icon="💡" text="Kotest 플러그인 추가 후 반드시 Kotest를 사용해야 하는 것은 아니며, Junit을 사용할 수 있습니다." />}}

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
@@ -1,5 +1,5 @@
 ---
-title: "Features"
+title: "기능"
 images: []
 menu:
 docs:
@@ -8,4 +8,33 @@ identifier: "kotest-plugin-features"
 weight: 91
 ---
 
-### 한국어 번역 필요
+Fixture Monkey에서 제공하는 Kotest 플러그인을 사용하면 더욱 향상된 테스트를 경험할 수 있습니다.
+- 원시 타입의 랜덤 값을 생성하는 기본 생성자를 Jqwik에서 Kotest의 프로퍼티 생성자(`Arb`)로 대체합니다. 빈(bean) 검증 어노테이션을 사용할 수도 있습니다.
+- `forAll`, `checkAll`을 포함한 Kotest의 [property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)를 지원합니다.
+
+{{< alert icon="💡" text="Kotest 플러그인 추가 후 반드시 Kotest를 사용해야 하는 것은 아니며, Junit을 사용할 수 있습니다." />}}
+
+## 의존성
+##### fixture-monkey-kotlin
+#### Gradle
+```groovy
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotest:{{< fixture-monkey-version >}}")
+```
+
+#### Maven
+```xml
+<dependency>
+  <groupId>com.navercorp.fixturemonkey</groupId>
+  <artifactId>fixture-monkey-kotest</artifactId>
+  <version>{{< fixture-monkey-version >}}</version>
+  <scope>test</scope>
+</dependency>
+```
+
+## 플러그인
+```kotlin
+val fixtureMonkey = FixtureMonkey.builder()
+    .plugin(KotestPlugin())
+    .plugin(KotlinPlugin())
+    .build()
+```

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/features.md
@@ -9,7 +9,7 @@ weight: 91
 ---
 
 Fixture Monkey에서 제공하는 Kotest 플러그인을 사용하면 더욱 향상된 테스트를 경험할 수 있습니다.
-- 원시 타입의 랜덤 값을 생성하는 기본 생성자를 Jqwik에서 Kotest의 프로퍼티 생성자(`Arb`)로 대체합니다. 빈(bean) 검증 어노테이션을 사용할 수도 있습니다.
+- 기본 타입의 랜덤 값을 생성하는 기본 생성자를 Jqwik에서 Kotest의 프로퍼티 생성자(`Arb`)로 대체합니다. 빈(bean) 검증 어노테이션을 사용할 수도 있습니다.
 - `forAll`, `checkAll`을 포함한 Kotest의 [property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)를 지원합니다.
 
 {{< alert icon="💡" text="Kotest 플러그인 추가 후 반드시 Kotest를 사용해야 하는 것은 아니며, Junit을 사용할 수 있습니다." />}}

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
@@ -8,7 +8,7 @@ identifier: "kotest-property-based-testing"
 weight: 92
 ---
 
-Fixture Monkey의 Kotest 플러그인은 향상된 [Kotest 프레임워크의 property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)의 2가지 주요 기능인 `forAll`과 `checkAll`을 제공합니다.
+Fixture Monkey의 Kotest 플러그인은 [Kotest 프레임워크의 property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)의 2가지 주요 기능인 `forAll`과 `checkAll`을 강화할 수 있는 기능을 제공합니다.
 
 이 기능을 활성화하려면 KotestPlugin과 KotlinPlugin을 추가해야 합니다.
 ```kotlin
@@ -22,7 +22,7 @@ val fixtureMonkey: FixtureMonkey = Fixture
 Kotest는 `(a, ..., n) -> Boolean` 형식의 n-arity 함수를 받아 프로퍼티를 테스트하는 `forAll` 함수를 제공합니다.
 모든 입력 값에 대해 함수가 true를 반환하면 테스트가 통과합니다.
 
-이 함수는 인수 타입에 대한 타입 파라미터를 허용하며, Kotest는 적합한 타입의 랜덤 값을 제공하는 생성자를 찾기 위해 사용합니다.
+이 함수는 타입 매개변수를 받고, 이를 사용하여 Kotest가 적절한 타입의 랜덤 값을 제공하는 생성기를 찾습니다.
 
 ```kotlin
 class PropertyExample: StringSpec({
@@ -34,11 +34,11 @@ class PropertyExample: StringSpec({
 })
 ```
 
-커스텀 생성자가 필요한 경우 Kotest에서는 `Arb` 생성자를 지정할 수 있습니다.
-Kotest에서는 제한된 유형의 생성자만 제공되며 커스텀하기 어렵습니다.
+커스텀 생성기가 필요한 경우 Kotest에서는 `Arb` 생성기를 지정할 수 있습니다.
+Kotest에서는 제한된 유형의 생성기만 제공되며 커스텀하기 어렵습니다.
 
-Fixture Monkey는 `giveMeArb()` 함수를 사용하여 커스텀 유형에 대한 `Arb`를 생성하는 방법을 제공합니다.
-Fixture Monkey의 커스텀 API를 사용하여 생성자를 한층 더 커스텀할 수 있습니다.
+Fixture Monkey는 `giveMeArb()` 함수를 사용하여 커스텀 타입에 대한 `Arb`를 생성하는 방법을 제공합니다.
+Fixture Monkey의 커스텀 API를 사용하여 생성기를 한층 더 커스텀할 수 있습니다.
 
 다음은 Fixture Monkey를 통해 `forAll`을 사용한 프로퍼티 기반 테스트의 예제 입니다.
 
@@ -57,7 +57,7 @@ class KotestInKotestTest : StringSpec({
 ## CheckAll
 Fixture Monkey는 Kotest의 `checkAll`과 유사한 확장 함수 `checkAll`을 제공합니다.
 
-### 기본 타입 입력
+### 기본 타입 입력 값
 checkAll을 사용하면 아래 예제와 같이 기본 데이터 타입에 대한 테스트를 검증할 수 있습니다.
 
 ```kotlin
@@ -71,9 +71,8 @@ class Test : StringSpec({
 })
 ```
 
-### 커스텀 타입 입력
-Fixture Monkey의 `checkAll` 확장 함수는 기본 타입을 사용하는 것 외에도 커스텀 타입을 사용할 수 있습니다. 
-또한 Fixture Monkey로 생성된 커스텀 타입은 입력 데이터로도 사용할 수 있습니다.
+### 커스텀 타입 입력 값
+Fixture Monkey의 `checkAll` 확장 함수를 이용하면 기본 타입을 생성하는 것 뿐만 아니라 사용자 정의 타입들도 입력 데이터로 사용할 수 있습니다.
 
 ```kotlin
 class Test : StringSpec({
@@ -87,7 +86,7 @@ class Test : StringSpec({
 }
 ```
 
-### ArbitraryBuilder 입력
+### ArbitraryBuilder 입력 값
 
 또한 `ArbitraryBuilder` 인스턴스를 활용하여 더 세부적인 커스터마이징을 통해 검증을 수행할 수 있습니다.
 

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
@@ -57,8 +57,8 @@ class KotestInKotestTest : StringSpec({
 ## CheckAll
 Fixture Monkey는 Kotest의 `checkAll`과 유사한 확장 함수 `checkAll`을 제공합니다.
 
-### 원시 타입 입력
-checkAll을 사용하면 아래 예제와 같이 원시적인 데이터 타입에 대한 테스트를 검증할 수 있습니다.
+### 기본 타입 입력
+checkAll을 사용하면 아래 예제와 같이 기본 데이터 타입에 대한 테스트를 검증할 수 있습니다.
 
 ```kotlin
 class Test : StringSpec({
@@ -72,7 +72,7 @@ class Test : StringSpec({
 ```
 
 ### 커스텀 타입 입력
-Fixture Monkey의 `checkAll` 확장 함수는 원시 타입을 사용하는 것 외에도 커스텀 타입을 사용할 수 있습니다. 
+Fixture Monkey의 `checkAll` 확장 함수는 기본 타입을 사용하는 것 외에도 커스텀 타입을 사용할 수 있습니다. 
 또한 Fixture Monkey로 생성된 커스텀 타입은 입력 데이터로도 사용할 수 있습니다.
 
 ```kotlin

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/property-based-testing.md
@@ -1,5 +1,5 @@
 ---
-title: "Kotest Property Based Testing"
+title: "Kotest 프로퍼티 기반 테스트"
 images: []
 menu:
 docs:
@@ -8,4 +8,99 @@ identifier: "kotest-property-based-testing"
 weight: 92
 ---
 
-### 한국어 번역 필요
+Fixture Monkey의 Kotest 플러그인은 향상된 [Kotest 프레임워크의 property-based 테스트](https://kotest.io/docs/proptest/property-test-functions.html)의 2가지 주요 기능인 `forAll`과 `checkAll`을 제공합니다.
+
+이 기능을 활성화하려면 KotestPlugin과 KotlinPlugin을 추가해야 합니다.
+```kotlin
+val fixtureMonkey: FixtureMonkey = Fixture
+    .plugin(KotestPlugin())
+    .plugin(KotlinPlugin())
+    .build()
+```
+
+## ForAll
+Kotest는 `(a, ..., n) -> Boolean` 형식의 n-arity 함수를 받아 프로퍼티를 테스트하는 `forAll` 함수를 제공합니다.
+모든 입력 값에 대해 함수가 true를 반환하면 테스트가 통과합니다.
+
+이 함수는 인수 타입에 대한 타입 파라미터를 허용하며, Kotest는 적합한 타입의 랜덤 값을 제공하는 생성자를 찾기 위해 사용합니다.
+
+```kotlin
+class PropertyExample: StringSpec({
+   "String size" {
+      forAll<String, String> { a, b ->
+         (a + b).length == a.length + b.length
+      }
+   }
+})
+```
+
+커스텀 생성자가 필요한 경우 Kotest에서는 `Arb` 생성자를 지정할 수 있습니다.
+Kotest에서는 제한된 유형의 생성자만 제공되며 커스텀하기 어렵습니다.
+
+Fixture Monkey는 `giveMeArb()` 함수를 사용하여 커스텀 유형에 대한 `Arb`를 생성하는 방법을 제공합니다.
+Fixture Monkey의 커스텀 API를 사용하여 생성자를 한층 더 커스텀할 수 있습니다.
+
+다음은 Fixture Monkey를 통해 `forAll`을 사용한 프로퍼티 기반 테스트의 예제 입니다.
+
+```kotlin
+class KotestInKotestTest : StringSpec({
+    "forAll" {
+        forAll(fixtureMonkey.giveMeArb<StringObject> { it.set("value", "test") }) { a ->
+            a.value == "test"
+        }
+    }
+}) {
+    data class StringObject(val value: String)
+}
+```
+
+## CheckAll
+Fixture Monkey는 Kotest의 `checkAll`과 유사한 확장 함수 `checkAll`을 제공합니다.
+
+### 원시 타입 입력
+checkAll을 사용하면 아래 예제와 같이 원시적인 데이터 타입에 대한 테스트를 검증할 수 있습니다.
+
+```kotlin
+class Test : StringSpec({
+    "checkAll" {
+        SUT.checkAll { string: String, int: Int ->
+            string shouldNotBeSameInstanceAs int
+            string shouldBe string
+        }
+    }
+})
+```
+
+### 커스텀 타입 입력
+Fixture Monkey의 `checkAll` 확장 함수는 원시 타입을 사용하는 것 외에도 커스텀 타입을 사용할 수 있습니다. 
+또한 Fixture Monkey로 생성된 커스텀 타입은 입력 데이터로도 사용할 수 있습니다.
+
+```kotlin
+class Test : StringSpec({
+    "checkAllObject" {
+        SUT.checkAll { stringObject: StringObject ->
+            stringObject.value shouldNotBe null
+        }
+    }
+}) {
+    data class StringObject(val value: String)
+}
+```
+
+### ArbitraryBuilder 입력
+
+또한 `ArbitraryBuilder` 인스턴스를 활용하여 더 세부적인 커스터마이징을 통해 검증을 수행할 수 있습니다.
+
+```kotlin
+class Test : StringSpec({
+    "checkAllArbitraryBuilder" {
+        SUT.checkAll { string: ArbitraryBuilder<List<String>> ->
+            string
+                .size("$", 3)
+                .sample() shouldHaveSize 3
+        }
+    }
+}) {
+    data class StringObject(val value: String)
+}
+```


### PR DESCRIPTION
## Summary
Translate `Features`, `Kotest Property Based Testing`  page of plugin/kotest-plugin section.
This korean translation works is related to #864

## How Has This Been Tested?
Tested with npm start to check translations of docs.

## Is the Document updated?
1. I had some concerns about translation of `generator` as 생성자.
2. Same as translation of `input` as 입력.
