### PR TITLE
Remove the deprecated getCause function in KotlinTest class

### DIFF
--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -81,7 +81,7 @@ class KotlinTest {
                 .set(javaGetter(KotlinObject::value), "test")
                 .sample()
                 .value
-        }.cause
+        }.cause()
             .isExactlyInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Kotlin type could not resolve property name.")
     }


### PR DESCRIPTION
## Summary

`AbstractThrowableAssert#getCause()` method was deprecated and changed to `AbstractThrowableAssert#cause()`.

## (Optional): Description

The git action execution history confirmed the use of a deprecated function. `AbstractThrowableAssert#getCause()` method was deprecated and changed to `AbstractThrowableAssert#cause()`. When I checked the method, there was no change behavior and the name change seemed to be the purpose.

## How Has This Been Tested?

Tested in `KotlinTest#kotlinObjectUseJavaGetterThrows`.

## Is the Document updated?

There are no feature changes.
