### PR TITLE
Refactor : Adjust resolveFieldName Method Logic to Correctly Handle Primitive boolean Field Names

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/expression/JavaGetterPropertyFieldNameResolver.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/expression/JavaGetterPropertyFieldNameResolver.java
@@ -28,13 +28,14 @@ public final class JavaGetterPropertyFieldNameResolver {
 
 	@Nullable
 	public String resolveFieldName(Class<?> targetClass, String methodName) {
-		if (hasPrefix(GET_PREFIX, methodName)) {
+
+		if (isValidField(targetClass, methodName)) {
+			// class could be using property-style getters (e.g. java record)
+			return methodName;
+		} else if (hasPrefix(GET_PREFIX, methodName)) {
 			return stripPrefixPropertyName(targetClass, methodName, GET_PREFIX.length());
 		} else if (hasPrefix(IS_PREFIX, methodName)) {
 			return stripPrefixPropertyName(targetClass, methodName, IS_PREFIX.length());
-		} else if (isValidField(targetClass, methodName)) {
-			// class could be using property-style getters (e.g. java record)
-			return methodName;
 		}
 
 		return null;


### PR DESCRIPTION
## Summary
`JavaGetterPropertyFieldNameResolver` 의 `resolveFieldName` 메소드가 필드 값을 추출하는 과정에서, 
원시 타입 `boolean` 필드값 추출 시  올바른 필드명이 추출되지 않아 메소드 순서를 변경했습니다.

## Description
`Lombok`의 `@Getter` 어노테이션을 사용할 때, `boolean` 타입을 `primitive type`으로 설정하고, 필드명의 prefix를 `“isXXX”` 로 사용하는 경우 문제가 있습니다.

```java
@Entity
@NoArgsConstructor
@AllArgsConstructor
@Builder
@Getter
public class Sample {

	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	private boolean isUsed;

}
```
위와 같은 엔티티에서  boolean isUsed; 라는 필드가 있다고 가정할 때,

```java
@Test
	void test(){
		FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
			.plugin(new JakartaValidationPlugin()) 
			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
			.build();

		Sample sample = fixtureMonkey.giveMeBuilder(Sample.class)
			.set(javaGetter(Sample::isUsed), true)
			.sample();
	}
```

Lombok 은 위처럼 필드명과 동일한 `getter` 를 생성합니다. ( `Sample::isUsed` )
<img width="708" alt="스크린샷 2024-11-19 오후 8 58 39" src="https://github.com/user-attachments/assets/30908f60-48db-4987-b460-cd037a653eac">
하지만 `JavaGetterPropertyFieldNameResolver` 의 `resolveFieldName` 메소드에서,
 `else if (hasPrefix(IS_PREFIX, methodName))` 가 `true` 일 경우

<img width="708" alt="스크린샷 2024-11-19 오후 8 59 06" src="https://github.com/user-attachments/assets/55617d44-d2a8-4818-848e-8c36e23739c7">
<img width="708" alt="스크린샷 2024-11-19 오후 8 59 56" src="https://github.com/user-attachments/assets/61b803db-24ff-4ba1-8981-38dd0a234702">

`stripPrefixPropertyName(targetClass, methodName, IS_PREFIX.length())` 를 수행하기 때문에, `isUsed` 필드명이 `used` 로 strip되어 resolve되기에 NPE 에러가 발생합니다.

```java
//JavaGetterPropertyFieldNameResolver.java
@Nullable
	public String resolveFieldName(Class<?> targetClass, String methodName) {

		if (isValidField(targetClass, methodName)) {
			return methodName;
		} else if (hasPrefix(GET_PREFIX, methodName)) {
			return stripPrefixPropertyName(targetClass, methodName, GET_PREFIX.length());
		} else if (hasPrefix(IS_PREFIX, methodName)) {
			return stripPrefixPropertyName(targetClass, methodName, IS_PREFIX.length());
		} 

		return null;
	}
```

위처럼 `isValidField(targetClass, methodName)` 검증을 가장 먼저 수행하도록 변경하면, 필드명과 메소드명이 동일한 경우에도 대응이 가능해 변경했습니다.

## How Has This Been Tested?

Passed All Existing Tests
