### PR TITLE
Fix for generating Kotlin self-reference with default arguments

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -66,7 +66,9 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector {
 
                     for (parameter in constructor.parameters) {
                         val resolvedArbitrary = arbitrariesByPropertyName[parameter.name]
-                        generatedByParameters[parameter] = resolvedArbitrary
+                        if (resolvedArbitrary != null || !parameter.isOptional || parameter.type.isMarkedNullable) {
+                            generatedByParameters[parameter] = resolvedArbitrary
+                        }
                     }
 
                     constructor.callBy(generatedByParameters)

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/CircularReferenceTestSpecs.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/CircularReferenceTestSpecs.kt
@@ -1,0 +1,11 @@
+package com.navercorp.fixturemonkey.tests.kotlin
+
+class CircularReferenceValueNullable(
+    val value: CircularReferenceDefaultArgument? = null
+)
+
+class CircularReferenceDefaultArgument(
+    val value: CircularReferenceValueNullable = CircularReferenceValueNullable(),
+)
+
+

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -889,6 +889,20 @@ class KotlinTest {
         then(actual).isInstanceOf(ArrayList::class.java)
     }
 
+    @RepeatedTest(TEST_COUNT)
+    fun circularReferenceDefaultArgument() {
+        val actual = SUT.giveMeOne<CircularReferenceDefaultArgument>().value
+
+        then(actual).isNotNull()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun circularReferenceNullable() {
+        val actual: CircularReferenceValueNullable = SUT.giveMeOne()
+
+        then(actual).isNotNull()
+    }
+
     companion object {
         private val SUT: FixtureMonkey = FixtureMonkey.builder()
             .plugin(KotlinPlugin())


### PR DESCRIPTION
## Summary
Fix for generating Kotlin self-reference with default arguments

## How Has This Been Tested?
* circularReferenceDefaultArgument
* circularReferenceNullable

## Is the Document updated?
It'll be another PR
