### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture Monkey는 Fixture Monkey Jakarta Validation 플러그인을 사용하여
 ### Dependencies
 #### Gradle
 ```
-testImplementation("com.navercorp.fixturemonkey:jakarta-validation:1.0.0")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:1.0.0")
 ```
 #### Maven
 ```

--- a/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.0.x-kor/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture Monkey는 Fixture Monkey Jakarta Validation 플러그인을 사용하여
 ### Dependencies
 #### Gradle
 ```
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:1.0.0")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 #### Maven
 ```

--- a/docs/content/v1.0.x/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.0.x/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture monkey supports generating valid data based on [Jakarta Bean Validation 
 ## Dependencies
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:jakarta-validation:{{< fixture-monkey-version >}}")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven

--- a/docs/content/v1.1.x-kor/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.1.x-kor/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture Monkey는 Fixture Monkey Jakarta Validation 플러그인을 사용하여
 ### Dependencies
 #### Gradle
 ```
-testImplementation("com.navercorp.fixturemonkey:jakarta-validation:1.0.0")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:1.0.0")
 ```
 #### Maven
 ```

--- a/docs/content/v1.1.x-kor/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.1.x-kor/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture Monkey는 Fixture Monkey Jakarta Validation 플러그인을 사용하여
 ### Dependencies
 #### Gradle
 ```
-testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:1.0.0")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 #### Maven
 ```

--- a/docs/content/v1.1.x/docs/plugins/jakarta-validation-plugin/features.md
+++ b/docs/content/v1.1.x/docs/plugins/jakarta-validation-plugin/features.md
@@ -15,7 +15,7 @@ Fixture monkey supports generating valid data based on [Jakarta Bean Validation 
 ## Dependencies
 #### Gradle
 ```groovy
-testImplementation("com.navercorp.fixturemonkey:jakarta-validation:{{< fixture-monkey-version >}}")
+testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:{{< fixture-monkey-version >}}")
 ```
 
 #### Maven


### PR DESCRIPTION
## Summary
`v1.0.x` 공식 문서의 Jakarta Validation 플러그인 관련 글에서 예시대로 Gradle 의존성 설정하다가 artifact id 오타를 발견했습니다.
 - `jakarta-validation` → `fixture-monkey-jakarta-validation`

다른 버전 문서도 확인했는데 `v0.6.x`는 문제 없고 `v1.0.x`와 `v1.1.x` 영문, 한글 문서에서 동일한 오타를 발견해서 4개의 파일을 수정했습니다.

