### PR TITLE
Add StringCombinableArbitrary for easy customisation

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.arbitrary;
 
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -37,7 +38,10 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 @API(since = "0.6.0", status = Status.MAINTAINED)
 public interface CombinableArbitrary<T> {
 	CombinableArbitrary<?> NOT_GENERATED = CombinableArbitrary.from((Object)null);
+
 	int DEFAULT_MAX_TRIES = 1_000;
+	ServiceLoader<StringCombinableArbitrary> STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(StringCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -186,4 +190,12 @@ public interface CombinableArbitrary<T> {
 	 * @return fixed
 	 */
 	boolean fixed();
+
+	/**
+	 * @return a {@link CombinableArbitrary} returns a randomly generated String
+	 */
+	@API(since = "1.0.4", status = Status.EXPERIMENTAL)
+	static StringCombinableArbitrary strings() {
+		return STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -1,0 +1,91 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
+	int STRING_DEFAULT_MIN_LENGTH = 0;
+	int STRING_DEFAULT_MAX_LENGTH = 100;
+
+	@Override
+	String combined();
+
+	@Override
+	String rawValue();
+
+	StringCombinableArbitrary withLength(int min, int max);
+
+	StringCombinableArbitrary ascii();
+
+	StringCombinableArbitrary numeric();
+
+	default StringCombinableArbitrary withMinLength(int min) {
+		return this.withLength(min, STRING_DEFAULT_MAX_LENGTH);
+	}
+
+	default StringCombinableArbitrary withMaxLength(int max) {
+		return this.withLength(STRING_DEFAULT_MIN_LENGTH, max);
+	}
+
+	@Override
+	default StringCombinableArbitrary filter(Predicate<String> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default StringCombinableArbitrary filter(int tries, Predicate<String> predicate) {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	default StringCombinableArbitrary filterCharacter(Predicate<Character> predicate) {
+		return this.filterCharacter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate);
+
+	/**
+	 * Generates the pattern matched arbitrary String.
+	 * Its performance differs from the generation engine you're using.
+	 *
+	 * @param stringPattern the regular expression pattern
+	 * @return the pattern matched StringCombinableArbitrary
+	 */
+	default StringCombinableArbitrary pattern(int tries, String stringPattern) {
+		Pattern pattern = Pattern.compile(stringPattern);
+		return this.filter(tries, it -> pattern.matcher(it).matches());
+	}
+
+	@Override
+	default StringCombinableArbitrary injectNull(double nullProbability) {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default StringCombinableArbitrary unique() {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitraryDelegator.java
@@ -1,0 +1,88 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+
+final class StringCombinableArbitraryDelegator implements StringCombinableArbitrary {
+	private static final int MAX_ASCII_CODEPOINT = 0x007F;
+
+	private final CombinableArbitrary<String> delegate;
+
+	public StringCombinableArbitraryDelegator(CombinableArbitrary<String> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public String combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public String rawValue() {
+		return delegate.combined();
+	}
+
+	@Override
+	public StringCombinableArbitrary withLength(int min, int max) {
+		return new StringCombinableArbitraryDelegator(delegate.filter(it -> min <= it.length() && it.length() <= max));
+	}
+
+	@Override
+	public StringCombinableArbitrary ascii() {
+		return new StringCombinableArbitraryDelegator(
+			delegate.filter(
+				it -> it.chars()
+					.allMatch(character -> Character.MIN_CODE_POINT <= character && character <= MAX_ASCII_CODEPOINT)
+			)
+		);
+	}
+
+	@Override
+	public StringCombinableArbitrary numeric() {
+		return new StringCombinableArbitraryDelegator(
+			delegate.filter(it -> it.chars().allMatch(character -> '0' <= character && character <= '9'))
+		);
+	}
+
+	@Override
+	public StringCombinableArbitrary filter(int tries, Predicate<String> predicate) {
+		return new StringCombinableArbitraryDelegator(delegate.filter(tries, predicate));
+	}
+
+	@Override
+	public StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate) {
+		return this.filter(tries, it -> it.chars().mapToObj(Character.class::cast).allMatch(predicate));
+	}
+
+	@Override
+	public StringCombinableArbitrary unique() {
+		return new StringCombinableArbitraryDelegator(delegate.unique());
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaTypeArbitraryGeneratorSet.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaTypeArbitraryGeneratorSet.java
@@ -46,7 +46,9 @@ public final class JqwikJavaTypeArbitraryGeneratorSet implements JavaTypeArbitra
 
 	@Override
 	public CombinableArbitrary<String> strings(ArbitraryGeneratorContext context) {
-		return ArbitraryUtils.toCombinableArbitrary(arbitraryResolver.strings(arbitraryGenerator.strings(), context));
+		return ArbitraryUtils.toCombinableArbitrary(
+			arbitraryResolver.strings(arbitraryGenerator.strings(), context)
+		);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
@@ -1,0 +1,108 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.ListArbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
+
+public final class JqwikStringCombinableArbitrary implements StringCombinableArbitrary {
+	private static final int MAX_ASCII_CODEPOINT = 0x007F;
+
+	private final Arbitrary<Character> characterArbitrary;
+	@Nullable
+	private Integer minSize = null;
+	@Nullable
+	private Integer maxSize = null;
+
+	public JqwikStringCombinableArbitrary() {
+		this.characterArbitrary = Arbitraries.chars();
+	}
+
+	private JqwikStringCombinableArbitrary(Arbitrary<Character> characterArbitrary) {
+		this.characterArbitrary = characterArbitrary;
+	}
+
+	@Override
+	public String combined() {
+		ListArbitrary<Character> characterListArbitrary = characterArbitrary.list();
+		if (this.minSize != null) {
+			characterListArbitrary = characterListArbitrary.ofMinSize(this.minSize);
+		}
+
+		if (this.maxSize != null) {
+			characterListArbitrary = characterListArbitrary.ofMaxSize(this.maxSize);
+		}
+
+		List<Character> characters = characterListArbitrary.sample();
+		StringBuilder stringBuilder = new StringBuilder();
+		for (Character character : characters) {
+			stringBuilder.append(character);
+		}
+		return stringBuilder.toString();
+	}
+
+	@Override
+	public String rawValue() {
+		return this.combined();
+	}
+
+	@Override
+	public StringCombinableArbitrary withLength(int minSize, int maxSize) {
+		this.minSize = minSize;
+		this.maxSize = maxSize;
+		return this;
+	}
+
+	@Override
+	public StringCombinableArbitrary ascii() {
+		return new JqwikStringCombinableArbitrary(
+			this.characterArbitrary.filter(
+				it -> (char)Character.MIN_CODE_POINT <= it && it <= (char)MAX_ASCII_CODEPOINT
+			)
+		);
+	}
+
+	@Override
+	public StringCombinableArbitrary numeric() {
+		return new JqwikStringCombinableArbitrary(this.characterArbitrary.filter(it -> '0' <= it && it <= '9'));
+	}
+
+	@Override
+	public StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate) {
+		return new JqwikStringCombinableArbitrary(this.characterArbitrary.filter(tries, predicate));
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+}

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikStringCombinableArbitrary

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.kotest
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import io.kotest.property.Arb
@@ -44,7 +45,6 @@ import io.kotest.property.arbitrary.offsetDateTime
 import io.kotest.property.arbitrary.period
 import io.kotest.property.arbitrary.short
 import io.kotest.property.arbitrary.single
-import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.yearMonth
 import io.kotest.property.arbitrary.zoneId
 import io.kotest.property.arbitrary.zoneOffset
@@ -79,17 +79,16 @@ import kotlin.time.toJavaDuration
 class KotestJavaArbitraryGeneratorSet(
     private val constraintGenerator: JavaConstraintGenerator,
 ) : JavaTypeArbitraryGeneratorSet {
-    override fun strings(context: ArbitraryGeneratorContext): CombinableArbitrary<String> {
+    override fun strings(context: ArbitraryGeneratorContext): StringCombinableArbitrary {
         val stringConstraint = constraintGenerator.generateStringConstraint(context)
 
-        return CombinableArbitrary.from {
-            if (stringConstraint != null) {
-                val minSize = stringConstraint.minSize?.toInt() ?: 0
-                val maxSize = stringConstraint.maxSize?.toInt() ?: 100
-                Arb.string(minSize = minSize, maxSize = maxSize).single()
-            } else {
-                Arb.string().single()
-            }
+        val combinableArbitrary = KotestStringCombinableArbitrary()
+        return if (stringConstraint != null) {
+            val minSize = stringConstraint.minSize?.toInt() ?: 0
+            val maxSize = stringConstraint.maxSize?.toInt() ?: 100
+            combinableArbitrary.withLength(minSize, maxSize)
+        } else {
+            combinableArbitrary
         }
     }
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
@@ -1,0 +1,72 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.codepoints
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.single
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.stringPattern
+import java.util.function.Predicate
+
+class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string()) : StringCombinableArbitrary {
+    override fun combined(): String = arb.single()
+
+    override fun rawValue(): String = arb.single()
+
+    override fun filter(tries: Int, predicate: Predicate<String>): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(arb.filter { predicate.test(it) })
+
+    override fun withLength(min: Int, max: Int): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(Arb.string(min..max))
+
+    override fun ascii(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints()
+                .filter { it.value.toChar() in Character.MIN_CODE_POINT.toChar()..MAX_ASCII_CODEPOINT.toChar() }
+        )
+    )
+
+    override fun numeric(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints().filter { it.value.toChar() in '0'..'9' }
+        )
+    )
+
+    override fun filterCharacter(tries: Int, predicate: Predicate<Char>): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(
+            Arb.string(
+                codepoints = Arb.codepoints().filter { predicate.test(it.value.toChar()) }
+            )
+        )
+
+    override fun pattern(treis: Int, pattern: String): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(Arb.stringPattern(pattern))
+
+    override fun clear() {
+    }
+
+    override fun fixed(): Boolean = false
+
+    companion object {
+        private const val MAX_ASCII_CODEPOINT: Int = 0x007F
+    }
+}

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -54,12 +54,14 @@ import net.jqwik.api.Arbitraries;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.jqwik.JqwikStringCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -1394,5 +1396,58 @@ class JavaTest {
 		String actual = sut.giveMeOne(String.class);
 
 		then(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void stringCombinableArbitraryIsJqwik() {
+		StringCombinableArbitrary actual = CombinableArbitrary.strings();
+
+		then(actual).isInstanceOf(JqwikStringCombinableArbitrary.class);
+	}
+
+	@Test
+	void stringCombinableArbitraryInjectNull() {
+		String actual = CombinableArbitrary.strings().injectNull(1).combined();
+
+		then(actual).isNull();
+	}
+
+	@Test
+	void stringCombinableArbitraryFilter() {
+		String actual = CombinableArbitrary.strings().filter(it -> it.length() > 5).combined();
+
+		then(actual).hasSizeGreaterThan(5);
+	}
+
+	@Test
+	void stringCombinableArbitraryFilterCharacter() {
+		String actual = CombinableArbitrary.strings().filterCharacter(it -> 'a' <= it && it <= 'z').combined();
+
+		then(actual).isAlphabetic();
+	}
+
+	@Test
+	void stringCombinableArbitraryFilterCharacterAndFilter() {
+		String actual = CombinableArbitrary.strings()
+			.filterCharacter(it -> 'a' <= it && it <= 'z')
+			.filter(it -> it.length() < 5)
+			.combined();
+
+		then(actual).isAlphabetic();
+		then(actual).hasSizeLessThan(5);
+	}
+
+	@Test
+	void stringCombinableArbitraryNumeric() {
+		String actual = CombinableArbitrary.strings().numeric().combined();
+
+		then(actual).matches("[0-9]*");
+	}
+
+	@Test
+	void stringCombinableArbitraryMap() {
+		String actual = CombinableArbitrary.strings().map(it -> "prefix" + it).combined();
+
+		then(actual).startsWith("prefix");
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -19,8 +19,10 @@
 package com.navercorp.fixturemonkey.tests.kotlin
 
 import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
 import com.navercorp.fixturemonkey.kotest.KotestPlugin
+import com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.giveMeArb
 import com.navercorp.fixturemonkey.kotest.setArb
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
@@ -33,6 +35,7 @@ import io.kotest.property.arbitrary.single
 import io.kotest.property.arbs.geo.zipcodes
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.BigInteger
 import javax.validation.constraints.DecimalMax
@@ -761,6 +764,20 @@ class KotestInJunitTest {
             .string
 
         then(actual).hasSize(5)
+    }
+
+    @Test
+    fun stringCombinableArbitrary(){
+        val actual = CombinableArbitrary.strings()
+
+        then(actual).isInstanceOf(KotestStringCombinableArbitrary::class.java)
+    }
+
+    @Test
+    fun stringCombinableArbitraryAscii(){
+        val actual = CombinableArbitrary.strings().ascii().combined()
+
+        then(actual).isInstanceOf(KotestStringCombinableArbitrary::class.java)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Add StringCombinableArbitrary for easy customisation

## How Has This Been Tested?
* stringCombinableArbitraryIsJqwik
* stringCombinableArbitraryAscii
* stringCombinableArbitrary
* stringCombinableArbitraryMap
* stringCombinableArbitraryNumeric
* stringCombinableArbitraryFilterCharacterAndFilter
* stringCombinableArbitraryFilterCharacter
* stringCombinableArbitraryFilter
* stringCombinableArbitraryInjectNull

## Is the Document updated?
later
