### PR TITLE
Fix ConstructorProperty equals and hashCode using Type instead of AnnotatedType

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ConstructorProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ConstructorProperty.java
@@ -114,7 +114,7 @@ public final class ConstructorProperty implements Property {
 			return false;
 		}
 		ConstructorProperty that = (ConstructorProperty)obj;
-		return annotatedType.equals(that.annotatedType)
+		return annotatedType.getType().equals(that.annotatedType.getType())
 			&& constructor.equals(that.constructor)
 			&& parameterName.equals(that.parameterName)
 			&& Objects.equals(fieldProperty, that.fieldProperty)
@@ -123,7 +123,7 @@ public final class ConstructorProperty implements Property {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(annotatedType, constructor, parameterName, fieldProperty, annotations);
+		return Objects.hash(annotatedType.getType(), constructor, parameterName, fieldProperty, annotations);
 	}
 
 	@Nullable


### PR DESCRIPTION
## Summary
Fix ConstructorProperty equals and hashCode using Type instead of AnnotatedType

In general, implementations of `AnnotatedType` do not override `equals` and `hashCode`.

## How Has This Been Tested?
existing tests

## Is the Document updated?
No
