### PR TITLE
Fix Korean document bugs

### DIFF
--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -11,7 +11,7 @@ rssLimit = 10
 # Multilingual
 defaultContentLanguage = "v1-0-0"
 disableLanguages = ["de", "nl"]
-# defaultContentLanguageInSubdir = true
+ defaultContentLanguageInSubdir = true
 
 # add redirects/headers
 [outputs]

--- a/docs/config/_default/languages.toml
+++ b/docs/config/_default/languages.toml
@@ -26,7 +26,7 @@
   [v1-0-0-kor.params]
     languageISO = "KOR"
     languageTag = "ko-KR"
-    getStartedPage = "/docs/get-started/requirements/"
+    getStartedPage = "/v1-0-0-kor/docs/get-started/requirements/"
 
 [v0-6-0-kor]
   languageName = "v0.6.x"

--- a/docs/config/_default/menus/menus.v1-0-0-kor.toml
+++ b/docs/config/_default/menus/menus.v1-0-0-kor.toml
@@ -1,10 +1,10 @@
 [[main]]
-name = "Docs"
+name = "문서"
 url = "/docs/introduction/overview/"
 weight = 10
 
 [[main]]
-name = "Release Notes"
+name = "릴리즈 노트"
 weight = 20
 identifier = "release-notes"
 url = "/release-notes/"

--- a/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/_index.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/kotest-plugin/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Kotest Plugin"
+title: "Kotest 플러그인"
 images: []
 menu:
   docs:

--- a/docs/layouts/partials/header/header.html
+++ b/docs/layouts/partials/header/header.html
@@ -148,9 +148,13 @@
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-versions">
             <li><a class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Params.languageISO }}</a></li>
             <li><hr class="dropdown-divider"></li>
+              {{ $currentLink := .RelPermalink }}
               {{ range .Site.Languages -}}
                 {{ if and (eq $.Site.Language.LanguageName .LanguageName) (ne $.Lang .Lang) }}
-                  <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Params.languageISO }}</a></li>
+                  {{ $currentLang := printf "/%s/" $.Lang }}
+                  {{ $selectedLang := printf "/%s/" .Lang }}
+                  {{ $newPermalink := replace $currentLink $currentLang $selectedLang}}
+                  <li><a class="dropdown-item" rel="alternate" href="{{ $newPermalink }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Params.languageISO }}</a></li>
                 {{ end -}}
               {{ end -}}
           </ul>


### PR DESCRIPTION
## Summary
Resolves #957

- Fix `Get started` button to go to korean translation.
- Remain the content url when changing language.