### PR TITLE
Add compatibility with ObjectPropertyGenerator and CandidateConcretePropertyResolver

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryProperty.java
@@ -53,12 +53,12 @@ public final class ArbitraryProperty {
 		ObjectProperty objectProperty,
 		boolean container,
 		double nullInject,
-		Map<Property, List<Property>> childPropertyListsByCandidateProperty
+		List<ConcreteTypeDefinition> concreteTypeDefinitions
 	) {
 		this.objectProperty = objectProperty;
 		this.container = container;
 		this.nullInject = nullInject;
-		this.concreteTypeDefinitions = toConcreteTypeDefinition(childPropertyListsByCandidateProperty);
+		this.concreteTypeDefinitions = concreteTypeDefinitions;
 	}
 
 	public ObjectProperty getObjectProperty() {
@@ -70,7 +70,12 @@ public final class ArbitraryProperty {
 	}
 
 	public ArbitraryProperty withNullInject(double nullInject) {
-		return new ArbitraryProperty(this.objectProperty.withNullInject(nullInject), this.container);
+		return new ArbitraryProperty(
+			this.objectProperty,
+			this.container,
+			nullInject,
+			this.concreteTypeDefinitions
+		);
 	}
 
 	public double getNullInject() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/DefaultObjectPropertyGenerator.java
@@ -18,14 +18,10 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class DefaultObjectPropertyGenerator implements ObjectPropertyGenerator {
@@ -35,16 +31,11 @@ public final class DefaultObjectPropertyGenerator implements ObjectPropertyGener
 	@Override
 	public ObjectProperty generate(ObjectPropertyGeneratorContext context) {
 		Property property = context.getProperty();
-		PropertyGenerator propertyGenerator = context.getPropertyGenerator();
-		List<Property> childProperties = propertyGenerator.generateChildProperties(property);
-		double nullInject = context.getNullInjectGenerator().generate(context);
 
 		return new ObjectProperty(
 			property,
 			context.getPropertyNameResolver(),
-			nullInject,
-			context.getElementIndex(),
-			Collections.singletonMap(property, childProperties)
+			context.getElementIndex()
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.generator;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -40,7 +41,7 @@ public final class ObjectProperty {
 	private final PropertyNameResolver propertyNameResolver;
 
 	@Deprecated
-	private final double nullInject;
+	private final Double nullInject;
 
 	@Nullable
 	private final Integer elementIndex;
@@ -48,6 +49,10 @@ public final class ObjectProperty {
 	@Deprecated
 	private final Map<Property, List<Property>> childPropertyListsByCandidateProperty;
 
+	/**
+	 * Use {@link ObjectProperty(Property, PropertyNameResolver, Integer)} instead.
+	 */
+	@Deprecated
 	public ObjectProperty(
 		Property property,
 		PropertyNameResolver propertyNameResolver,
@@ -60,6 +65,18 @@ public final class ObjectProperty {
 		this.nullInject = nullInject;
 		this.elementIndex = elementIndex;
 		this.childPropertyListsByCandidateProperty = childPropertyListsByCandidateProperty;
+	}
+
+	public ObjectProperty(
+		Property property,
+		PropertyNameResolver propertyNameResolver,
+		@Nullable Integer elementIndex
+	) {
+		this.property = property;
+		this.propertyNameResolver = propertyNameResolver;
+		this.elementIndex = elementIndex;
+		this.nullInject = null;
+		this.childPropertyListsByCandidateProperty = Collections.emptyMap();
 	}
 
 	public Property getProperty() {
@@ -75,7 +92,8 @@ public final class ObjectProperty {
 	}
 
 	@Deprecated
-	public double getNullInject() {
+	@Nullable
+	public Double getNullInject() {
 		return this.nullInject;
 	}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/InterfacePlugin.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/plugin/InterfacePlugin.java
@@ -26,14 +26,14 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.api.generator.InterfaceObjectPropertyGenerator;
-import com.navercorp.fixturemonkey.api.generator.ObjectPropertyGenerator;
 import com.navercorp.fixturemonkey.api.introspector.AnonymousArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.MatchArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.ExactTypeMatcher;
 import com.navercorp.fixturemonkey.api.matcher.Matcher;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptionsBuilder;
+import com.navercorp.fixturemonkey.api.property.CandidateConcretePropertyResolver;
+import com.navercorp.fixturemonkey.api.property.ConcreteTypeCandidateConcretePropertyResolver;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 /**
@@ -41,7 +41,8 @@ import com.navercorp.fixturemonkey.api.type.Types;
  */
 @API(since = "1.0.6", status = Status.EXPERIMENTAL)
 public final class InterfacePlugin implements Plugin {
-	private final List<MatcherOperator<ObjectPropertyGenerator>> objectPropertyGenerators = new ArrayList<>();
+	private final List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers =
+		new ArrayList<>();
 	private boolean useAnonymousArbitraryIntrospector = true;
 
 	/**
@@ -83,10 +84,10 @@ public final class InterfacePlugin implements Plugin {
 		Matcher matcher,
 		List<Class<? extends T>> implementations
 	) {
-		this.objectPropertyGenerators.add(
+		this.candidateConcretePropertyResolvers.add(
 			new MatcherOperator<>(
 				matcher.intersect(p -> Modifier.isInterface(Types.getActualType(p.getType()).getModifiers())),
-				new InterfaceObjectPropertyGenerator<>(implementations)
+				new ConcreteTypeCandidateConcretePropertyResolver<>(implementations)
 			)
 		);
 
@@ -132,26 +133,13 @@ public final class InterfacePlugin implements Plugin {
 		Matcher matcher,
 		List<Class<? extends T>> implementations
 	) {
-		this.objectPropertyGenerators.add(
+		this.candidateConcretePropertyResolvers.add(
 			new MatcherOperator<>(
 				matcher.intersect(p -> Modifier.isAbstract(Types.getActualType(p.getType()).getModifiers())),
-				new InterfaceObjectPropertyGenerator<>(implementations)
+				new ConcreteTypeCandidateConcretePropertyResolver<>(implementations)
 			)
 		);
 
-		return this;
-	}
-
-	/**
-	 * Registers an interface implementation with a specified matcher.
-	 * This method facilitates adding custom implementations for interfaces using a matcher.
-	 *
-	 * @param objectPropertyGenerator the object property generator to add
-	 * @return the InterfacePlugin instance for fluent chaining
-	 */
-	@Deprecated
-	public InterfacePlugin interfaceImplements(MatcherOperator<ObjectPropertyGenerator> objectPropertyGenerator) {
-		this.objectPropertyGenerators.add(objectPropertyGenerator);
 		return this;
 	}
 
@@ -171,8 +159,8 @@ public final class InterfacePlugin implements Plugin {
 
 	@Override
 	public void accept(FixtureMonkeyOptionsBuilder optionsBuilder) {
-		for (MatcherOperator<ObjectPropertyGenerator> objectPropertyGenerator : objectPropertyGenerators) {
-			optionsBuilder.insertFirstArbitraryObjectPropertyGenerator(objectPropertyGenerator);
+		for (MatcherOperator<CandidateConcretePropertyResolver> resolver : candidateConcretePropertyResolvers) {
+			optionsBuilder.insertFirstCandidateConcretePropertyResolvers(resolver);
 		}
 
 		if (useAnonymousArbitraryIntrospector) {


### PR DESCRIPTION
## Summary
Add compatibility with ObjectPropertyGenerator and CandidateConcretePropertyResolver

## (Optional): Description
ObjectPropetyGenerator will not resolve the child properties and the candidate concrete property.

To remove the concrete type of `ObjectPropetyGenerator` from 1.1.0, make ObjectPropertyGenerator and CandidateConcretePropertyResolver compatible.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*
