### PR TITLE
Translation of kotlin-plugin/introspectors-for-kotlin document

### DIFF
--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
@@ -1,5 +1,5 @@
 ---
-title: "Introspectors for Kotlin"
+title: "Kotlin 을 위한 Introspector"
 images: []
 menu:
 docs:
@@ -8,4 +8,36 @@ identifier: "introspectors-for-kotlin"
 weight: 62
 ---
 
-### 한국어 번역 필요
+Fixture Monkey 는 코틀린 클래스를 생성하기 위한 추가적인 introspector 들을 제공합니다.
+
+## PrimaryConstructorArbitraryIntrospector
+
+`PrimaryConstructorArbitraryIntrospector` 는 코틀린 플러그인이 추가되면 자동으로 기본 introspector 로 설정됩니다.
+이 introspector 는 주 생성자를 기반으로 코틀린 클래스를 생성합니다.
+
+**예제 Kotlin Class :**
+```kotlin
+data class Product (
+  val id: Long?,
+
+  val productName: String,
+
+  val price: Long,
+
+  val options: List<String>,
+
+  val createdAt: Instant
+)
+```
+
+**PrimaryConstructorArbitraryIntrospector 를 이용해 픽스쳐 생성 :**
+```kotlin
+@Test
+fun test() {
+  val fixtureMonkey = FixtureMonkey.builder()
+      .plugin(KotlinPlugin())
+      .build()
+
+  val product: Product = fixtureMonkey.giveMeOne()
+}
+```

--- a/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotlin-plugin/introspectors-for-kotlin.md
@@ -1,5 +1,5 @@
 ---
-title: "Kotlin 을 위한 Introspector"
+title: "Kotlin 지원 Introspector"
 images: []
 menu:
 docs:


### PR DESCRIPTION
## Summary
Translation of kotlin-plugin/introspectors-for-kotlin for Koreans.
This korean translation works is related to #864.

## How Has This Been Tested?
Tested with `npm start` to check translations of docs.

## Is the Document updated?
`kotlin-plugin/introspectors-for-kotlin` document is updated.

