### PR TITLE
Refactor scoped context

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/ObjectBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/ObjectBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * It is for internal use as a marker interface in 1.1.0.
+ * Please do not use it directly.
+ *
+ * @param <T> the type to generate
+ */
+@API(since = "1.1.0", status = Status.INTERNAL)
+public interface ObjectBuilder<T> {
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
@@ -18,21 +18,34 @@
 
 package com.navercorp.fixturemonkey.api.context;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.ObjectBuilder;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
+import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class MonkeyContextBuilder {
+	private final FixtureMonkeyOptions fixtureMonkeyOptions;
+
 	private ConcurrentLruCache<Property, CombinableArbitrary<?>> arbitrariesByProperty;
 	private ConcurrentLruCache<Property, CombinableArbitrary<?>> javaArbitrariesByProperty;
 	private ConcurrentLruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
+	private List<MatcherOperator<? extends ObjectBuilder<?>>> registeredObjectBuilders;
 	private int cacheSize = 2048;
 	private int generatorContextSize = 1000;
+
+	public MonkeyContextBuilder(FixtureMonkeyOptions fixtureMonkeyOptions) {
+		this.fixtureMonkeyOptions = fixtureMonkeyOptions;
+	}
 
 	public MonkeyContextBuilder arbitrariesByProperty(
 		ConcurrentLruCache<Property, CombinableArbitrary<?>> arbitrariesByProperty
@@ -65,6 +78,13 @@ public final class MonkeyContextBuilder {
 		return this;
 	}
 
+	public MonkeyContextBuilder registeredObjectBuilder(
+		List<MatcherOperator<? extends ObjectBuilder<?>>> registeredObjectBuilders
+	) {
+		this.registeredObjectBuilders = registeredObjectBuilders;
+		return this;
+	}
+
 	public MonkeyContext build() {
 		if (arbitrariesByProperty == null) {
 			arbitrariesByProperty = new ConcurrentLruCache<>(cacheSize);
@@ -78,10 +98,16 @@ public final class MonkeyContextBuilder {
 			generatorContextByRootProperty = new ConcurrentLruCache<>(generatorContextSize);
 		}
 
+		if (registeredObjectBuilders == null) {
+			registeredObjectBuilders = new ArrayList<>();
+		}
+
 		return new MonkeyContext(
 			arbitrariesByProperty,
 			javaArbitrariesByProperty,
-			generatorContextByRootProperty
+			generatorContextByRootProperty,
+			registeredObjectBuilders,
+			fixtureMonkeyOptions
 		);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyGeneratorContext.java
@@ -25,8 +25,13 @@ import java.util.SortedMap;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
 import com.navercorp.fixturemonkey.api.property.PropertyPath;
 
+/**
+ * It is the same context as {@code TraverseContext}, but exposed as public by {@link ArbitraryGeneratorContext}.
+ * It focuses mainly on generation.
+ */
 @API(since = "0.4.3", status = Status.MAINTAINED)
 public final class MonkeyGeneratorContext {
 	private final SortedMap<PropertyPath, Set<Object>> uniqueSetsByProperty;

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -34,11 +34,8 @@ import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntr
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin
-import com.navercorp.fixturemonkey.api.property.CandidateConcretePropertyResolver
 import com.navercorp.fixturemonkey.api.property.ConcreteTypeCandidateConcretePropertyResolver
-import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyUtils
-import com.navercorp.fixturemonkey.api.type.Types
 import com.navercorp.fixturemonkey.api.type.Types.GeneratingWildcardType
 import com.navercorp.fixturemonkey.customizer.Values
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -20,7 +20,6 @@ package com.navercorp.fixturemonkey;
 
 import static java.util.stream.Collectors.toList;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -30,6 +29,7 @@ import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitrary;
 
+import com.navercorp.fixturemonkey.api.ObjectBuilder;
 import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
@@ -50,19 +50,17 @@ public final class FixtureMonkey {
 	private final FixtureMonkeyOptions fixtureMonkeyOptions;
 	private final ManipulatorOptimizer manipulatorOptimizer;
 	private final MonkeyContext monkeyContext;
-	private final List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredArbitraryBuilders = new ArrayList<>();
 	private final MonkeyManipulatorFactory monkeyManipulatorFactory;
 
 	public FixtureMonkey(
 		FixtureMonkeyOptions fixtureMonkeyOptions,
 		ManipulatorOptimizer manipulatorOptimizer,
-		MonkeyContext monkeyContext,
 		List<MatcherOperator<Function<FixtureMonkey, ? extends ArbitraryBuilder<?>>>> registeredArbitraryBuilders,
 		MonkeyManipulatorFactory monkeyManipulatorFactory
 	) {
 		this.fixtureMonkeyOptions = fixtureMonkeyOptions;
 		this.manipulatorOptimizer = manipulatorOptimizer;
-		this.monkeyContext = monkeyContext;
+		this.monkeyContext = MonkeyContext.builder(fixtureMonkeyOptions).build();
 		this.monkeyManipulatorFactory = monkeyManipulatorFactory;
 		initializeRegisteredArbitraryBuilders(registeredArbitraryBuilders);
 	}
@@ -84,52 +82,44 @@ public final class FixtureMonkey {
 	public <T> ArbitraryBuilder<T> giveMeBuilder(TypeReference<T> type) {
 		RootProperty rootProperty = new RootProperty(type.getAnnotatedType());
 
-		ArbitraryBuilderContext builderContext = registeredArbitraryBuilders.stream()
+		ArbitraryBuilderContext builderContext = monkeyContext.getRegisteredArbitraryBuilders().stream()
 			.filter(it -> it.match(rootProperty))
 			.map(MatcherOperator::getOperator)
 			.findAny()
 			.map(DefaultArbitraryBuilder.class::cast)
 			.map(DefaultArbitraryBuilder::getContext)
-			.orElse(new ArbitraryBuilderContext());
+			.orElse(ArbitraryBuilderContext.newBuilderContext(monkeyContext));
 
 		return new DefaultArbitraryBuilder<>(
-			fixtureMonkeyOptions,
 			rootProperty,
 			new ArbitraryResolver(
 				manipulatorOptimizer,
 				monkeyManipulatorFactory,
-				fixtureMonkeyOptions,
-				monkeyContext,
-				registeredArbitraryBuilders
+				monkeyContext
 			),
 			monkeyManipulatorFactory,
 			builderContext.copy(),
-			registeredArbitraryBuilders,
 			monkeyContext,
 			fixtureMonkeyOptions.getInstantiatorProcessor()
 		);
 	}
 
 	public <T> ArbitraryBuilder<T> giveMeBuilder(T value) {
-		ArbitraryBuilderContext context = new ArbitraryBuilderContext();
+		ArbitraryBuilderContext context = ArbitraryBuilderContext.newBuilderContext(monkeyContext);
 
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator("$", value);
 		context.addManipulator(arbitraryManipulator);
 
 		return new DefaultArbitraryBuilder<>(
-			fixtureMonkeyOptions,
 			new RootProperty(new LazyAnnotatedType<>(() -> value)),
 			new ArbitraryResolver(
 				manipulatorOptimizer,
 				monkeyManipulatorFactory,
-				fixtureMonkeyOptions,
-				monkeyContext,
-				registeredArbitraryBuilders
+				monkeyContext
 			),
 			monkeyManipulatorFactory,
 			context,
-			registeredArbitraryBuilders,
 			monkeyContext,
 			fixtureMonkeyOptions.getInstantiatorProcessor()
 		);
@@ -186,13 +176,13 @@ public final class FixtureMonkey {
 	private void initializeRegisteredArbitraryBuilders(
 		List<MatcherOperator<Function<FixtureMonkey, ? extends ArbitraryBuilder<?>>>> registeredArbitraryBuilders
 	) {
-		List<? extends MatcherOperator<? extends ArbitraryBuilder<?>>> generatedRegisteredArbitraryBuilder =
+		List<? extends MatcherOperator<? extends ObjectBuilder<?>>> generatedRegisteredArbitraryBuilder =
 			registeredArbitraryBuilders.stream()
-				.map(it -> new MatcherOperator<>(it.getMatcher(), it.getOperator().apply(this)))
+				.map(it -> new MatcherOperator<>(it.getMatcher(), (ObjectBuilder<?>)(it.getOperator().apply(this))))
 				.collect(toList());
 
 		for (int i = generatedRegisteredArbitraryBuilder.size() - 1; i >= 0; i--) {
-			this.registeredArbitraryBuilders.add(generatedRegisteredArbitraryBuilder.get(i));
+			monkeyContext.getRegisteredArbitraryBuilders().add(generatedRegisteredArbitraryBuilder.get(i));
 		}
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -32,8 +32,6 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator;
 import com.navercorp.fixturemonkey.api.container.DecomposedContainerValueFactory;
-import com.navercorp.fixturemonkey.api.context.MonkeyContext;
-import com.navercorp.fixturemonkey.api.context.MonkeyContextBuilder;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfoGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ContainerPropertyGenerator;
@@ -70,7 +68,6 @@ public final class FixtureMonkeyBuilder {
 		registeredArbitraryBuilders = new ArrayList<>();
 	private ManipulatorOptimizer manipulatorOptimizer = new NoneManipulatorOptimizer();
 	private MonkeyExpressionFactory monkeyExpressionFactory = new ArbitraryExpressionFactory();
-	private final MonkeyContextBuilder monkeyContextBuilder = MonkeyContext.builder();
 	private long seed = System.nanoTime();
 
 	public FixtureMonkeyBuilder pushPropertyGenerator(MatcherOperator<PropertyGenerator> propertyGenerator) {
@@ -489,12 +486,10 @@ public final class FixtureMonkeyBuilder {
 			fixtureMonkeyOptions.getDecomposedContainerValueFactory()
 		);
 
-		MonkeyContext monkeyContext = monkeyContextBuilder.build();
 		Randoms.create(String.valueOf(seed));
 		return new FixtureMonkey(
 			fixtureMonkeyOptions,
 			manipulatorOptimizer,
-			monkeyContext,
 			registeredArbitraryBuilders,
 			monkeyManipulatorFactory
 		);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/MonkeyManipulatorFactory.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/customizer/MonkeyManipulatorFactory.java
@@ -36,7 +36,7 @@ import org.apiguardian.api.API.Status;
 
 import net.jqwik.api.Arbitrary;
 
-import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.api.ObjectBuilder;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.container.DecomposedContainerValueFactory;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryContainerInfo;
@@ -138,7 +138,7 @@ public final class MonkeyManipulatorFactory {
 	}
 
 	public List<ArbitraryManipulator> newRegisteredArbitraryManipulators(
-		List<MatcherOperator<? extends ArbitraryBuilder<?>>> registeredArbitraryBuilders,
+		List<MatcherOperator<? extends ObjectBuilder<?>>> registeredArbitraryBuilders,
 		Map<Property, List<ObjectNode>> nodesByType
 	) {
 		List<ArbitraryManipulator> manipulators = new ArrayList<>();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
@@ -67,10 +67,14 @@ public final class ObjectNode implements ObjectTreeNode {
 	private static final ConcurrentLruCache<Property, List<Property>> CANDIDATE_CONCRETE_PROPERTIES_BY_PROPERTY =
 		new ConcurrentLruCache<>(1024);
 
+	private final RootProperty rootProperty;
+
 	@Nullable
 	private final Property resolvedParentProperty;
+	private final TreeProperty treeProperty;
+	private final TraverseContext traverseContext;
+
 	private Property resolvedProperty;
-	private TreeProperty treeProperty;
 	@Nullable
 	private ObjectNode parent = null;
 	private List<ObjectNode> children;
@@ -86,7 +90,7 @@ public final class ObjectNode implements ObjectTreeNode {
 		new ArrayList<>();
 
 	private final LazyArbitrary<Boolean> childNotCacheable = LazyArbitrary.lazy(() -> {
-		for (ObjectNode child : children) {
+		for (ObjectNode child : this.getChildren()) {
 			if (child.manipulated() || child.childNotCacheable.getValue() || child.treeProperty.isContainer()) {
 				return true;
 			}
@@ -107,22 +111,19 @@ public final class ObjectNode implements ObjectTreeNode {
 		);
 	});
 
-	private final FixtureMonkeyOptions fixtureMonkeyOptions;
-	private final TraverseContext traverseContext;
-
 	ObjectNode(
+		RootProperty rootProperty,
 		@Nullable Property resolvedParentProperty,
 		Property resolvedProperty,
 		TreeProperty treeProperty,
 		double nullInject,
-		FixtureMonkeyOptions fixtureMonkeyOptions,
 		TraverseContext traverseContext
 	) {
+		this.rootProperty = rootProperty;
 		this.resolvedParentProperty = resolvedParentProperty;
 		this.resolvedProperty = resolvedProperty;
 		this.treeProperty = treeProperty;
 		this.nullInject = nullInject;
-		this.fixtureMonkeyOptions = fixtureMonkeyOptions;
 		this.traverseContext = traverseContext;
 	}
 
@@ -147,10 +148,6 @@ public final class ObjectNode implements ObjectTreeNode {
 
 	public TreeProperty getTreeProperty() {
 		return this.treeProperty;
-	}
-
-	public void setTreeProperty(TreeProperty treeProperty) {
-		this.treeProperty = treeProperty;
 	}
 
 	/**
@@ -335,27 +332,27 @@ public final class ObjectNode implements ObjectTreeNode {
 
 	static ObjectNode generateRootNode(
 		RootProperty rootProperty,
-		FixtureMonkeyOptions fixtureMonkeyOptions,
 		TraverseContext traverseContext
 	) {
 		return ObjectNode.generateObjectNode(
+			rootProperty,
 			null,
 			rootProperty,
 			null,
 			0.0d,
-			fixtureMonkeyOptions,
 			traverseContext
 		);
 	}
 
 	static ObjectNode generateObjectNode(
+		RootProperty rootProperty,
 		@Nullable Property resolvedParentProperty,
 		Property property,
 		@Nullable Integer propertySequence,
 		double parentNullInject,
-		FixtureMonkeyOptions fixtureMonkeyOptions,
 		TraverseContext context
 	) {
+		FixtureMonkeyOptions fixtureMonkeyOptions = context.getMonkeyContext().getFixtureMonkeyOptions();
 		ContainerPropertyGenerator containerPropertyGenerator =
 			fixtureMonkeyOptions.getContainerPropertyGenerator(property);
 		boolean container = containerPropertyGenerator != null;
@@ -443,11 +440,11 @@ public final class ObjectNode implements ObjectTreeNode {
 		TraverseContext nextTraverseContext = context.appendArbitraryProperty(treeProperty);
 
 		ObjectNode newObjectNode = new ObjectNode(
+			rootProperty,
 			resolvedParentProperty,
 			new CompositeTypeDefinition(typeDefinitions).getResolvedProperty(),
 			treeProperty,
 			nullInject,
-			fixtureMonkeyOptions,
 			nextTraverseContext
 		);
 
@@ -503,11 +500,11 @@ public final class ObjectNode implements ObjectTreeNode {
 			}
 
 			ObjectNode childNode = generateObjectNode(
+				rootProperty,
 				resolvedParentProperty,
 				childProperty,
 				sequence,
 				parentNullInject,
-				this.fixtureMonkeyOptions,
 				context
 			);
 			children.add(childNode);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -42,51 +42,28 @@ import com.navercorp.fixturemonkey.api.generator.CompositeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.IntrospectedArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ValidateArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
-import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
 import com.navercorp.fixturemonkey.api.type.Types;
-import com.navercorp.fixturemonkey.customizer.ContainerInfoManipulator;
 import com.navercorp.fixturemonkey.customizer.NodeManipulator;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ObjectTree {
 	private final RootProperty rootProperty;
 	private final ObjectNode rootNode;
-	private final FixtureMonkeyOptions fixtureMonkeyOptions;
 	private final ObjectTreeMetadata metadata;
-	private final MonkeyContext monkeyContext;
-	private final boolean validOnly;
-	private final Map<Class<?>, ArbitraryIntrospector> arbitraryIntrospectorConfigurer;
+	private final TraverseContext traverseContext;
 
 	public ObjectTree(
 		RootProperty rootProperty,
-		FixtureMonkeyOptions fixtureMonkeyOptions,
-		MonkeyContext monkeyContext,
-		boolean validOnly,
-		Map<Class<?>, ArbitraryIntrospector> arbitraryIntrospectorConfigurer,
-		List<ContainerInfoManipulator> containerInfoManipulators,
-		Map<Class<?>, List<Property>> propertyConfigurers,
-		List<MatcherOperator<List<ContainerInfoManipulator>>> registeredContainerInfoManipulators
+		TraverseContext traverseContext
 	) {
 		this.rootProperty = rootProperty;
-		this.fixtureMonkeyOptions = fixtureMonkeyOptions;
-		this.monkeyContext = monkeyContext;
-		this.rootNode = ObjectNode.generateRootNode(
-			rootProperty,
-			fixtureMonkeyOptions,
-			new TraverseContext(
-				new ArrayList<>(),
-				containerInfoManipulators,
-				registeredContainerInfoManipulators,
-				propertyConfigurers
-			)
-		);
+		this.traverseContext = traverseContext;
+		this.rootNode = ObjectNode.generateRootNode(rootProperty, traverseContext);
 		MetadataCollector metadataCollector = new MetadataCollector(rootNode);
 		this.metadata = metadataCollector.collect();
-		this.validOnly = validOnly;
-		this.arbitraryIntrospectorConfigurer = arbitraryIntrospectorConfigurer;
 	}
 
 	public ObjectTreeMetadata getMetadata() {
@@ -124,7 +101,10 @@ public final class ObjectTree {
 			childrenProperties.add(childNode.getArbitraryProperty());
 		}
 
-		MonkeyGeneratorContext monkeyGeneratorContext = monkeyContext.retrieveGeneratorContext(rootProperty);
+		MonkeyContext monkeyContext = traverseContext.getMonkeyContext();
+		MonkeyGeneratorContext monkeyGeneratorContext = monkeyContext.newGeneratorContext(rootProperty);
+		FixtureMonkeyOptions fixtureMonkeyOptions = monkeyContext.getFixtureMonkeyOptions();
+
 		return new ArbitraryGeneratorContext(
 			resolvedParentProperty,
 			arbitraryProperty,
@@ -150,6 +130,11 @@ public final class ObjectTree {
 		ObjectNode node,
 		@Nullable ArbitraryGeneratorContext currentContext
 	) {
+		MonkeyContext monkeyContext = traverseContext.getMonkeyContext();
+		Map<Class<?>, ArbitraryIntrospector> arbitraryIntrospectorConfigurer =
+			traverseContext.getArbitraryIntrospectorConfigurer();
+		FixtureMonkeyOptions fixtureMonkeyOptions = monkeyContext.getFixtureMonkeyOptions();
+
 		CombinableArbitrary<?> generated;
 		if (node.getArbitrary() != null) {
 			generated = node.getArbitrary()
@@ -192,8 +177,10 @@ public final class ObjectTree {
 	}
 
 	private ArbitraryGenerator getArbitraryGenerator(@Nullable ArbitraryIntrospector arbitraryIntrospector) {
-		ArbitraryGenerator arbitraryGenerator = this.fixtureMonkeyOptions.getDefaultArbitraryGenerator();
+		FixtureMonkeyOptions fixtureMonkeyOptions = traverseContext.getMonkeyContext().getFixtureMonkeyOptions();
+		ArbitraryGenerator arbitraryGenerator = fixtureMonkeyOptions.getDefaultArbitraryGenerator();
 
+		boolean validOnly = traverseContext.isValidOnly();
 		if (arbitraryIntrospector != null) {
 			arbitraryGenerator = new CompositeArbitraryGenerator(
 				Arrays.asList(
@@ -208,8 +195,8 @@ public final class ObjectTree {
 				Arrays.asList(
 					arbitraryGenerator,
 					new ValidateArbitraryGenerator(
-						this.fixtureMonkeyOptions.getJavaConstraintGenerator(),
-						this.fixtureMonkeyOptions.getDecomposedContainerValueFactory()
+						fixtureMonkeyOptions.getJavaConstraintGenerator(),
+						fixtureMonkeyOptions.getDecomposedContainerValueFactory()
 					)
 				)
 			);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/TraverseContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/TraverseContext.java
@@ -29,29 +29,52 @@ import javax.annotation.Nullable;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.context.MonkeyContext;
+import com.navercorp.fixturemonkey.api.introspector.ArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.tree.TreeProperty;
 import com.navercorp.fixturemonkey.customizer.ContainerInfoManipulator;
 
+/**
+ * {@link FixtureMonkey} → {@link ArbitraryBuilder} → {@link ObjectTree} → {@link CombinableArbitrary}
+ * 						1:N							1:N					1:1
+ * <p>
+ * It is a context within {@link ObjectTree}. It represents a status of the {@link ObjectTree}.
+ * The {@link ObjectTree} should be the same if the {@link TraverseContext} is the same.
+ * <p>
+ * It is for internal use only. It can be changed or removed at any time.
+ */
 @API(since = "0.4.0", status = Status.INTERNAL)
-final class TraverseContext {
+public final class TraverseContext {
 	private final List<TreeProperty> treeProperties;
 	private final List<ContainerInfoManipulator> containerInfoManipulators;
 	private final List<MatcherOperator<List<ContainerInfoManipulator>>> registeredContainerInfoManipulators;
 	private final Map<Class<?>, List<Property>> propertyConfigurers;
+	private final Map<Class<?>, ArbitraryIntrospector> arbitraryIntrospectorConfigurer;
+	private final boolean validOnly;
+	private final MonkeyContext monkeyContext;
 
-	TraverseContext(
+	public TraverseContext(
 		List<TreeProperty> treeProperties,
 		List<ContainerInfoManipulator> containerInfoManipulators,
 		List<MatcherOperator<List<ContainerInfoManipulator>>> registeredContainerInfoManipulators,
-		Map<Class<?>, List<Property>> propertyConfigurers
+		Map<Class<?>, List<Property>> propertyConfigurers,
+		Map<Class<?>, ArbitraryIntrospector> arbitraryIntrospectorConfigurer,
+		boolean validOnly,
+		MonkeyContext monkeyContext
 	) {
 		this.treeProperties = treeProperties;
 		this.containerInfoManipulators = containerInfoManipulators;
 		this.registeredContainerInfoManipulators = registeredContainerInfoManipulators;
 		this.propertyConfigurers = propertyConfigurers;
+		this.arbitraryIntrospectorConfigurer = arbitraryIntrospectorConfigurer;
+		this.validOnly = validOnly;
+		this.monkeyContext = monkeyContext;
 	}
 
 	@Nullable
@@ -69,6 +92,18 @@ final class TraverseContext {
 
 	public Map<Class<?>, List<Property>> getPropertyConfigurers() {
 		return propertyConfigurers;
+	}
+
+	public Map<Class<?>, ArbitraryIntrospector> getArbitraryIntrospectorConfigurer() {
+		return arbitraryIntrospectorConfigurer;
+	}
+
+	public boolean isValidOnly() {
+		return validOnly;
+	}
+
+	public MonkeyContext getMonkeyContext() {
+		return monkeyContext;
 	}
 
 	public TraverseContext appendArbitraryProperty(
@@ -97,7 +132,10 @@ final class TraverseContext {
 			treeProperties,
 			concat,
 			this.registeredContainerInfoManipulators,
-			propertyConfigurers
+			propertyConfigurers,
+			this.arbitraryIntrospectorConfigurer,
+			this.validOnly,
+			this.monkeyContext
 		);
 	}
 
@@ -131,7 +169,10 @@ final class TraverseContext {
 			newArbitraryPropertyList,
 			new ArrayList<>(this.containerInfoManipulators),
 			this.registeredContainerInfoManipulators,
-			this.propertyConfigurers
+			this.propertyConfigurers,
+			this.arbitraryIntrospectorConfigurer,
+			this.validOnly,
+			this.monkeyContext
 		);
 	}
 


### PR DESCRIPTION
## Summary
Refactor scoped context

## Description
Each component has a context and contexts have a hierarchy. A child context has a reference to the parent context, the parent context does not have a reference to the child context.

- FixtureMonkey → `MonkeyContext`
- ArbitrayBuilder → `ArbitraryBuilderContext`
- ObjectTree → `TraverseContext`

![image](https://github.com/user-attachments/assets/9442f33e-0e5c-41c7-bdf6-5f05c78463b4)

## How Has This Been Tested?
* existing tests

## Is the Document updated?
No needed
