### PR TITLE
Fix generation of enum implementations as a sealed class in JDK17

### DIFF
--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -5,6 +5,11 @@ menu:
 docs:
 weight: 100
 ---
+sectionStart
+### v.1.0.20
+Fix generation of enum implementations as a sealed class in JDK17.
+
+sectionEnd
 
 sectionStart
 ### v.1.0.19

--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -7,6 +7,12 @@ weight: 100
 ---
 
 sectionStart
+### v.1.0.20
+Fix generation of enum implementations as a sealed class in JDK17.
+
+sectionEnd
+
+sectionStart
 ### v.1.0.19
 Fix a SimpleValuePlugin "out of byte range" error when generate Byte.
 

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/option/JdkVariantOptions.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/option/JdkVariantOptions.java
@@ -32,7 +32,7 @@ public final class JdkVariantOptions {
 
 	public void apply(FixtureMonkeyOptionsBuilder optionsBuilder) {
 		optionsBuilder.insertFirstArbitraryObjectPropertyGenerator(
-			p -> Types.getActualType(p.getType()).isSealed(),
+			p -> Types.getActualType(p.getType()).isSealed() && !Types.getActualType(p.getType()).isEnum(),
 			SEALED_TYPE_OBJECT_PROPERTY_GENERATOR
 		);
 	}

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/JacksonRecordTest.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.tests.java17;
 
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
 
 import org.junit.jupiter.api.RepeatedTest;
 
@@ -27,6 +28,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.jackson.plugin.JacksonPlugin;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.ContainerRecord;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.DateTimeRecord;
+import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.EnumClass;
 import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.JavaTypeRecord;
 
 class JacksonRecordTest {
@@ -80,5 +82,10 @@ class JacksonRecordTest {
 			.sample();
 
 		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleEnum() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(EnumClass.class));
 	}
 }

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/RecordTestSpecs.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/RecordTestSpecs.java
@@ -135,4 +135,21 @@ final class RecordTestSpecs {
 			string = "12345";
 		}
 	}
+
+	public enum EnumClass {
+		ENUM_A {
+			@Override
+			public String getString() {
+				return "a";
+			}
+		},
+		ENUM_B {
+			@Override
+			public String getString() {
+				return "b";
+			}
+		};
+
+		public abstract String getString();
+	}
 }

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/SealedClassTest.java
@@ -20,6 +20,7 @@ package com.navercorp.fixturemonkey.tests.java17;
 
 import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
 
 import java.beans.ConstructorProperties;
 
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.tests.java17.RecordTestSpecs.EnumClass;
 
 class SealedClassTest {
 	private static final FixtureMonkey SUT = FixtureMonkey.builder()
@@ -96,5 +98,10 @@ class SealedClassTest {
 
 		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
 		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleEnum() {
+		thenNoException().isThrownBy(() -> SUT.giveMeOne(EnumClass.class));
 	}
 }


### PR DESCRIPTION
## Summary
An enum instance with abstract method treated as a sealed class.
So, its properties are generated by the `SealedTypeObjectPropertyGenerator`, resulting in an unexpected generation failure.


## How Has This Been Tested?
- JacksonRecordTest#sampleEnum
- SealedClassTest#sampleEnum

## Is the Document updated?
Yes
