### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/v1.0.x-kor/docs/customizing-objects/interface.md
+++ b/docs/content/v1.0.x-kor/docs/customizing-objects/interface.md
@@ -26,7 +26,7 @@ String result = fixture.giveMeBuilder(StringSupplier.class)
 ```
 
 인터페이스를 생성하는 `ArbitraryBuilder`가 제어할 수 있는 프로퍼티는 실제로 생성한 구현체마다 다릅니다.
-하지만 아직은 구현체를 선택할 수 있는 `ArbitraryBulder` API가 존재하지 않습니다. 
+하지만 아직은 구현체를 선택할 수 있는 `ArbitraryBuilder` API가 존재하지 않습니다. 
 인터페이스가 하나의 구현체를 가지고 있다면 구현체 프로퍼티도 제어가 가능합니다. 하지만 구현체가 두 개 이상이라면 인터페이스의 프로퍼티만 제어가 가능합니다. 
 
 

--- a/docs/content/v1.0.x/docs/customizing-objects/interface.md
+++ b/docs/content/v1.0.x/docs/customizing-objects/interface.md
@@ -25,7 +25,7 @@ String result = fixture.giveMeBuilder(StringSupplier.class)
 ```
 
 The properties of the interface in `ArbitraryBuilder` differ in the implementation.
-Unfortunately, there is currently no ArbitraryBuilder API that resolves the implementation of the interface. 
+Unfortunately, there is currently no `ArbitraryBuilder` API that resolves the implementation of the interface. 
 Unless the interface has only one implementation, you can customize the properties of the interface, not the implementation.
 
 You cannot generate the randomly populated intended implementation, but you can generate the fixed implementation by using the `set` API.


### PR DESCRIPTION
## Summary
- 한글 문서에 `ArbitraryBuilder`에 오타가 있어서 수정했습니다.
- 위에서 수정한 부분이 영어 문서에서 text로 되어 있어서, 한글 문서와 동일하게 inline code로 통일했습니다.