### PR TITLE
Add PriorityConstructorArbitraryIntrospector

### DIFF
--- a/docs/content/v1.0.x-kor/docs/cheat-sheet/faq.md
+++ b/docs/content/v1.0.x-kor/docs/cheat-sheet/faq.md
@@ -63,3 +63,14 @@ val product = sut.giveMeBuilder<Product>()
 ### 필드 중 하나가 다른 필드의 값에 의존하고 있습니다. 이러한 픽스처를 커스터마이징 하려면 어떻게 해야 하나요?
 
 `thenApply()` 메서드는 다른 필드에 의존하는 필드를 커스터마이징 할 때 유용합니다. 자세한 내용은 [`thenApply()`](../../customizing-objects/apis/#thenapply)을 확인해주세요.
+
+### 특정 타입을 생성할 때 예외가 발생해요
+
+먼저 [PriorityConstructorArbitraryIntrospector](../../generating-objects/introspector/#PriorityConstructorArbitraryIntrospector)를 사용해보세요. 다음과 같이 사용할 수 있습니다.
+```java
+FixtureMonkey.builder()
+    .pushExactTypeArbitraryIntrospector(ProblematicType.class, PriorityConstructorArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+위 옵션을 추가했는데도 동작하지 않는다면, `ArbitraryIntrospector`을 직접 만들거나 깃허브에 [이슈](https://github.com/naver/fixture-monkey/issues)를 만들어주시면 도움을 드리겠습니다.

--- a/docs/content/v1.0.x-kor/release-notes/_index.md
+++ b/docs/content/v1.0.x-kor/release-notes/_index.md
@@ -6,6 +6,12 @@ docs:
 weight: 100
 ---
 sectionStart
+## v.1.0.26
+Add `PriorityConstructorArbitraryIntrospector`
+
+sectionEnd
+
+sectionStart
 ### v.1.0.25
 Fix concurrency issue with string generation
 

--- a/docs/content/v1.0.x/docs/cheat-sheet/faq.md
+++ b/docs/content/v1.0.x/docs/cheat-sheet/faq.md
@@ -67,3 +67,14 @@ In such cases, it's recommended to use `set()` instead.
 
 The `thenApply()` method comes in handy when you need to customize a field that relies on another field.
 For more information, check the [`thenApply()` section](../../customizing-objects/apis/#thenapply)
+
+### Throws an exception when generating a certain type
+
+Use [PriorityConstructorArbitraryIntrospector](../../generating-objects/introspector/#PriorityConstructorArbitraryIntrospector) first. Apply as shown below.
+```java
+FixtureMonkey.builder()
+    .pushExactTypeArbitraryIntrospector(ProblematicType.class, PriorityConstructorArbitraryIntrospector.INSTANCE)
+    .build();
+```
+
+If it does not work, please try to make your own `ArbitraryIntrospector` or create [an issue](https://github.com/naver/fixture-monkey/issues) on github and ask for help.

--- a/docs/content/v1.0.x/release-notes/_index.md
+++ b/docs/content/v1.0.x/release-notes/_index.md
@@ -6,6 +6,12 @@ docs:
 weight: 100
 ---
 sectionStart
+## v.1.0.26
+Add `PriorityConstructorArbitraryIntrospector`
+
+sectionEnd
+
+sectionStart
 ### v.1.0.25
 Fix concurrency issue with string generation
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorArbitraryIntrospector.java
@@ -18,9 +18,10 @@
 
 package com.navercorp.fixturemonkey.api.introspector;
 
+import static com.navercorp.fixturemonkey.api.type.TypeCache.getParameterNames;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -61,9 +62,7 @@ public final class ConstructorArbitraryIntrospector implements ArbitraryIntrospe
 		}
 
 		List<String> parameterNames = constructorWithParamNames.getParameterNames().isEmpty()
-			? Arrays.stream(constructorWithParamNames.getConstructor().getParameters())
-			.map(Parameter::getName)
-			.collect(Collectors.toList())
+			? Arrays.asList(getParameterNames(constructorWithParamNames.getConstructor()))
 			: constructorWithParamNames.getParameterNames();
 
 		return new ArbitraryIntrospectorResult(

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/PriorityConstructorArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/PriorityConstructorArbitraryIntrospector.java
@@ -1,0 +1,143 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.introspector;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorArbitraryIntrospector.ConstructorWithParameterNames;
+import com.navercorp.fixturemonkey.api.property.Property;
+import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
+import com.navercorp.fixturemonkey.api.type.TypeCache;
+import com.navercorp.fixturemonkey.api.type.Types;
+
+@API(since = "1.0.26", status = Status.EXPERIMENTAL)
+public final class PriorityConstructorArbitraryIntrospector implements ArbitraryIntrospector {
+	public static final PriorityConstructorArbitraryIntrospector INSTANCE =
+		new PriorityConstructorArbitraryIntrospector();
+
+	private static final Map<Property, ConstructorArbitraryIntrospector> CONSTRUCTOR_INTROSPECTORS_BY_PROPERTY =
+		new ConcurrentLruCache<>(256);
+
+	private final Predicate<Constructor<?>> constructorFilter;
+	private final Comparator<Constructor<?>> sortingCriteria;
+	private final Function<Constructor<?>, List<String>> parameterNamesResolver;
+
+	public PriorityConstructorArbitraryIntrospector() {
+		this(
+			constructor -> !Modifier.isPrivate(constructor.getModifiers()),
+			Comparator.comparing(Constructor::getParameterCount),
+			constructor -> Collections.emptyList()
+		);
+	}
+
+	public PriorityConstructorArbitraryIntrospector withConstructorFilter(
+		Predicate<Constructor<?>> constructorFilter
+	) {
+		return new PriorityConstructorArbitraryIntrospector(
+			constructorFilter,
+			this.sortingCriteria,
+			this.parameterNamesResolver
+		);
+	}
+
+	public PriorityConstructorArbitraryIntrospector withSortingCriteria(
+		Comparator<Constructor<?>> sortingCriteria
+	) {
+		return new PriorityConstructorArbitraryIntrospector(
+			this.constructorFilter,
+			sortingCriteria,
+			this.parameterNamesResolver
+		);
+	}
+
+	public PriorityConstructorArbitraryIntrospector withParameterNamesResolver(
+		Function<Constructor<?>, List<String>> parameterNamesResolver
+	) {
+		return new PriorityConstructorArbitraryIntrospector(
+			this.constructorFilter,
+			this.sortingCriteria,
+			parameterNamesResolver
+		);
+	}
+
+	private PriorityConstructorArbitraryIntrospector(
+		Predicate<Constructor<?>> constructorFilter,
+		Comparator<Constructor<?>> sortingCriteria,
+		Function<Constructor<?>, List<String>> parameterNamesResolver
+	) {
+		this.constructorFilter = constructorFilter;
+		this.sortingCriteria = sortingCriteria;
+		this.parameterNamesResolver = parameterNamesResolver;
+	}
+
+	@Override
+	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
+		return getConstructorArbitraryIntrospector(context.getResolvedProperty()).introspect(context);
+	}
+
+	@Override
+	public PropertyGenerator getRequiredPropertyGenerator(Property property) {
+		return getConstructorArbitraryIntrospector(property).getRequiredPropertyGenerator(property);
+	}
+
+	private ConstructorArbitraryIntrospector getConstructorArbitraryIntrospector(Property property) {
+		Class<?> actualType = Types.getActualType(property.getType());
+
+		return CONSTRUCTOR_INTROSPECTORS_BY_PROPERTY.computeIfAbsent(
+			property,
+			p -> {
+				Constructor<?> constructor = TypeCache.getDeclaredConstructors(actualType).stream()
+					.filter(constructorFilter)
+					.min(sortingCriteria)
+					.orElseThrow(() -> new IllegalArgumentException(
+						"No matching constructor given type: " + actualType.getTypeName())
+					);
+
+				List<String> parameterNames = parameterNamesResolver.apply(constructor);
+
+				if (!parameterNames.isEmpty() && parameterNames.size() != constructor.getParameterCount()) {
+					throw new IllegalArgumentException(
+						"PriorityConstructorArbitraryIntrospector fails to resolve the parameter names "
+							+ "with the constructor of " + actualType.getTypeName()
+							+ " Please check your parameterNamesResolver."
+					);
+				}
+
+				return new ConstructorArbitraryIntrospector(
+					new ConstructorWithParameterNames<>(
+						constructor,
+						parameterNames
+					)
+				);
+			}
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeCache.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/TypeCache.java
@@ -197,7 +197,7 @@ public abstract class TypeCache {
 		CONSTRUCTORS.clear();
 	}
 
-	private static String[] getParameterNames(Constructor<?> constructor) {
+	public static String[] getParameterNames(Constructor<?> constructor) {
 		Parameter[] parameters = constructor.getParameters();
 		boolean namePresent = Arrays.stream(parameters).anyMatch(Parameter::isNamePresent);
 		boolean parameterEmpty = parameters.length == 0;
@@ -214,8 +214,15 @@ public abstract class TypeCache {
 			boolean anyReceiverParameter = Arrays.stream(constructor.getAnnotatedParameterTypes())
 				.anyMatch(it -> constructor.getAnnotatedReceiverType() != null
 					&& it.getType().equals(constructor.getAnnotatedReceiverType().getType()));
+			ConstructorProperties constructorProperties = constructor.getAnnotation(ConstructorProperties.class);
 
-			String[] constructorPropertiesNames = constructor.getAnnotation(ConstructorProperties.class).value();
+			if (constructorProperties == null) {
+				return Arrays.stream(parameters)
+					.map(Parameter::getName)
+					.toArray(String[]::new);
+			}
+
+			String[] constructorPropertiesNames = constructorProperties.value();
 			if (!anyReceiverParameter) {
 				return constructorPropertiesNames;
 			}

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableGenericTypeSpecs.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/ImmutableGenericTypeSpecs.java
@@ -64,6 +64,28 @@ class ImmutableGenericTypeSpecs {
 	}
 
 	@Value
+	public static class TwoGenericObjectConstructorParameterOrderDiff<T, U> {
+		T value1;
+		U value2;
+
+		public TwoGenericObjectConstructorParameterOrderDiff(U value2, T value1) {
+			this.value1 = value1;
+			this.value2 = value2;
+		}
+	}
+
+	@Value
+	public static class TwoGenericObjectConstructorParameterOrderDiffNameDiff<T, U> {
+		T value1;
+		U value2;
+
+		public TwoGenericObjectConstructorParameterOrderDiffNameDiff(U value1, T value2) {
+			this.value1 = value2;
+			this.value2 = value1;
+		}
+	}
+
+	@Value
 	@Builder
 	public static class ThreeGenericObject<T, U, V> {
 		T value1;

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/PriorityConstructorArbitraryIntrospectorTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/PriorityConstructorArbitraryIntrospectorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.java;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.PriorityConstructorArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.type.TypeReference;
+import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.GenericObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.TwoGenericObject;
+import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.TwoGenericObjectConstructorParameterOrderDiff;
+import com.navercorp.fixturemonkey.tests.java.ImmutableGenericTypeSpecs.TwoGenericObjectConstructorParameterOrderDiffNameDiff;
+
+class PriorityConstructorArbitraryIntrospectorTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.objectIntrospector(PriorityConstructorArbitraryIntrospector.INSTANCE)
+		.defaultNotNull(true)
+		.build();
+
+	@RepeatedTest(TEST_COUNT)
+	void sample() {
+		Timestamp actual = SUT.giveMeOne(Timestamp.class);
+
+		then(actual).isNotNull();
+	}
+
+	@Test
+	void setWithoutName() {
+		Timestamp actual = SUT.giveMeBuilder(Timestamp.class)
+			.set("time", 0)
+			.sample();
+
+		Timestamp expected = new Timestamp(0);
+		then(actual).isNotEqualTo(expected);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void set() {
+		// given
+		PriorityConstructorArbitraryIntrospector priorityConstructorArbitraryIntrospector =
+			PriorityConstructorArbitraryIntrospector.INSTANCE.withParameterNamesResolver(
+				constructor -> Arrays.asList("time")
+			);
+
+		FixtureMonkey sut = FixtureMonkey.builder()
+			.objectIntrospector(priorityConstructorArbitraryIntrospector)
+			.build();
+
+		// when
+		Timestamp actual = sut.giveMeBuilder(Timestamp.class)
+			.set("time", 0)
+			.sample();
+
+		// then
+		Timestamp expected = new Timestamp(0);
+		then(actual).isEqualTo(expected);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void genericType() {
+		String actual = SUT.giveMeOne(new TypeReference<GenericObject<String>>() {
+		}).getValue();
+
+		then(actual).isExactlyInstanceOf(String.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void twoGenericType() {
+		TwoGenericObject<String, Integer> actual = SUT.giveMeOne(
+			new TypeReference<TwoGenericObject<String, Integer>>() {
+			});
+
+		then(actual.getValue1()).isExactlyInstanceOf(String.class);
+		then(actual.getValue2()).isExactlyInstanceOf(Integer.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void twoGenericObjectConstructorParameterOrderDiff() {
+		TwoGenericObjectConstructorParameterOrderDiff<String, Integer> actual = SUT.giveMeOne(
+			new TypeReference<TwoGenericObjectConstructorParameterOrderDiff<String, Integer>>() {
+			});
+
+		then(actual.getValue1()).isExactlyInstanceOf(String.class);
+		then(actual.getValue2()).isExactlyInstanceOf(Integer.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void twoGenericObjectConstructorParameterOrderDiffNameDiff() {
+		TwoGenericObjectConstructorParameterOrderDiffNameDiff<String, Integer> actual = SUT.giveMeOne(
+			new TypeReference<TwoGenericObjectConstructorParameterOrderDiffNameDiff<String, Integer>>() {
+			});
+
+		then(actual.getValue1()).isExactlyInstanceOf(String.class);
+		then(actual.getValue2()).isExactlyInstanceOf(Integer.class);
+	}
+}


### PR DESCRIPTION
## Summary
Add PriorityConstructorArbitraryIntrospector

## How Has This Been Tested?
- PriorityConstructorArbitraryIntrospectorTest#sample
- PriorityConstructorArbitraryIntrospectorTest#setWithoutName
- PriorityConstructorArbitraryIntrospectorTest#sample
- PriorityConstructorArbitraryIntrospectorTest#set
- PriorityConstructorArbitraryIntrospectorTest#genericType
- PriorityConstructorArbitraryIntrospectorTest#twoGenericType
- PriorityConstructorArbitraryIntrospectorTest#twoGenericObjectConstructorParameterOrderDiff
- PriorityConstructorArbitraryIntrospectorTest#twoGenericObjectConstructorParameterOrderDiffNameDiff

## Is the Document updated?
Yes
