### PR TITLE
Refactor customizeProperty works in order

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
@@ -20,6 +20,8 @@ package com.navercorp.fixturemonkey.kotlin
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
+import com.navercorp.fixturemonkey.api.experimental.TypedPropertySelector
 import com.navercorp.fixturemonkey.api.instantiator.Instantiator
 import com.navercorp.fixturemonkey.api.property.PropertySelector
 import com.navercorp.fixturemonkey.api.type.TypeReference
@@ -228,6 +230,11 @@ class KotlinTypeDefaultArbitraryBuilder<T>(
         instantiator: Instantiator?,
     ): KotlinTypeDefaultArbitraryBuilder<T> =
         this.apply { delegate.instantiate(type, instantiator) }
+
+    override fun <U : Any?> customizeProperty(
+        propertySelector: TypedPropertySelector<U>,
+        combinableArbitraryCustomizer: Function<CombinableArbitrary<out U>, CombinableArbitrary<out U>>
+    ): ArbitraryBuilder<T> = this.apply { delegate.customizeProperty(propertySelector, combinableArbitraryCustomizer) }
 
     override fun build(): Arbitrary<T> = delegate.build()
 

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -22,6 +22,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.api.experimental.JavaGetterMethodPropertySelector.javaGetter
 import com.navercorp.fixturemonkey.api.experimental.TypedExpressionGenerator.typedRoot
