### PR TITLE
synchronize 1.0.15 version change history

### DIFF
--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -22,6 +22,8 @@ Add "KotlinDurationIntrospector" supporting generating a Duration type in Kotlin
 
 Fix setting a child of a concrete type to an abstract type.
 
+Add a new Kotlin Exp expression for referencing root. ex. `set(String::root, "expected")`
+
 sectionEnd
 
 sectionStart

--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -18,6 +18,8 @@ sectionStart
 ### v.1.0.15
 Add `ConcreteTypeDefinition` in `ArbitraryProperty`, deprecate `getChildPropertiesByResolvedProperty` and `getChildPropertyListsByCandidateProperty` which is added in 1.0.14.
 
+Add "KotlinDurationIntrospector" supporting generating a Duration type in Kotlin.
+
 Fix setting a child of a concrete type to an abstract type.
 
 Add a new Kotlin Exp expression for referencing root. ex. `set(String::root, "expected")`


### PR DESCRIPTION
## Summary

There is a difference between English and Korean document release notes.

## (Optional): Description

**ASIS - In English Docs**

- Add `ConcreteTypeDefinition` in `ArbitraryProperty`, deprecate `getChildPropertiesByResolvedProperty` and `getChildPropertyListsByCandidateProperty` which is added in 1.0.14.
- Fix setting a child of a concrete type to an abstract type.
- Add a new Kotlin Exp expression for referencing root. ex. `set(String::root, "expected")`

**ASIS - In Korean Docs**

- Add `ConcreteTypeDefinition` in `ArbitraryProperty`, deprecate `getChildPropertiesByResolvedProperty` and `getChildPropertyListsByCandidateProperty` which is added in 1.0.14.
- Add "KotlinDurationIntrospector" supporting generating a Duration type in Kotlin.
- Add a new Kotlin Exp expression for referencing root. ex. `set(String::root, "expected")`

**TOBE - Sync**

- Add `ConcreteTypeDefinition` in `ArbitraryProperty`, deprecate `getChildPropertiesByResolvedProperty` and `getChildPropertyListsByCandidateProperty` which is added in 1.0.14.
- Add "KotlinDurationIntrospector" supporting generating a Duration type in Kotlin.
- Fix setting a child of a concrete type to an abstract type.
- Add a new Kotlin Exp expression for referencing root. ex. `set(String::root, "expected")`


## How Has This Been Tested?

Just update release notes.

## Is the Document updated?

update release notes.

