### PR TITLE
Fix a SimpleValuePlugin "out of byte range" error

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -18,7 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.plugin;
 
-import java.lang.reflect.Type;
+import com.navercorp.fixturemonkey.api.type.Types;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -224,7 +224,7 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 			BigInteger negativeMin = BigInteger.valueOf(this.negativeMinNumberValue);
 			BigInteger negativeMax = BigInteger.valueOf(this.negativeMaxNumberValue);
 
-			Type type = context.getResolvedType();
+			Class<?> type = Types.getActualType(context.getResolvedType());
 
 			if (type == Byte.class || type == byte.class) {
 				positiveMax = positiveMax.min(BIG_INTEGER_MAX_BYTE);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -221,17 +221,17 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 		public JavaIntegerConstraint generateIntegerConstraint(ArbitraryGeneratorContext context) {
 			BigInteger positiveMin = BigInteger.valueOf(this.positiveMinNumberValue);
 			BigInteger positiveMax = BigInteger.valueOf(this.positiveMaxNumberValue);
-			BigInteger negativeMax = BigInteger.valueOf(this.negativeMinNumberValue);
-			BigInteger negativeMin = BigInteger.valueOf(this.negativeMaxNumberValue);
+			BigInteger negativeMin = BigInteger.valueOf(this.negativeMinNumberValue);
+			BigInteger negativeMax = BigInteger.valueOf(this.negativeMaxNumberValue);
 
 			Type type = context.getResolvedType();
 
-			if ((type == Byte.class || type == byte.class)) {
-				positiveMax = BIG_INTEGER_MAX_BYTE;
-				negativeMax = BIG_INTEGER_MIN_BYTE;
+			if (type == Byte.class || type == byte.class) {
+				positiveMax = positiveMax.min(BIG_INTEGER_MAX_BYTE);
+				negativeMin = negativeMin.max(BIG_INTEGER_MIN_BYTE);
 			}
 
-			return new JavaIntegerConstraint(positiveMin, positiveMax, negativeMax, negativeMin);
+			return new JavaIntegerConstraint(positiveMin, positiveMax, negativeMin, negativeMax);
 		}
 
 		@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.plugin;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -218,12 +219,19 @@ public final class SimpleValueJqwikPlugin implements Plugin {
 
 		@Override
 		public JavaIntegerConstraint generateIntegerConstraint(ArbitraryGeneratorContext context) {
-			return new JavaIntegerConstraint(
-				BigInteger.valueOf(this.positiveMinNumberValue),
-				BigInteger.valueOf(this.positiveMaxNumberValue),
-				BigInteger.valueOf(this.negativeMinNumberValue),
-				BigInteger.valueOf(this.negativeMaxNumberValue)
-			);
+			BigInteger positiveMin = BigInteger.valueOf(this.positiveMinNumberValue);
+			BigInteger positiveMax = BigInteger.valueOf(this.positiveMaxNumberValue);
+			BigInteger negativeMax = BigInteger.valueOf(this.negativeMinNumberValue);
+			BigInteger negativeMin = BigInteger.valueOf(this.negativeMaxNumberValue);
+
+			Type type = context.getResolvedType();
+
+			if ((type == Byte.class || type == byte.class)) {
+				positiveMax = BIG_INTEGER_MAX_BYTE;
+				negativeMax = BIG_INTEGER_MIN_BYTE;
+			}
+
+			return new JavaIntegerConstraint(positiveMin, positiveMax, negativeMax, negativeMin);
 		}
 
 		@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/SimpleValueJqwikPlugin.java
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.api.plugin;
 
-import com.navercorp.fixturemonkey.api.type.Types;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -45,6 +44,7 @@ import com.navercorp.fixturemonkey.api.jqwik.JavaTypeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikJavaArbitraryResolver;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikJavaTypeArbitraryGeneratorSet;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptionsBuilder;
+import com.navercorp.fixturemonkey.api.type.Types;
 
 @API(since = "1.0.17", status = Status.EXPERIMENTAL)
 public final class SimpleValueJqwikPlugin implements Plugin {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
@@ -165,8 +165,41 @@ class SimpleValueJqwikPluginTest {
             .plugin(SimpleValueJqwikPlugin())
             .build()
 
-        val actual = sut.giveMeOne(Byte::class.java)
+        val actual: Byte = sut.giveMeOne()
 
         then(actual).isBetween(Byte.MIN_VALUE, Byte.MAX_VALUE)
     }
+
+    @RepeatedTest(TEST_COUNT)
+    fun modifyNumberValueByte() {
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(
+                SimpleValueJqwikPlugin()
+                    .minNumberValue(-1)
+                    .maxNumberValue(1)
+            )
+            .build()
+
+        val actual: Byte = sut.giveMeOne()
+
+        then(actual).isBetween(-1, 1)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun modifyOutOfRangeNumberValueByte() {
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(
+                SimpleValueJqwikPlugin()
+                    .minNumberValue(-129)
+                    .maxNumberValue(129)
+            )
+            .build()
+
+        val actual: Byte = sut.giveMeOne()
+
+        then(actual).isBetween(Byte.MIN_VALUE, Byte.MAX_VALUE)
+    }
+
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SimpleValueJqwikPluginTest.kt
@@ -157,4 +157,16 @@ class SimpleValueJqwikPluginTest {
         then(setObject).isNotNull
         then(setObject.integers).hasSize(3)
     }
+
+    @RepeatedTest(TEST_COUNT)
+    fun sampleByte() {
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(SimpleValueJqwikPlugin())
+            .build()
+
+        val actual = sut.giveMeOne(Byte::class.java)
+
+        then(actual).isBetween(Byte.MIN_VALUE, Byte.MAX_VALUE)
+    }
 }


### PR DESCRIPTION
## Summary
Fix "out of byte range" issue by modifying SimpleValueJqwikPlugin to limit byte value generation to within Byte.MIN_VALUE and Byte.MAX_VALUE.


## (Optional): Description
This PR addresses the issue where byte values generated by SimpleValueJqwikPlugin could exceed the valid range of Byte.MIN_VALUE and Byte.MAX_VALUE. The plugin has been modified to ensure byte values are constrained within this range.


## How Has This Been Tested?
The changes have been tested by adding a new unit test, sampleSetObjectByte, which ensures that byte values generated by SimpleValueJqwikPlugin are within the range of Byte.MIN_VALUE and Byte.MAX_VALUE.

