### PR TITLE
Extend MatcherOperator to manage ArbitraryBuilders with a single variable

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/MatcherOperator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/MatcherOperator.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
-public final class MatcherOperator<T> implements Matcher {
+public class MatcherOperator<T> implements Matcher {
 	private final Matcher matcher;
 	private final T operator;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/NamedMatcherOperator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/NamedMatcherOperator.java
@@ -1,0 +1,49 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.matcher;
+
+import com.navercorp.fixturemonkey.api.property.Property;
+
+public final class NamedMatcherOperator<T> extends MatcherOperator<T> {
+	private final String registeredName;
+	private boolean active;
+
+	public NamedMatcherOperator(Matcher matcher, T operator, String name) {
+		super(matcher, operator);
+		this.registeredName = name;
+		this.active = false;
+	}
+
+	public String getRegisteredName() {
+		return registeredName;
+	}
+
+	public void activate() {
+		this.active = true;
+	}
+
+	public void deactivate() {
+		this.active = false;
+	}
+
+	@Override
+	public boolean match(Property property) {
+		return active && super.match(property);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/NamedMatcherOperatorAdapter.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/matcher/NamedMatcherOperatorAdapter.java
@@ -1,0 +1,26 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.matcher;
+
+
+public final class NamedMatcherOperatorAdapter {
+	public static <T> NamedMatcherOperator<T> adapt(Matcher matcher, T operator, String name) {
+		return new NamedMatcherOperator<>(matcher, operator, name);
+	}
+}


### PR DESCRIPTION
## Summary
- Extending MatcherOperator for improved ArbitraryBuilder management

## (Optional): Description
- Implementing a **new subclass of MatcherOperator** with an `active` boolean field to dynamically manage selection states based on user input
- initializing `active` as false in giveMeBuilder and updating it in selectName method when names match.
## How Has This Been Tested?
- existing tests
## Is the Document updated?
No needed
