### PR TITLE
Fix 'How to use Kotlin ArbitraryBuilder APIs' in 1.1.x migration guide

### DIFF
--- a/docs/content/v1.1.x-kor/docs/migration-guide/migration-guide.md
+++ b/docs/content/v1.1.x-kor/docs/migration-guide/migration-guide.md
@@ -23,7 +23,7 @@ docs:
 `FixtureMonkey.giveMeBuilder(Class)` 혹은 `FixtureMonkey.giveMeJavaBuilder(Class)`.
 
 ### 코틀린 ArbitraryBuilder API 사용법
-코틀린 특화된 API를 다음 코틀린 확장함수를 사용하면 됩니다. `FixtureMonkey.giveMeBuilder<Class>()`
+코틀린 특화된 API를 다음 코틀린 확장함수를 사용하면 됩니다. `FixtureMonkey.giveMeKotlinBuilder<Class>()`
 
 ## 추상 타입의 구현체 확장하는 방법
 

--- a/docs/content/v1.1.x/docs/migration-guide/migration-guide.md
+++ b/docs/content/v1.1.x/docs/migration-guide/migration-guide.md
@@ -24,7 +24,7 @@ Java-specific APIs when creating a Kotlin type, and vice versa.
 To use Java-specific APIs, use `FixtureMonkey.giveMeBuilder(Class)` or `FixtureMonkey.giveMeJavaBuilder(Class)`.
 
 ### How to use Kotlin ArbitraryBuilder APIs
-To use Kotlin-specific APIs, use the extension function `FixtureMonkey.giveMeBuilder<Class>()`.
+To use Kotlin-specific APIs, use the extension function `FixtureMonkey.giveMeKotlinBuilder<Class>()`.
 
 ## Resolves the implementation of the abstract type
 


### PR DESCRIPTION
## Summary
[#1084](https://github.com/naver/fixture-monkey/issues/1084)
replace `giveMeBuilder` with `giveMeKotlinBuilder` in section `How to use Kotlin ArbiraryBuilder APIs` of v1.1.x migration-guide

## (Optional): Description


## How Has This Been Tested?


## Is the Document updated?
Yes