+import com.navercorp.fixturemonkey.api.experimental.TypedExpressionGenerator.typedString
 import com.navercorp.fixturemonkey.api.introspector.AnonymousArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospectorResult
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector
@@ -892,6 +893,46 @@ class KotlinTest {
             .string
 
         then(actual).hasSizeLessThan(5)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun customizePropertyAfterSet() {
+        // given
+        class StringValue(val value: String)
+
+        val expected = "abc"
+
+        // when
+        val actual = SUT.giveMeKotlinBuilder<StringValue>()
+            .setExp(StringValue::value, "abcdef")
+            .customizeProperty(typedString<String>("value")) {
+                it.map { str -> str.substring(0..2) }
+            }
+            .sample()
+            .value
+
+        //then
+        then(actual).isEqualTo(expected)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun customizePropertyIgnoredIfSet() {
+        // given
+        class StringValue(val value: String)
+
+        val expected = "fixed"
+
+        // when
+        val actual = SUT.giveMeKotlinBuilder<StringValue>()
+            .customizeProperty(typedString<String>("value")) {
+                it.filter { value -> value.length > 5 }
+            }
+            .setExp(StringValue::value, expected)
+            .sample()
+            .value
+
+        //then
+        then(actual).isEqualTo(expected)
     }
 
     companion object {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/ArbitraryBuilder.java
@@ -36,6 +36,8 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Combinators.F3;
 import net.jqwik.api.Combinators.F4;
 
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.experimental.TypedPropertySelector;
 import com.navercorp.fixturemonkey.api.instantiator.Instantiator;
 import com.navercorp.fixturemonkey.api.property.PropertySelector;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -554,4 +556,10 @@ public interface ArbitraryBuilder<T> {
 	ArbitraryBuilder<T> instantiate(Class<?> type, Instantiator instantiator);
 
 	ArbitraryBuilder<T> instantiate(TypeReference<?> type, Instantiator instantiator);
+
+	@API(since = "1.0.9", status = Status.MAINTAINED)
+	<U> ArbitraryBuilder<T> customizeProperty(
+		TypedPropertySelector<U> propertySelector,
+		Function<CombinableArbitrary<? extends U>, CombinableArbitrary<? extends U>> combinableArbitraryCustomizer
+	);
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/JavaTypeDefaultTypeArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/JavaTypeDefaultTypeArbitraryBuilder.java
@@ -38,6 +38,8 @@ import net.jqwik.api.Combinators.F4;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.JavaTypeArbitraryBuilder;
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.experimental.TypedPropertySelector;
 import com.navercorp.fixturemonkey.api.instantiator.Instantiator;
 import com.navercorp.fixturemonkey.api.property.PropertySelector;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -334,5 +336,13 @@ public final class JavaTypeDefaultTypeArbitraryBuilder<T> implements JavaTypeArb
 	public JavaTypeArbitraryBuilder<T> instantiate(TypeReference<?> type, Instantiator instantiator) {
 		delegate.instantiate(type, instantiator);
 		return this;
+	}
+
+	@Override
+	public <U> ArbitraryBuilder<T> customizeProperty(
+		TypedPropertySelector<U> propertySelector,
+		Function<CombinableArbitrary<? extends U>, CombinableArbitrary<? extends U>> combinableArbitraryCustomizer
+	) {
+		return delegate.customizeProperty(propertySelector, combinableArbitraryCustomizer);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/NodeCustomizerManipulator.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/NodeCustomizerManipulator.java
@@ -39,6 +39,12 @@ public final class NodeCustomizerManipulator<T> implements NodeManipulator {
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
 	public void manipulate(ObjectNode objectNode) {
-		objectNode.addArbitraryCustomizer((Function)arbitraryCustomizer);
+		if (objectNode.getArbitrary() != null) {
+			CombinableArbitrary<? extends T> customized = arbitraryCustomizer.apply(
+				(CombinableArbitrary<? extends T>)objectNode.getArbitrary());
+			objectNode.setArbitrary(customized);
+		} else {
+			objectNode.addGeneratedArbitraryCustomizer((Function)arbitraryCustomizer);
+		}
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/experimental/ExperimentalArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/experimental/ExperimentalArbitraryBuilder.java
@@ -18,20 +18,11 @@
 
 package com.navercorp.fixturemonkey.experimental;
 
-import java.util.function.Function;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
-import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
-import com.navercorp.fixturemonkey.api.experimental.TypedPropertySelector;
 
 @API(since = "0.6.12", status = Status.MAINTAINED)
 public interface ExperimentalArbitraryBuilder<T> extends ArbitraryBuilder<T> {
-	@API(since = "1.0.9", status = Status.EXPERIMENTAL)
-	<U> ArbitraryBuilder<T> customizeProperty(
-		TypedPropertySelector<U> propertySelector,
-		Function<CombinableArbitrary<? extends U>, CombinableArbitrary<? extends U>> combinableArbitraryCustomizer
-	);
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
@@ -160,11 +160,13 @@ public final class ObjectNode {
 		return arbitraryFilters;
 	}
 
-	public void addArbitraryCustomizer(Function<CombinableArbitrary<?>, CombinableArbitrary<?>> arbitraryCustomizer) {
+	public void addGeneratedArbitraryCustomizer(
+		Function<CombinableArbitrary<?>, CombinableArbitrary<?>> arbitraryCustomizer
+	) {
 		this.arbitraryCustomizers.add(arbitraryCustomizer);
 	}
 
-	public List<Function<CombinableArbitrary<?>, CombinableArbitrary<?>>> getArbitraryCustomizers() {
+	public List<Function<CombinableArbitrary<?>, CombinableArbitrary<?>>> getGeneratedArbitraryCustomizers() {
 		return arbitraryCustomizers;
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -152,6 +152,14 @@ public final class ObjectTree {
 				);
 				generated = getArbitraryGenerator(node.getResolvedProperty(), arbitraryIntrospector)
 					.generate(childArbitraryGeneratorContext);
+
+				List<Function<CombinableArbitrary<?>, CombinableArbitrary<?>>> customizers =
+					node.getGeneratedArbitraryCustomizers();
+
+				for (Function<CombinableArbitrary<?>, CombinableArbitrary<?>> customizer : customizers) {
+					generated = customizer.apply(generated);
+				}
+
 				if (node.cacheable()) {
 					monkeyContext.putCachedArbitrary(
 						node.getProperty(),
@@ -159,13 +167,6 @@ public final class ObjectTree {
 					);
 				}
 			}
-		}
-
-		List<Function<CombinableArbitrary<?>, CombinableArbitrary<?>>> arbitraryCustomizers =
-			node.getArbitraryCustomizers();
-
-		for (Function<CombinableArbitrary<?>, CombinableArbitrary<?>> arbitraryCustomizer : arbitraryCustomizers) {
-			generated = arbitraryCustomizer.apply(generated);
 		}
 
 		List<Predicate> arbitraryFilters = node.getArbitraryFilters();


### PR DESCRIPTION
## Summary
Refactor customizeProperty works in order

## (Optional): Description
ArbitraryBuilder API `customizeProperty` is affected by order from 1.1.0.

For example, the results of two examples are different.

```kotlin
.setExp(StringValue::value, "abcdef")
.customizeProperty(typedString<String>("value")) {
    it.map { str -> str.substring(0..2) }
}

result -> `abc`
```


```kotlin
.customizeProperty(typedString<String>("value")) {
    it.filter { value -> value.length > 5 }
}
.setExp(StringValue::value, "fixed")

result -> "fixed"
```

## How Has This Been Tested?
* customizePropertyAfterSet
* customizePropertyIgnoredIfSet

## Is the Document updated?
Later
