### PR TITLE
Add support multi-level inheritance of sealed

### DIFF
--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -9,6 +9,8 @@ sectionStart
 ### v.1.0.20
 Fix generation of enum implementations as a sealed class in JDK17.
 
+Add support for multi-level inheritance of sealed class and sealed interface.
+
 sectionEnd
 
 sectionStart

--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -10,6 +10,8 @@ sectionStart
 ### v.1.0.20
 Fix generation of enum implementations as a sealed class in JDK17.
 
+Add support for multi-level inheritance of sealed class and sealed interface.
+
 sectionEnd
 
 sectionStart

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
@@ -19,10 +19,10 @@
 package com.navercorp.fixturemonkey.api.generator;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -40,7 +40,7 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 		double nullInject = context.getNullInjectGenerator().generate(context);
 
 		Map<Property, List<Property>> childPropertiesByProperty = new HashMap<>();
-		for (Class<?> subClass : collectPermittedSubclasses(actualType).collect(Collectors.toSet())) {
+		for (Class<?> subClass : collectPermittedSubclasses(actualType)) {
 			Property subProperty = PropertyUtils.toProperty(subClass);
 
 			List<Property> subPropertyChildProperties = context.getPropertyGenerator()
@@ -58,12 +58,19 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 		);
 	}
 
-	private static Stream<Class<?>> collectPermittedSubclasses(Class<?> type) {
+	private static Set<Class<?>> collectPermittedSubclasses(Class<?> type) {
+		Set<Class<?>> subclasses = new HashSet<>();
+		collectPermittedSubclasses(type, subclasses);
+		return subclasses;
+	}
+
+	private static void collectPermittedSubclasses(Class<?> type, Set<Class<?>> subclasses) {
 		if (type.isSealed()) {
-			return Stream.of(type.getPermittedSubclasses())
-				.flatMap(SealedTypeObjectPropertyGenerator::collectPermittedSubclasses);
+			for (Class<?> subclass : type.getPermittedSubclasses()) {
+				collectPermittedSubclasses(subclass, subclasses);
+			}
 		} else {
-			return Stream.of(type);
+			subclasses.add(type);
 		}
 	}
 }

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
@@ -38,9 +38,10 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 		Property sealedTypeProperty = context.getProperty();
 		Class<?> actualType = Types.getActualType(sealedTypeProperty.getType());
 		double nullInject = context.getNullInjectGenerator().generate(context);
+		Set<Class<?>> permittedSubclasses = collectPermittedSubclasses(actualType);
 
 		Map<Property, List<Property>> childPropertiesByProperty = new HashMap<>();
