### PR TITLE
Deprecate the ObjectPropertyGenerators that modify child properties

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
@@ -61,6 +61,23 @@ public final class ObjectPropertyGeneratorContext {
 		this.nullInjectGenerator = nullInjectGenerator;
 	}
 
+	// Please use since 1.1.0
+	public ObjectPropertyGeneratorContext(
+		Property property,
+		@Nullable Integer elementIndex,
+		@Nullable ArbitraryProperty ownerProperty,
+		boolean container,
+		PropertyNameResolver propertyNameResolver
+	) {
+		this.property = property;
+		this.elementIndex = elementIndex;
+		this.ownerProperty = ownerProperty;
+		this.container = container;
+		this.propertyNameResolver = propertyNameResolver;
+		this.propertyGenerator = null;
+		this.nullInjectGenerator = null;
+	}
+
 	public Property getProperty() {
 		return this.property;
 	}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/SingleValueObjectPropertyGenerator.java
@@ -25,7 +25,11 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
 
+/**
+ * It is deprecated. Use {@link DefaultObjectPropertyGenerator} since 1.1.0.
+ */
 @API(since = "0.4.0", status = Status.MAINTAINED)
+@Deprecated
 public final class SingleValueObjectPropertyGenerator implements ObjectPropertyGenerator {
 	public static final SingleValueObjectPropertyGenerator INSTANCE = new SingleValueObjectPropertyGenerator();
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/InterfaceCandidateConcretePropertyResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/InterfaceCandidateConcretePropertyResolver.java
@@ -1,0 +1,75 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.property;
+
+import static com.navercorp.fixturemonkey.api.type.Types.generateAnnotatedTypeWithoutAnnotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.0.21", status = Status.EXPERIMENTAL)
+public final class InterfaceCandidateConcretePropertyResolver<T> implements CandidateConcretePropertyResolver {
+	private final List<Class<? extends T>> implementations;
+
+	public InterfaceCandidateConcretePropertyResolver(List<Class<? extends T>> implementations) {
+		this.implementations = implementations;
+	}
+
+	@Override
+	public List<Property> resolve(Property property) {
+		return implementations.stream()
+			.map(implementation -> new Property() {
+				@Override
+				public Type getType() {
+					return implementation;
+				}
+
+				@Override
+				public AnnotatedType getAnnotatedType() {
+					return generateAnnotatedTypeWithoutAnnotation(implementation);
+				}
+
+				@Nullable
+				@Override
+				public String getName() {
+					return property.getName();
+				}
+
+				@Override
+				public List<Annotation> getAnnotations() {
+					return property.getAnnotations();
+				}
+
+				@Nullable
+				@Override
+				public Object getValue(Object instance) {
+					return property.getValue(instance);
+				}
+			})
+			.collect(Collectors.toList());
+	}
+}

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/property/SealedTypeCandidateConcretePropertyResolver.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/property/SealedTypeCandidateConcretePropertyResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.property;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.type.Types;
+
+@API(since = "1.0.21", status = Status.EXPERIMENTAL)
+public final class SealedTypeCandidateConcretePropertyResolver implements CandidateConcretePropertyResolver {
+	@Override
+	public List<Property> resolve(Property property) {
+		Class<?> actualType = Types.getActualType(property.getType());
+		Set<Class<?>> permittedSubclasses = collectPermittedSubclasses(actualType);
+
+		return permittedSubclasses.stream()
+			.map(PropertyUtils::toProperty)
+			.toList();
+	}
+
+	private static Set<Class<?>> collectPermittedSubclasses(Class<?> type) {
+		Set<Class<?>> subclasses = new HashSet<>();
+		doCollectPermittedSubclasses(type, subclasses);
+		return subclasses;
+	}
+
+	private static void doCollectPermittedSubclasses(Class<?> type, Set<Class<?>> subclasses) {
+		if (type.isSealed()) {
+			for (Class<?> subclass : type.getPermittedSubclasses()) {
+				doCollectPermittedSubclasses(subclass, subclasses);
+			}
+		} else {
+			subclasses.add(type);
+		}
+	}
+}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ArbitraryTraverser.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ArbitraryTraverser.java
@@ -106,17 +106,17 @@ public final class ArbitraryTraverser {
 			index = getIndex(resolvedParentProperty, parentArbitraryProperty, propertySequence);
 		}
 
-		ObjectProperty objectProperty = objectPropertyGenerator.generate(
-			new ObjectPropertyGeneratorContext(
-				property,
-				index,
-				parentArbitraryProperty,
-				container,
-				getPropertyGenerator(context.getPropertyConfigurers()),
-				fixtureMonkeyOptions.getPropertyNameResolver(property),
-				fixtureMonkeyOptions.getNullInjectGenerator(property)
-			)
+		ObjectPropertyGeneratorContext objectPropertyGeneratorContext = new ObjectPropertyGeneratorContext(
+			property,
+			index,
+			parentArbitraryProperty,
+			container,
+			getPropertyGenerator(context.getPropertyConfigurers()),
+			fixtureMonkeyOptions.getPropertyNameResolver(property),
+			fixtureMonkeyOptions.getNullInjectGenerator(property)
 		);
+
+		ObjectProperty objectProperty = objectPropertyGenerator.generate(objectPropertyGeneratorContext);
 
 		Map<Property, List<Property>> childPropertyListsByCandidateProperty;
 		ContainerInfoManipulator appliedContainerInfoManipulator = null;


### PR DESCRIPTION
## Summary
Deprecate the ObjectPropertyGenerators that modify child properties listed below.
- InterfaceObjectPropertyGenerator
- SingleValueObjectPropertyGenerator
- SealedTypeObjectPropertyGenerator

They are replaced by the implementations of `CandidateConcretePropertyResolver`

## How Has This Been Tested?
existing tests

## Is the Document updated?
No
