### PR TITLE
Fix when to apply JdkVariantOptions

### DIFF
--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -11,6 +11,8 @@ Fix generation of enum implementations as a sealed class in JDK17.
 
 Add support for multi-level inheritance of sealed class and sealed interface.
 
+Fix JdkVariantOptions having higher priority than custom options.
+
 sectionEnd
 
 sectionStart

--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -12,6 +12,8 @@ Fix generation of enum implementations as a sealed class in JDK17.
 
 Add support for multi-level inheritance of sealed class and sealed interface.
 
+Fix JdkVariantOptions having higher priority than custom options.
+
 sectionEnd
 
 sectionStart

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -136,11 +136,11 @@ public final class FixtureMonkeyOptionsBuilder {
 	@Nullable
 	private Function<JavaConstraintGenerator, JavaTimeArbitraryGeneratorSet> generateJavaTimeArbitrarySet = null;
 	private InstantiatorProcessor instantiatorProcessor = new JavaInstantiatorProcessor();
-	private final JdkVariantOptions jdkVariantOptions = new JdkVariantOptions();
 	private List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers =
 		new ArrayList<>(FixtureMonkeyOptions.DEFAULT_CANDIDATE_CONCRETE_PROPERTY_RESOLVERS);
 
 	FixtureMonkeyOptionsBuilder() {
+		new JdkVariantOptions().apply(this);
 	}
 
 	public FixtureMonkeyOptionsBuilder propertyGenerators(List<MatcherOperator<PropertyGenerator>> propertyGenerators) {
@@ -534,8 +534,6 @@ public final class FixtureMonkeyOptionsBuilder {
 	}
 
 	public FixtureMonkeyOptions build() {
-		jdkVariantOptions.apply(this);
-
 		ObjectPropertyGenerator defaultObjectPropertyGenerator = defaultIfNull(
 			this.defaultObjectPropertyGenerator,
 			() -> FixtureMonkeyOptions.DEFAULT_OBJECT_PROPERTY_GENERATOR

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
@@ -20,15 +20,15 @@ class JdkVariantOptionsTest {
 	void sampleSealedClass() {
 		// given
 		FixtureMonkey sut = FixtureMonkey.builder()
-		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
-		.defaultNotNull(true)
-		.pushAssignableTypeObjectPropertyGenerator(
-			BaseSealedClass.class,
-			new InterfaceObjectPropertyGenerator<>(
-				List.of(SealedClass.class)
-			)
-		)
-		.build();
+		    .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+		    .defaultNotNull(true)
+		    .pushAssignableTypeObjectPropertyGenerator(
+			    BaseSealedClass.class,
+			    new InterfaceObjectPropertyGenerator<>(
+			    	List.of(SealedClass.class)
+			    )
+		    )
+		    .build();
 		
 		// when
 		BaseSealedClass actual = sut.giveMeOne(BaseSealedClass.class);

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
@@ -1,0 +1,37 @@
+package com.navercorp.fixturemonkey.tests.java17;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedClass;
+import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClass;
+
+class JdkVariantOptionsTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+		.defaultNotNull(true)
+		.pushAssignableTypeObjectPropertyGenerator(
+			BaseSealedClass.class,
+			new InterfaceObjectPropertyGenerator<>(
+				List.of(SealedClass.class)
+			)
+		)
+		.build();
+
+	@RepeatedTest(TEST_COUNT)
+	@DisplayName("User-added ObjectPropertyGenerators have a higher priority.")
+	void sampleSealedClass() {
+		// when
+		BaseSealedClass actual = SUT.giveMeOne(BaseSealedClass.class);
+
+		then(actual).isInstanceOf(SealedClass.class);
+	}
+}

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
@@ -15,21 +15,21 @@ import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedC
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClass;
 
 class JdkVariantOptionsTest {
-    @RepeatedTest(TEST_COUNT)
+	@RepeatedTest(TEST_COUNT)
 	@DisplayName("User-added ObjectPropertyGenerators have a higher priority.")
 	void sampleSealedClass() {
 		// given
 		FixtureMonkey sut = FixtureMonkey.builder()
-		    .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
-		    .defaultNotNull(true)
-		    .pushAssignableTypeObjectPropertyGenerator(
-			    BaseSealedClass.class,
-			    new InterfaceObjectPropertyGenerator<>(
-			    	List.of(SealedClass.class)
-			    )
-		    )
-		    .build();
-		
+			.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+			.defaultNotNull(true)
+			.pushAssignableTypeObjectPropertyGenerator(
+				BaseSealedClass.class,
+				new InterfaceObjectPropertyGenerator<>(
+					List.of(SealedClass.class)
+				)
+			)
+			.build();
+
 		// when
 		BaseSealedClass actual = sut.giveMeOne(BaseSealedClass.class);
 

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JdkVariantOptionsTest.java
@@ -15,7 +15,11 @@ import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.BaseSealedC
 import com.navercorp.fixturemonkey.tests.java17.SealedClassTestSpecs.SealedClass;
 
 class JdkVariantOptionsTest {
-	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+    @RepeatedTest(TEST_COUNT)
+	@DisplayName("User-added ObjectPropertyGenerators have a higher priority.")
+	void sampleSealedClass() {
+		// given
+		FixtureMonkey sut = FixtureMonkey.builder()
 		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 		.defaultNotNull(true)
 		.pushAssignableTypeObjectPropertyGenerator(
@@ -25,12 +29,9 @@ class JdkVariantOptionsTest {
 			)
 		)
 		.build();
-
-	@RepeatedTest(TEST_COUNT)
-	@DisplayName("User-added ObjectPropertyGenerators have a higher priority.")
-	void sampleSealedClass() {
+		
 		// when
-		BaseSealedClass actual = SUT.giveMeOne(BaseSealedClass.class);
+		BaseSealedClass actual = sut.giveMeOne(BaseSealedClass.class);
 
 		then(actual).isInstanceOf(SealedClass.class);
 	}


### PR DESCRIPTION
## Summary
Fix when to apply JdkVariantOptions in FixtureMonkeyOptionsBuilder.

## (Optional): Description
Fix an issue where JdkVariantOptions.apply has a higher priority than options set by the user because it is in the build method of FixtureMonkeyOptionsBuilder.

## How Has This Been Tested?
Use existing tests.
