### PR TITLE
feat: 'InnerSpec.keys()' Method with Collection Parameter Support

### DIFF
--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/InnerSpec.java
@@ -24,6 +24,7 @@ import static com.navercorp.fixturemonkey.Constants.NO_OR_ALL_INDEX_INTEGER_VALU
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -163,6 +164,16 @@ public final class InnerSpec {
 	public InnerSpec key(Object key) {
 		entrySize++;
 		setMapKey(key);
+		return this;
+	}
+
+	/**
+	 * Sets Collection of keys in the currently referred map property.
+	 *
+	 * @param keys The Collection of keys to set in the map. Can be empty.
+	 */
+	public InnerSpec keys(Collection<?> keys) {
+		keys.forEach(this::key);
 		return this;
 	}
 

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/InnerSpecTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -826,5 +827,19 @@ class InnerSpecTest {
 			.getStr();
 
 		then(actual).isNotNull();
+	}
+
+	@Property
+	void keysForCollection() {
+		List<String> keyList = Arrays.asList("key1", "key2", "key3");
+		Map<String, String> actual = SUT.giveMeBuilder(MapObject.class)
+			.setInner(
+				new InnerSpec()
+					.property("strMap", it -> it.keys(keyList).size(3))
+			)
+			.sample()
+			.getStrMap();
+
+		then(actual.keySet()).contains("key1", "key2", "key3");
 	}
 }


### PR DESCRIPTION
## Summary

Supports collection type as a parameter to InnerSpec.keys().

related: resolve #679 

## (Optional): Description

add method as follow:

```java
public InnerSpec keys(Collection<?> keys) {
	keys.forEach(this::key())
	return this;
}
```

However, since the keys() method currently takes an Object as a parameter, I think we should approach method overloading very carefully.

## How Has This Been Tested?

I written test code that takes a list as a parameter.

## Is the Document updated?

No