### PR TITLE
Fix doc introspector description

### DIFF
--- a/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
+++ b/docs/content/v1.0.x-kor/docs/generating-objects/introspector.md
@@ -50,6 +50,8 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
     .build();
 ```
 
+{{< alert icon="💡" text="만약 final이 아닌 변수가 선언되어 있다면 getter 또는 setter 없이도 사용 가능합니다." />}}
+
 ## BuilderArbitraryIntrospector
 클래스 빌더를 사용하여 클래스를 생성하려면 `BuilderArbitraryIntrospector`를 사용할 수 있습니다.
 이런 경우 클래스에 빌더가 있어야 합니다.
@@ -59,8 +61,6 @@ FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
     .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
     .build();
 ```
-
-{{< alert icon="💡" text="만약 final이 아닌 변수가 선언되어 있다면 getter 또는 setter 없이도 사용 가능합니다." />}}
 
 ## FailoverArbitraryIntrospector
 프로덕션 코드에서 다수의 클래스가 있을 때 각 클래스마다 다른 설정을 가진다면 하나의 introspector로 모든 객체를 생성하기 어려울 수 있습니다.


### PR DESCRIPTION
## Summary
#1037

한글 버전 공식 문서의 `Introspector` 페이지에서 `"만약 final이 아닌 변수가 선언되어 있다면 getter 또는 setter 없이도 사용 가능합니다."`의 내용이 `FieldReflectionArbitrary` 아래가 아닌 `BuilderArbitraryIntrospector` 아래에 위치해있습니다. 

해당 부분을 `FieldReflectionArbitrary` 아래에 위치하도록 파일을 수정했습니다.

(※영문 파일은 정상이며, 한글 파일만 위치가 잘못되어 있기 때문에 한글 파일만을 수정했습니다.)

## Is the Document updated?
yes