### PR TITLE
Fix decompose Java Kotlin functional interface

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/container/DefaultDecomposedContainerValueFactory.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/container/DefaultDecomposedContainerValueFactory.java
@@ -19,6 +19,7 @@
 package com.navercorp.fixturemonkey.api.container;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.Proxy;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Iterator;
 import java.util.List;
@@ -82,7 +83,16 @@ public final class DefaultDecomposedContainerValueFactory implements DecomposedC
 				1
 			);
 		} else if (Supplier.class.isAssignableFrom(actualType)) {
-			return new DecomposableJavaContainer(container, 1);
+			return new DecomposableJavaContainer(((Supplier<?>)container).get(), 1);
+		} else if (container instanceof Proxy) {
+			try {
+				return new DecomposableJavaContainer(
+					Proxy.getInvocationHandler(container).invoke(container, null, null),
+					1
+				);
+			} catch (Throwable e) {
+				// ignored
+			}
 		}
 
 		return additionalDecomposedContainerValueFactory.from(container);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FunctionalInterfaceContainerPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/FunctionalInterfaceContainerPropertyGenerator.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -72,13 +71,7 @@ public final class FunctionalInterfaceContainerPropertyGenerator implements Cont
 
 			@Override
 			public Object getValue(Object instance) {
-				Class<?> actualType = Types.getActualType(instance.getClass());
-
-				if (Supplier.class.isAssignableFrom(actualType)) {
-					return instance;
-				}
-
-				throw new IllegalArgumentException("given value has no match");
+				return instance;
 			}
 		};
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FunctionalInterfaceArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FunctionalInterfaceArbitraryIntrospector.java
@@ -53,7 +53,7 @@ public final class FunctionalInterfaceArbitraryIntrospector implements Arbitrary
 			type.getClassLoader(),
 			new Class[] {type},
 			(proxy, method, args) -> {
-				if ("equals".equals(method.getName())) {
+				if (method != null && "equals".equals(method.getName())) {
 					return Objects.equals(args[0], value);
 				}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -628,7 +628,12 @@ public final class FixtureMonkeyOptionsBuilder {
 					this.decomposableContainerFactoryMap.entrySet()
 				) {
 					Class<?> type = entry.getKey();
-					DecomposableJavaContainer decomposedValue = entry.getValue().from(obj);
+					DecomposableJavaContainer decomposedValue;
+					try {
+						decomposedValue = entry.getValue().from(obj);
+					} catch (IllegalArgumentException ex) {
+						continue;
+					}
 
 					if (type.isAssignableFrom(actualType)) {
 						return decomposedValue;

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/KotlinPlugin.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/KotlinPlugin.kt
@@ -18,8 +18,8 @@
 
 package com.navercorp.fixturemonkey.kotlin
 
-import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator
 import com.navercorp.fixturemonkey.api.generator.FunctionalInterfaceContainerPropertyGenerator
+import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator
 import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator
 import com.navercorp.fixturemonkey.api.introspector.FunctionalInterfaceArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.MatchArbitraryIntrospector

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableFunctionalInterfaceSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableFunctionalInterfaceSpecs.java
@@ -1,0 +1,36 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.java;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import lombok.Value;
+
+class ImmutableFunctionalInterfaceSpecs {
+	@Value
+	public static class FunctionObject {
+		Function<Integer, String> value;
+	}
+
+	@Value
+	public static class SupplierObject {
+		Supplier<String> value;
+	}
+}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.RepeatedTest;
@@ -69,6 +70,8 @@ import com.navercorp.fixturemonkey.tests.java.ConstructorTestSpecs.SimpleContain
 import com.navercorp.fixturemonkey.tests.java.ImmutableDepthTestSpecs.DepthStringValueList;
 import com.navercorp.fixturemonkey.tests.java.ImmutableDepthTestSpecs.OneDepthStringValue;
 import com.navercorp.fixturemonkey.tests.java.ImmutableDepthTestSpecs.TwoDepthStringValue;
+import com.navercorp.fixturemonkey.tests.java.ImmutableFunctionalInterfaceSpecs.FunctionObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableFunctionalInterfaceSpecs.SupplierObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericArrayObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericImplementationObject;
 import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericObject;
@@ -1253,12 +1256,24 @@ class JavaTest {
 	}
 
 	@Test
-	void decomposeFunction() {
-		Function<Integer, String> actual = SUT.giveMeBuilder(new TypeReference<Function<Integer, String>>() {
+	void decomposeFunctionObject() {
+		Function<Integer, String> actual = SUT.giveMeBuilder(FunctionObject.class)
+			.thenApply((function, builder) -> {
 			})
-			.fixed()
-			.sample();
+			.sample()
+			.getValue();
 
 		then(actual.apply(1)).isNotNull();
+	}
+
+	@Test
+	void decomposeSupplierObject() {
+		Supplier<String> actual = SUT.giveMeBuilder(SupplierObject.class)
+			.thenApply((function, builder) -> {
+			})
+			.sample()
+			.getValue();
+
+		then(actual.get()).isNotNull();
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -818,12 +818,38 @@ class KotlinTest {
     }
 
     @Test
+    fun decomposeKotlinLambdaOnlyReturnType() {
+        // given
+        class KotlinLambdaValue(val lambda: () -> String)
+
+        // when
+        val actual = SUT.giveMeBuilder<KotlinLambdaValue>()
+            .thenApply { _, _ -> }
+            .sample()
+
+        then(actual.lambda.invoke()).isNotNull
+    }
+
+    @Test
     fun kotlinLambdaReturnType() {
         // given
         class KotlinLambdaValue(val lambda: (String) -> String)
 
         // when
         val actual: KotlinLambdaValue = SUT.giveMeOne()
+
+        then(actual.lambda.invoke("test")).isNotNull
+    }
+
+    @Test
+    fun decomposeKotlinLambdaReturnType() {
+        // given
+        class KotlinLambdaValue(val lambda: (String) -> String)
+
+        // when
+        val actual = SUT.giveMeBuilder<KotlinLambdaValue>()
+            .thenApply { _, _ -> }
+            .sample()
 
         then(actual.lambda.invoke("test")).isNotNull
     }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/NodeSetDecomposedValueManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/NodeSetDecomposedValueManipulator.java
@@ -24,6 +24,7 @@ import static com.navercorp.fixturemonkey.api.type.Types.isAssignable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -98,6 +99,11 @@ public final class NodeSetDecomposedValueManipulator<T> implements NodeManipulat
 
 		boolean container = objectNode.getArbitraryProperty().isContainer();
 		if (container) {
+			if (Types.getActualType(objectNode.getResolvedProperty().getType()) == Function.class) {
+				objectNode.setArbitrary(CombinableArbitrary.from(value));
+				return;
+			}
+
 			DecomposableJavaContainer decomposableJavaContainer = decomposedContainerValueFactory.from(value);
 			Object containerValue = decomposableJavaContainer.getJavaContainer();
 			int decomposedContainerSize = decomposableJavaContainer.getSize();


### PR DESCRIPTION
## Summary
Fix decompose Java Kotlin functional interface

## How Has This Been Tested?
* decomposeKotlinLambdaReturnType
* decomposeKotlinLambdaOnlyReturnType
* decomposeSupplierObject
* decomposeFunctionObject

## Is the Document updated?
Not Yet