-		for (Class<?> subClass : collectPermittedSubclasses(actualType)) {
+		for (Class<?> subClass : permittedSubclasses) {
 			Property subProperty = PropertyUtils.toProperty(subClass);
 
 			List<Property> subPropertyChildProperties = context.getPropertyGenerator()
@@ -60,14 +61,14 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 
 	private static Set<Class<?>> collectPermittedSubclasses(Class<?> type) {
 		Set<Class<?>> subclasses = new HashSet<>();
-		collectPermittedSubclasses(type, subclasses);
+		doCollectPermittedSubclasses(type, subclasses);
 		return subclasses;
 	}
 
-	private static void collectPermittedSubclasses(Class<?> type, Set<Class<?>> subclasses) {
+	private static void doCollectPermittedSubclasses(Class<?> type, Set<Class<?>> subclasses) {
 		if (type.isSealed()) {
 			for (Class<?> subclass : type.getPermittedSubclasses()) {
-				collectPermittedSubclasses(subclass, subclasses);
+				doCollectPermittedSubclasses(subclass, subclasses);
 			}
 		} else {
 			subclasses.add(type);

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
@@ -21,6 +21,8 @@ package com.navercorp.fixturemonkey.api.generator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -38,7 +40,7 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 		double nullInject = context.getNullInjectGenerator().generate(context);
 
 		Map<Property, List<Property>> childPropertiesByProperty = new HashMap<>();
-		for (Class<?> subClass : actualType.getPermittedSubclasses()) {
+		for (Class<?> subClass : collectPermittedSubclasses(actualType).collect(Collectors.toSet())) {
 			Property subProperty = PropertyUtils.toProperty(subClass);
 
 			List<Property> subPropertyChildProperties = context.getPropertyGenerator()
@@ -54,5 +56,14 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 			context.getElementIndex(),
 			childPropertiesByProperty
 		);
+	}
+
+	private static Stream<Class<?>> collectPermittedSubclasses(Class<?> type) {
+		if (type.isSealed()) {
+			return Stream.of(type.getPermittedSubclasses())
+				.flatMap(SealedTypeObjectPropertyGenerator::collectPermittedSubclasses);
+		} else {
+			return Stream.of(type);
+		}
 	}
 }

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
@@ -1,0 +1,106 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.java17;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.beans.ConstructorProperties;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+
+class MultiLevelSealedClassTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+		.defaultNotNull(true)
+		.build();
+
+	private static sealed class SealedClass permits IntermediateSealedClass {
+	}
+
+	private static sealed class IntermediateSealedClass extends SealedClass permits SealedClassImpl {
+	}
+
+	private static final class SealedClassImpl extends IntermediateSealedClass {
+		private final String value;
+
+		@ConstructorProperties("value")
+		public SealedClassImpl(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedClass() {
+		// when
+		SealedClass actual = SUT.giveMeOne(SealedClass.class);
+
+		then(actual).isInstanceOf(SealedClassImpl.class);
+	}
+
+	private sealed interface SealedInterface permits IntermediateSealedInterface {
+	}
+
+	private sealed interface IntermediateSealedInterface extends SealedInterface permits SealedInterfaceImpl {
+	}
+
+	private record SealedInterfaceImpl(String value) implements IntermediateSealedInterface {
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedInterface() {
+		// when
+		SealedInterface actual = SUT.giveMeOne(SealedInterface.class);
+
+		then(actual).isInstanceOf(SealedInterface.class);
+	}
+
+	private record SealedClassProperty(
+		SealedClass sealedClass,
+		SealedInterface sealedInterface
+	) {
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedClassProperty() {
+		// when
+		SealedClassProperty actual = SUT.giveMeOne(SealedClassProperty.class);
+
+		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
+		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedSealedClassProperty() {
+		// when
+		SealedClassProperty actual = SUT.giveMeBuilder(SealedClassProperty.class)
+			.fixed()
+			.sample();
+
+		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
+		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
+	}
+}

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
@@ -21,12 +21,15 @@ package com.navercorp.fixturemonkey.tests.java17;
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
 
-import java.beans.ConstructorProperties;
-
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedClass;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedClassProperty;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedInterface;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterfaceImpl;
 
 class MultiLevelSealedClassTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
@@ -34,60 +37,26 @@ class MultiLevelSealedClassTest {
 		.defaultNotNull(true)
 		.build();
 
-	private static sealed class SealedClass permits IntermediateSealedClass {
-	}
-
-	private static sealed class IntermediateSealedClass extends SealedClass permits SealedClassImpl {
-	}
-
-	private static final class SealedClassImpl extends IntermediateSealedClass {
-		private final String value;
-
-		@ConstructorProperties("value")
-		public SealedClassImpl(String value) {
-			this.value = value;
-		}
-
-		public String getValue() {
-			return value;
-		}
-	}
-
 	@RepeatedTest(TEST_COUNT)
 	void sampleSealedClass() {
 		// when
-		SealedClass actual = SUT.giveMeOne(SealedClass.class);
+		BaseSealedClass actual = SUT.giveMeOne(BaseSealedClass.class);
 
 		then(actual).isInstanceOf(SealedClassImpl.class);
-	}
-
-	private sealed interface SealedInterface permits IntermediateSealedInterface {
-	}
-
-	private sealed interface IntermediateSealedInterface extends SealedInterface permits SealedInterfaceImpl {
-	}
-
-	private record SealedInterfaceImpl(String value) implements IntermediateSealedInterface {
 	}
 
 	@RepeatedTest(TEST_COUNT)
 	void sampleSealedInterface() {
 		// when
-		SealedInterface actual = SUT.giveMeOne(SealedInterface.class);
+		BaseSealedInterface actual = SUT.giveMeOne(BaseSealedInterface.class);
 
-		then(actual).isInstanceOf(SealedInterface.class);
-	}
-
-	private record SealedClassProperty(
-		SealedClass sealedClass,
-		SealedInterface sealedInterface
-	) {
+		then(actual).isInstanceOf(BaseSealedInterface.class);
 	}
 
 	@RepeatedTest(TEST_COUNT)
 	void sampleSealedClassProperty() {
 		// when
-		SealedClassProperty actual = SUT.giveMeOne(SealedClassProperty.class);
+		BaseSealedClassProperty actual = SUT.giveMeOne(BaseSealedClassProperty.class);
 
 		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
 		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
@@ -96,7 +65,7 @@ class MultiLevelSealedClassTest {
 	@RepeatedTest(TEST_COUNT)
 	void fixedSealedClassProperty() {
 		// when
-		SealedClassProperty actual = SUT.giveMeBuilder(SealedClassProperty.class)
+		BaseSealedClassProperty actual = SUT.giveMeBuilder(BaseSealedClassProperty.class)
 			.fixed()
 			.sample();
 

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.RepeatedTest;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedClass;
-import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedClassProperty;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedInterface;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterfaceImpl;
 
 class MultiLevelSealedClassTest {

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
@@ -22,35 +22,22 @@ import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 
-import java.beans.ConstructorProperties;
-
 import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.EnumClass;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClass;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassProperty;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterface;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterfaceImpl;
 
 class SealedClassTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
 		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 		.defaultNotNull(true)
 		.build();
-
-	private static sealed class SealedClass permits SealedClassImpl {
-	}
-
-	private static final class SealedClassImpl extends SealedClass {
-		private final String value;
-
-		@ConstructorProperties("value")
-		public SealedClassImpl(String value) {
-			this.value = value;
-		}
-
-		public String getValue() {
-			return value;
-		}
-	}
 
 	@RepeatedTest(TEST_COUNT)
 	void sampleSealedClass() {
@@ -60,24 +47,12 @@ class SealedClassTest {
 		then(actual).isInstanceOf(SealedClassImpl.class);
 	}
 
-	private sealed interface SealedInterface permits SealedInterfaceImpl {
-	}
-
-	private record SealedInterfaceImpl(String value) implements SealedInterface {
-	}
-
 	@RepeatedTest(TEST_COUNT)
 	void sampleSealedInterface() {
 		// when
 		SealedInterface actual = SUT.giveMeOne(SealedInterface.class);
 
-		then(actual).isInstanceOf(SealedInterface.class);
-	}
-
-	private record SealedClassProperty(
-		SealedClass sealedClass,
-		SealedInterface sealedInterface
-	) {
+		then(actual).isInstanceOf(SealedInterfaceImpl.class);
 	}
 
 	@RepeatedTest(TEST_COUNT)

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
@@ -28,9 +28,9 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.EnumClass;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClass;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassProperty;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterface;
-import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClassImpl;
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedInterfaceImpl;
 
 class SealedClassTest {

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTestSpecs.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTestSpecs.java
@@ -1,0 +1,30 @@
+package com.navercorp.fixturemonkey.tests.java17;
+
+final class SealedClassTestSpecs {
+	public static sealed class BaseSealedClass permits SealedClass {
+	}
+
+	public static sealed class SealedClass extends BaseSealedClass permits SealedClassImpl {
+	}
+
+	public static final class SealedClassImpl extends SealedClass {
+	}
+
+	public sealed interface BaseSealedInterface permits SealedInterface {
+	}
+
+	public sealed interface SealedInterface extends BaseSealedInterface permits SealedInterfaceImpl {
+	}
+
+	public record SealedInterfaceImpl(String value) implements SealedInterface {
+	}
+
+	public record BaseSealedClassProperty(BaseSealedClass sealedClass, BaseSealedInterface sealedInterface) {
+	}
+
+	public record SealedClassProperty(
+		SealedClass sealedClass,
+		SealedInterface sealedInterface
+	) {
+	}
+}


### PR DESCRIPTION
## Summary
Add support for multi-level inheritance of sealed class and sealed interface.

## How Has This Been Tested?
Add a new test that adds an intermediate inherited class and interface to an existing test.
