### PR TITLE
Enhance Kotlin introspector to support Java reference types

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -87,13 +87,12 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
     ): Any? {
         try {
             val parameterType = parameter.type.jvmErasure
-            return if(parameterType.isJavaReferenceTypeClass()) {
+            return if (parameterType.isJavaReferenceTypeClass()) {
                 val javaClass = parameterType.java
                 val constructor = javaClass.constructors.firstOrNull()
                 constructor?.isAccessible = true
                 return constructor?.newInstance()
-            }
-            else if (parameterType.isValue) {
+            } else if (parameterType.isValue) {
                 parameterType.primaryConstructor!!.isAccessible = true
                 parameterType.primaryConstructor!!.call(arbitrariesByPropertyName[parameter.name])
             } else {
@@ -114,4 +113,4 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
 }
 
 private fun KClass<*>.isJavaReferenceTypeClass(): Boolean =
-     !this.java.isPrimitive && this.java.annotations.none { it.annotationClass.simpleName == "Metadata" }
+    !this.java.isPrimitive && this.java.annotations.none { it.annotationClass.simpleName == "Metadata" }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -27,6 +27,7 @@ import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator
 import com.navercorp.fixturemonkey.api.type.Types
 import com.navercorp.fixturemonkey.kotlin.property.KotlinPropertyGenerator
+import com.navercorp.fixturemonkey.kotlin.type.isKotlinType
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.MAINTAINED
 import org.slf4j.LoggerFactory
@@ -42,7 +43,11 @@ import kotlin.reflect.jvm.jvmErasure
 @API(since = "0.4.0", status = MAINTAINED)
 class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
     override fun introspect(context: ArbitraryGeneratorContext): ArbitraryIntrospectorResult {
-        val type = Types.getActualType(context.resolvedType)
+        val type: Class<*> = Types.getActualType(context.resolvedType)
+        if (!type.isKotlinType()) {
+            return ArbitraryIntrospectorResult.NOT_INTROSPECTED
+        }
+
         if (Modifier.isAbstract(type.modifiers)) {
             return ArbitraryIntrospectorResult.NOT_INTROSPECTED
         }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -99,6 +99,7 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
             return arbitrariesByPropertyName[parameter.name]
         }
     }
+
     companion object {
         val INSTANCE = PrimaryConstructorArbitraryIntrospector()
         private val LOGGER = LoggerFactory.getLogger(PrimaryConstructorArbitraryIntrospector::class.java)

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.kotlin
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
 import com.navercorp.fixturemonkey.kotlin.spec.JavaObject
+import net.jqwik.api.Property
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
 
@@ -31,7 +32,7 @@ class FixtureMonkeyKotlinJavaCompositionTest {
         // given
         val sut: FixtureMonkey = FixtureMonkey.builder()
         .plugin(KotlinPlugin())
-            .build()
+        .build()
 
         // when
         class KotlinObjectWithJavaObject(val javaObject: JavaObject)
@@ -39,6 +40,5 @@ class FixtureMonkeyKotlinJavaCompositionTest {
 
         then(actual).isNotNull
         then(actual.javaObject).isNotNull
-        then(actual.javaObject.value).isNotNull
     }
 }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
@@ -38,5 +38,7 @@ class FixtureMonkeyKotlinJavaCompositionTest {
         val actual = sut.giveMeOne<KotlinObjectWithJavaObject>()
 
         then(actual).isNotNull
+        then(actual.javaObject).isNotNull
+        then(actual.javaObject.value).isNotNull
     }
 }

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotlin
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
+import com.navercorp.fixturemonkey.kotlin.spec.JavaObject
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+
+class FixtureMonkeyKotlinJavaCompositionTest {
+
+    @Test
+    fun KotlinObjectWithJavaObject() {
+        // given
+        val sut: FixtureMonkey = FixtureMonkey.builder()
+        .plugin(KotlinPlugin())
+            .build()
+
+        // when
+        class KotlinObjectWithJavaObject(val javaObject: JavaObject)
+        val actual = sut.giveMeOne<KotlinObjectWithJavaObject>()
+
+        then(actual).isNotNull
+    }
+}

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyKotlinJavaCompositionTest.kt
@@ -19,9 +19,7 @@
 package com.navercorp.fixturemonkey.kotlin
 
 import com.navercorp.fixturemonkey.FixtureMonkey
-import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
 import com.navercorp.fixturemonkey.kotlin.spec.JavaObject
-import net.jqwik.api.Property
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
 
@@ -31,11 +29,12 @@ class FixtureMonkeyKotlinJavaCompositionTest {
     fun KotlinObjectWithJavaObject() {
         // given
         val sut: FixtureMonkey = FixtureMonkey.builder()
-        .plugin(KotlinPlugin())
-        .build()
+            .plugin(KotlinPlugin())
+            .build()
 
         // when
         class KotlinObjectWithJavaObject(val javaObject: JavaObject)
+
         val actual = sut.giveMeOne<KotlinObjectWithJavaObject>()
 
         then(actual).isNotNull


### PR DESCRIPTION
## Summary
This is a pr regarding the issue at
https://github.com/naver/fixture-monkey/issues/946

i have made modification toPrimaryConstructorArbitraryIntrospector to handle kotlin and java class both.

additionaly added a corresponding test case.


The current modification serves as a temporary measure to prevent failures during object creation; 

however, it results in the fields of the internal Java reference type properties being bound to null. 
It has also been observed that the same issue occurs when using other introspectors.

Fundamentally, it seems necessary to implement branching at a higher level in the introspector process, but due to a lack of comprehensive understanding of the overall structure, only this level of modification has been made.

## How Has This Been Tested?

check through test case

## Is the Document updated?
Should i update the limitations of creating Kotlin objects with Java references class properties, or recommend alternative implementation methods?
