### PR TITLE
Add enableLoggingFail option for failed introspect to FixtureMonkeyOptions

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -60,6 +60,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 	private final int generateUniqueMaxTries;
 	private final AtomicReference<CombinableArbitrary<?>> generated =
 		new AtomicReference<>(CombinableArbitrary.NOT_GENERATED);
+	private final boolean enableLoggingFail;
 
 	public ArbitraryGeneratorContext(
 		Property resolvedProperty,
@@ -69,7 +70,8 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		BiFunction<ArbitraryGeneratorContext, ArbitraryProperty, CombinableArbitrary<?>> resolveArbitrary,
 		LazyArbitrary<PropertyPath> lazyPropertyPath,
 		MonkeyGeneratorContext monkeyGeneratorContext,
-		int generateUniqueMaxTries
+		int generateUniqueMaxTries,
+		boolean enableLoggingFail
 	) {
 		this.resolvedProperty = resolvedProperty;
 		this.property = property;
@@ -79,6 +81,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		this.lazyPropertyPath = lazyPropertyPath;
 		this.monkeyGeneratorContext = monkeyGeneratorContext;
 		this.generateUniqueMaxTries = generateUniqueMaxTries;
+		this.enableLoggingFail = enableLoggingFail;
 	}
 
 	public ArbitraryProperty getArbitraryProperty() {
@@ -147,6 +150,10 @@ public final class ArbitraryGeneratorContext implements Traceable {
 
 	public int getGenerateUniqueMaxTries() {
 		return generateUniqueMaxTries;
+	}
+
+	public boolean isEnableLoggingFail() {
+		return enableLoggingFail;
 	}
 
 	public CombinableArbitrary<?> getGenerated() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorContext.java
@@ -60,7 +60,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 	private final int generateUniqueMaxTries;
 	private final AtomicReference<CombinableArbitrary<?>> generated =
 		new AtomicReference<>(CombinableArbitrary.NOT_GENERATED);
-	private final boolean enableLoggingFail;
+	private final ArbitraryGeneratorLoggingContext loggingContext;
 
 	public ArbitraryGeneratorContext(
 		Property resolvedProperty,
@@ -71,7 +71,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		LazyArbitrary<PropertyPath> lazyPropertyPath,
 		MonkeyGeneratorContext monkeyGeneratorContext,
 		int generateUniqueMaxTries,
-		boolean enableLoggingFail
+		ArbitraryGeneratorLoggingContext loggingContext
 	) {
 		this.resolvedProperty = resolvedProperty;
 		this.property = property;
@@ -81,7 +81,7 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		this.lazyPropertyPath = lazyPropertyPath;
 		this.monkeyGeneratorContext = monkeyGeneratorContext;
 		this.generateUniqueMaxTries = generateUniqueMaxTries;
-		this.enableLoggingFail = enableLoggingFail;
+		this.loggingContext = loggingContext;
 	}
 
 	public ArbitraryProperty getArbitraryProperty() {
@@ -152,8 +152,8 @@ public final class ArbitraryGeneratorContext implements Traceable {
 		return generateUniqueMaxTries;
 	}
 
-	public boolean isEnableLoggingFail() {
-		return enableLoggingFail;
+	public ArbitraryGeneratorLoggingContext getLoggingContext() {
+		return loggingContext;
 	}
 
 	public CombinableArbitrary<?> getGenerated() {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorLoggingContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorLoggingContext.java
@@ -1,6 +1,27 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.navercorp.fixturemonkey.api.generator;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 
+@API(since = "1.0.28", status = Status.EXPERIMENTAL)
 public final class ArbitraryGeneratorLoggingContext {
 	private final boolean enableLoggingFail;
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorLoggingContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ArbitraryGeneratorLoggingContext.java
@@ -1,0 +1,14 @@
+package com.navercorp.fixturemonkey.api.generator;
+
+
+public final class ArbitraryGeneratorLoggingContext {
+	private final boolean enableLoggingFail;
+
+	public ArbitraryGeneratorLoggingContext(boolean enableLoggingFail) {
+		this.enableLoggingFail = enableLoggingFail;
+	}
+
+	public boolean isEnableLoggingFail() {
+		return enableLoggingFail;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitraryDelegator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
@@ -66,7 +67,8 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				if (context.isEnableLoggingFail()) {
+				ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+				if (loggingContext.isEnableLoggingFail()) {
 					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
 				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BeanArbitraryIntrospector.java
@@ -66,7 +66,9 @@ public final class BeanArbitraryIntrospector implements ArbitraryIntrospector {
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				if (context.isEnableLoggingFail()) {
+					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
 			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.CompositeProperty;
@@ -90,7 +91,8 @@ public final class BuilderArbitraryIntrospector implements ArbitraryIntrospector
 				}
 			);
 		} catch (Exception ex) {
-			if (context.isEnableLoggingFail()) {
+			ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+			if (loggingContext.isEnableLoggingFail()) {
 				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
 			}
 			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/BuilderArbitraryIntrospector.java
@@ -90,7 +90,9 @@ public final class BuilderArbitraryIntrospector implements ArbitraryIntrospector
 				}
 			);
 		} catch (Exception ex) {
-			LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+			if (context.isEnableLoggingFail()) {
+				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+			}
 			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 		Method builderMethod = BUILDER_CACHE.get(type);

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
@@ -68,11 +68,13 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 
 		Entry<Constructor<?>, String[]> parameterNamesByConstructor = TypeCache.getParameterNamesByConstructor(type);
 		if (parameterNamesByConstructor == null) {
-			LOGGER.warn(
-				"Given type {} is failed to generate due to the exception. It may be null.",
-				type,
-				new IllegalArgumentException("Primary Constructor does not exist. type " + type.getSimpleName())
-			);
+			if (context.isEnableLoggingFail()) {
+				LOGGER.warn(
+					"Given type {} is failed to generate due to the exception. It may be null.",
+					type,
+					new IllegalArgumentException("Primary Constructor does not exist. type " + type.getSimpleName())
+				);
+			}
 			return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ConstructorPropertiesArbitraryIntrospector.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.ConstructorParameterPropertyGenerator;
 import com.navercorp.fixturemonkey.api.property.Property;
@@ -68,7 +69,8 @@ public final class ConstructorPropertiesArbitraryIntrospector implements Arbitra
 
 		Entry<Constructor<?>, String[]> parameterNamesByConstructor = TypeCache.getParameterNamesByConstructor(type);
 		if (parameterNamesByConstructor == null) {
-			if (context.isEnableLoggingFail()) {
+			ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+			if (loggingContext.isEnableLoggingFail()) {
 				LOGGER.warn(
 					"Given type {} is failed to generate due to the exception. It may be null.",
 					type,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 
 @API(since = "0.6.0", status = Status.MAINTAINED)
 public final class FailoverIntrospector implements ArbitraryIntrospector {
@@ -57,7 +58,8 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 					results.add(new FailoverIntrospectorResult(introspector, result));
 				}
 			} catch (Exception ex) {
-				if (context.isEnableLoggingFail() || enableLoggingFail) {
+				ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+				if (loggingContext.isEnableLoggingFail() || enableLoggingFail) {
 					LOGGER.warn(
 						String.format(
 							"\"%s\" is failed to introspect \"%s\" type.",
@@ -85,7 +87,8 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().combined();
 						} catch (Exception ex) {
-							if (context.isEnableLoggingFail() || enableLoggingFail) {
+							ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+							if (loggingContext.isEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect \"%s\" type.",
@@ -115,7 +118,8 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().rawValue();
 						} catch (Exception ex) {
-							if (context.isEnableLoggingFail() || enableLoggingFail) {
+							ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+							if (loggingContext.isEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect type \"%s\"",

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FailoverIntrospector.java
@@ -57,7 +57,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 					results.add(new FailoverIntrospectorResult(introspector, result));
 				}
 			} catch (Exception ex) {
-				if (enableLoggingFail) {
+				if (context.isEnableLoggingFail() || enableLoggingFail) {
 					LOGGER.warn(
 						String.format(
 							"\"%s\" is failed to introspect \"%s\" type.",
@@ -85,7 +85,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().combined();
 						} catch (Exception ex) {
-							if (enableLoggingFail) {
+							if (context.isEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect \"%s\" type.",
@@ -115,7 +115,7 @@ public final class FailoverIntrospector implements ArbitraryIntrospector {
 							result = iterator.next();
 							return result.getResult().getValue().rawValue();
 						} catch (Exception ex) {
-							if (enableLoggingFail) {
+							if (context.isEnableLoggingFail() || enableLoggingFail) {
 								LOGGER.warn(
 									String.format(
 										"\"%s\" is failed to introspect type \"%s\"",

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -62,7 +62,9 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				if (context.isEnableLoggingFail()) {
+					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
+				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;
 			}
 			generated = CombinableArbitrary.from(() -> Reflections.newInstance(type));

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/FieldReflectionArbitraryIntrospector.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitraryDelegator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
@@ -62,7 +63,8 @@ public final class FieldReflectionArbitraryIntrospector implements ArbitraryIntr
 			try {
 				checkPrerequisite(type);
 			} catch (Exception ex) {
-				if (context.isEnableLoggingFail()) {
+				ArbitraryGeneratorLoggingContext loggingContext = context.getLoggingContext();
+				if (loggingContext.isEnableLoggingFail()) {
 					LOGGER.warn("Given type {} is failed to generate due to the exception. It may be null.", type, ex);
 				}
 				return ArbitraryIntrospectorResult.NOT_INTROSPECTED;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
@@ -169,6 +169,7 @@ public final class FixtureMonkeyOptions {
 	private final JavaConstraintGenerator javaConstraintGenerator;
 	private final InstantiatorProcessor instantiatorProcessor;
 	private final List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers;
+	private final boolean enableLoggingFail;
 
 	public FixtureMonkeyOptions(
 		List<MatcherOperator<PropertyGenerator>> propertyGenerators,
@@ -189,7 +190,8 @@ public final class FixtureMonkeyOptions {
 		int generateUniqueMaxTries,
 		JavaConstraintGenerator javaConstraintGenerator,
 		InstantiatorProcessor instantiatorProcessor,
-		List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers
+		List<MatcherOperator<CandidateConcretePropertyResolver>> candidateConcretePropertyResolvers,
+		boolean enableLoggingFail
 	) {
 		this.propertyGenerators = propertyGenerators;
 		this.defaultPropertyGenerator = defaultPropertyGenerator;
@@ -210,6 +212,7 @@ public final class FixtureMonkeyOptions {
 		this.javaConstraintGenerator = javaConstraintGenerator;
 		this.instantiatorProcessor = instantiatorProcessor;
 		this.candidateConcretePropertyResolvers = candidateConcretePropertyResolvers;
+		this.enableLoggingFail = enableLoggingFail;
 	}
 
 	public static FixtureMonkeyOptionsBuilder builder() {
@@ -349,6 +352,10 @@ public final class FixtureMonkeyOptions {
 
 	public InstantiatorProcessor getInstantiatorProcessor() {
 		return instantiatorProcessor;
+	}
+
+	public boolean isEnableLoggingFail() {
+		return enableLoggingFail;
 	}
 
 	@Nullable

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptionsBuilder.java
@@ -108,6 +108,7 @@ public final class FixtureMonkeyOptionsBuilder {
 	private boolean defaultNotNull = false;
 	private boolean nullableContainer = false;
 	private boolean nullableElement = false;
+	private boolean enableLoggingFail = true;
 	private UnaryOperator<NullInjectGenerator> defaultNullInjectGeneratorOperator = it -> it;
 	private ArbitraryValidator defaultArbitraryValidator = (obj) -> {
 	};
@@ -453,6 +454,11 @@ public final class FixtureMonkeyOptionsBuilder {
 		return this;
 	}
 
+	public FixtureMonkeyOptionsBuilder enableLoggingFail(boolean enableLoggingFail) {
+		this.enableLoggingFail = enableLoggingFail;
+		return this;
+	}
+
 	public FixtureMonkeyOptionsBuilder defaultArbitraryValidator(ArbitraryValidator arbitraryValidator) {
 		this.defaultArbitraryValidator = arbitraryValidator;
 		return this;
@@ -664,7 +670,8 @@ public final class FixtureMonkeyOptionsBuilder {
 			this.generateUniqueMaxTries,
 			resolvedJavaConstraintGenerator,
 			this.instantiatorProcessor,
-			this.candidateConcretePropertyResolvers
+			this.candidateConcretePropertyResolvers,
+			this.enableLoggingFail
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -450,6 +450,11 @@ public final class FixtureMonkeyBuilder {
 		return this;
 	}
 
+	public FixtureMonkeyBuilder enableLoggingFail(boolean enableLoggingFail) {
+		this.fixtureMonkeyOptionsBuilder.enableLoggingFail(enableLoggingFail);
+		return this;
+	}
+
 	/**
 	 * It is deprecated. Please use {@link InterfacePlugin#interfaceImplements(Matcher, List)} instead.
 	 */

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -127,7 +127,8 @@ public final class ObjectTree {
 			},
 			objectNode.getLazyPropertyPath(),
 			monkeyGeneratorContext,
-			fixtureMonkeyOptions.getGenerateUniqueMaxTries()
+			fixtureMonkeyOptions.getGenerateUniqueMaxTries(),
+			fixtureMonkeyOptions.isEnableLoggingFail()
 		);
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -37,6 +37,7 @@ import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.context.MonkeyGeneratorContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext;
+import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorLoggingContext;
 import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.generator.CompositeArbitraryGenerator;
 import com.navercorp.fixturemonkey.api.generator.IntrospectedArbitraryGenerator;
@@ -112,6 +113,9 @@ public final class ObjectTree {
 		}
 
 		MonkeyGeneratorContext monkeyGeneratorContext = monkeyContext.retrieveGeneratorContext(rootProperty);
+		ArbitraryGeneratorLoggingContext loggingContext = new ArbitraryGeneratorLoggingContext(
+			fixtureMonkeyOptions.isEnableLoggingFail());
+
 		return new ArbitraryGeneratorContext(
 			resolvedParentProperty,
 			arbitraryProperty,
@@ -128,7 +132,7 @@ public final class ObjectTree {
 			objectNode.getLazyPropertyPath(),
 			monkeyGeneratorContext,
 			fixtureMonkeyOptions.getGenerateUniqueMaxTries(),
-			fixtureMonkeyOptions.isEnableLoggingFail()
+			loggingContext
 		);
 	}
 


### PR DESCRIPTION
## Summary
add enableLoggingFail option for failed introspect warning log.
[#1066](https://github.com/naver/fixture-monkey/issues/1066)

## (Optional): Description
* I used `||` due to overlapping parts with the existing `enableLoggingFail` option in the `FailoverIntrospector`.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
* I also think it overlaps with the existing `enableLoggingFail` option, so I have omitted it for now.
