### PR TITLE
Add enableLoggingFail option for failed introspect to FixtureMonkeyOptions

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -60,6 +60,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 	private final int generateUniqueMaxTries;
 	private final AtomicReference<CombinableArbitrary<?>> generated =
 		new AtomicReference<>(CombinableArbitrary.NOT_GENERATED);
+	private final boolean enableLoggingFail;
 
 	public ArbitraryGeneratorContext(
 		Property resolvedProperty,
@@ -69,7 +70,8 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, CombinableArbitrary<?>> resolveArbitrary,
 		LazyArbitrary<PropertyPath> lazyPropertyPath,
 		MonkeyGeneratorContext monkeyGeneratorContext,
-		int generateUniqueMaxTries
+		int generateUniqueMaxTries,
+		boolean enableLoggingFail
 	) {
 		this.resolvedProperty = resolvedProperty;
 		this.property = property;
@@ -79,6 +81,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		this.lazyPropertyPath = lazyPropertyPath;
 		this.monkeyGeneratorContext = monkeyGeneratorContext;
 		this.generateUniqueMaxTries = generateUniqueMaxTries;
+		this.enableLoggingFail = enableLoggingFail;
 	}
 
 	public ArbitraryProperty getArbitraryProperty() {
@@ -147,6 +150,10 @@ public final class ArbitraryGeneratorContext implements Traceable {
 
 	public int getGenerateUniqueMaxTries() {
 		return generateUniqueMaxTries;
+	}
+
+	public boolean getEnableLoggingFail() {
+		return enableLoggingFail;
 	}
 
 	public CombinableArbitrary<?> getGenerated() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -66,7 +66,9 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				if (context.getEnableLoggingFail()) {
+					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
 			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -90,7 +90,9 @@ public final class BuilderArbitraryIntrospector implements ArbitraryIntrospector
 				}
 			);
 		} catch (Exception ex) {
-			LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+			if (context.getEnableLoggingFail()) {
+				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+			}
 			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 		Method builderMethod = BUILDER_CACHE.get(type);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
@@ -68,11 +68,13 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 
 		Entry<Constructor<?>, String[]> parameterNamesByConstructor = TypeCache.getParameterNamesByConstructor(type);
 		if (parameterNamesByConstructor == null) {
-			LOGGER.warn(
-				"Given type {} is failed to generate due to the exception. It may be null.",
-				type,
-				new IllegalArgumentException("Primary Constructor does not exist. type " + type.getSimpleName())
-			);
+			if (context.getEnableLoggingFail()) {
+				LOGGER.warn(
+					"Given type {} is failed to generate due to the exception. It may be null.",
+					type,
+					new IllegalArgumentException("Primary Constructor does not exist. type " + type.getSimpleName())
+				);
+			}
 			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
@@ -57,7 +57,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 					results.add(new FailoverIntrospectorResult(introspector, result));
 				}
 			} catch (Exception ex) {
-				if (enableLoggingFail) {
+				if (context.getEnableLoggingFail() || enableLoggingFail) {
 					LOGGER.warn(
 						String.format(
 							"\"%s\" is failed to introspect \"%s\" type.",
@@ -85,7 +85,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().combined();
 						} catch (Exception ex) {
-							if (enableLoggingFail) {
+							if (context.getEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect \"%s\" type.",
@@ -115,7 +115,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().rawValue();
 						} catch (Exception ex) {
-							if (enableLoggingFail) {
+							if (context.getEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect type \"%s\"",

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -62,7 +62,9 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				if (context.getEnableLoggingFail()) {
+					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
 			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
@@ -169,6 +169,7 @@ public final class FixtureMonkeyOptions {
 	private final JavaConstraintGenerator javaConstraintGenerator;
 	private final InstantiatorProcessor instantiatorProcessor;
 	private final List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers;
+	private final boolean enableLoggingFail;
 
 	public FixtureMonkeyOptions(
 		List<MatcherOperator<PropertyGenerator>> propertyGenerators,
@@ -189,7 +190,8 @@ public final class FixtureMonkeyOptions {
 		int generateUniqueMaxTries,
 		JavaConstraintGenerator javaConstraintGenerator,
 		InstantiatorProcessor instantiatorProcessor,
-		List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers
+		List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers,
+		boolean enableLoggingFail
 	) {
 		this.propertyGenerators = propertyGenerators;
 		this.defaultPropertyGenerator = defaultPropertyGenerator;
@@ -210,6 +212,7 @@ public final class FixtureMonkeyOptions {
 		this.javaConstraintGenerator = javaConstraintGenerator;
 		this.instantiatorProcessor = instantiatorProcessor;
 		this.candidateConcretePropertyResolvers = candidateConcretePropertyResolvers;
+		this.enableLoggingFail = enableLoggingFail;
 	}
 
 	public static FixtureMonkeyOptionsBuilder builder() {
@@ -349,6 +352,10 @@ public final class FixtureMonkeyOptions {
 
 	public InstantiatorProcessor getInstantiatorProcessor() {
 		return instantiatorProcessor;
+	}
+
+	public boolean isEnableLoggingFail() {
+		return enableLoggingFail;
 	}
 
 	@Nullable

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -108,6 +108,7 @@ public final class FixtureMonkeyOptionsBuilder {
 	private boolean defaultNotNull = false;
 	private boolean nullableContainer = false;
 	private boolean nullableElement = false;
+	private boolean enableLoggingFail = true;
 	private UnaryOperator<NullInjectGenerator> defaultNullInjectGeneratorOperator = it -> it;
 	private ArbitraryValidator defaultArbitraryValidator = (obj) -> {
 	};
@@ -453,6 +454,11 @@ public final class FixtureMonkeyOptionsBuilder {
 		return this;
 	}
 
+	public FixtureMonkeyOptionsBuilder enableLoggingFail(boolean enableLoggingFail) {
+		this.enableLoggingFail = enableLoggingFail;
+		return this;
+	}
+
 	public FixtureMonkeyOptionsBuilder defaultArbitraryValidator(ArbitraryValidator arbitraryValidator) {
 		this.defaultArbitraryValidator = arbitraryValidator;
 		return this;
@@ -664,7 +670,8 @@ public final class FixtureMonkeyOptionsBuilder {
 			this.generateUniqueMaxTries,
 			resolvedJavaConstraintGenerator,
 			this.instantiatorProcessor,
-			this.candidateConcretePropertyResolvers
+			this.candidateConcretePropertyResolvers,
+			this.enableLoggingFail
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -450,6 +450,11 @@ public final class FixtureMonkeyBuilder {
 		return this;
 	}
 
+	public FixtureMonkeyBuilder enableLoggingFail(boolean enableLoggingFail) {
+		this.fixtureMonkeyOptionsBuilder.enableLoggingFail(enableLoggingFail);
+		return this;
+	}
+
 	/**
 	 * It is deprecated. Please use {@link InterfacePlugin#interfaceImplements(Matcher, List)} instead.
 	 */

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -127,7 +127,8 @@ public final class ObjectTree {
 			},
 			objectNode.getLazyPropertyPath(),
 			monkeyGeneratorContext,
-			fixtureMonkeyOptions.getGenerateUniqueMaxTries()
+			fixtureMonkeyOptions.getGenerateUniqueMaxTries(),
+			fixtureMonkeyOptions.isEnableLoggingFail()
 		);
 	}
 


### PR DESCRIPTION
## Summary
add enableLoggingFail option for failed introspect warning log.
[#1066](https://github.com/naver/fixture-monkey/issues/1066)

## (Optional): Description
* I used `||` due to overlapping parts with the existing `enableLoggingFail` option in the `FailoverIntrospector`.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
* I also think it overlaps with the existing `enableLoggingFail` option, so I have omitted it for now.
