### PR TITLE
Fix simple value plugin constuctor

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -141,10 +141,10 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 							new SimpleJavaConstraintGenerator(
 								this.minStringLength,
 								this.maxStringLength,
-								this.positiveMinNumberValue,
-								this.positiveMaxNumberValue,
 								this.negativeMinNumberValue,
 								this.negativeMaxNumberValue,
+								this.positiveMinNumberValue,
+								this.positiveMaxNumberValue,
 								this.minContainerSize,
 								this.maxContainerSize,
 								this.minusDaysFromToday,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -141,10 +141,10 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 							new SimpleJavaConstraintGenerator(
 								this.minStringLength,
 								this.maxStringLength,
-								this.negativeMinNumberValue,
-								this.negativeMaxNumberValue,
 								this.positiveMinNumberValue,
 								this.positiveMaxNumberValue,
+								this.negativeMinNumberValue,
+								this.negativeMaxNumberValue,
 								this.minContainerSize,
 								this.maxContainerSize,
 								this.minusDaysFromToday,
@@ -170,10 +170,10 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 	private static class SimpleJavaConstraintGenerator implements JavaConstraintGenerator {
 		private final long stringMinLength;
 		private final long stringMaxLength;
-		private final long negativeMinNumberValue;
-		private final long negativeMaxNumberValue;
 		private final long positiveMinNumberValue;
 		private final long positiveMaxNumberValue;
+		private final long negativeMinNumberValue;
+		private final long negativeMaxNumberValue;
 		private final int minContainerSize;
 		private final int maxContainerSize;
 		private final long minusDaysFromToday;
@@ -182,10 +182,10 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 		public SimpleJavaConstraintGenerator(
 			long stringMinLength,
 			long stringMaxLength,
-			long negativeMinNumberValue,
-			long negativeMaxNumberValue,
 			long positiveMinNumberValue,
 			long positiveMaxNumberValue,
+			long negativeMinNumberValue,
+			long negativeMaxNumberValue,
 			int minContainerSize,
 			int maxContainerSize,
 			long minusDaysFromToday,
@@ -193,10 +193,10 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 		) {
 			this.stringMinLength = stringMinLength;
 			this.stringMaxLength = stringMaxLength;
-			this.negativeMinNumberValue = negativeMinNumberValue;
-			this.negativeMaxNumberValue = negativeMaxNumberValue;
 			this.positiveMinNumberValue = positiveMinNumberValue;
 			this.positiveMaxNumberValue = positiveMaxNumberValue;
+			this.negativeMinNumberValue = negativeMinNumberValue;
+			this.negativeMaxNumberValue = negativeMaxNumberValue;
 			this.minContainerSize = minContainerSize;
 			this.maxContainerSize = maxContainerSize;
 			this.minusDaysFromToday = minusDaysFromToday;

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
@@ -139,4 +139,22 @@ class SimpleValueJqwikPluginTest {
         then(actual.annotatedInt).isBetween(20, 30)
         then(actual.notAnnotatedInt).isBetween(-10000, 10000)
     }
+
+    @RepeatedTest(TEST_COUNT)
+    fun sampleSetObject() {
+        class SetObject (val integers: Set<Integer>)
+
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(SimpleValueJqwikPlugin())
+            .build()
+
+        val setObject = sut.giveMeBuilder(SetObject::class.java)
+            .size("integers", 3)
+            .sample()
+
+
+        then(setObject).isNotNull
+        then(setObject.integers).hasSize(3)
+    }
 }


### PR DESCRIPTION
## Summary
*Describe what feature is implemented by this PR.*
*If there is a related issue, write the issue number and link*

Resolves #986 

## (Optional): Description
*Describe your changes in detail*

Fixed a problem with the order of parameters injected when creating an instance of `SimpleValueJqwikPlugin` in the `accept()` method within the `SimpleValueJqwikPlugin` class.

## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*

to verify the scenario that was reproduced in the #986 issue. 