### PR TITLE
Refactor add TreeRootProperty

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContext.java
@@ -32,7 +32,7 @@ import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.type.Types;
 
 /**
@@ -48,14 +48,14 @@ import com.navercorp.fixturemonkey.api.type.Types;
 public final class MonkeyContext {
 	private final ConcurrentLruCache<Property, CombinableArbitrary<?>> arbitrariesByProperty;
 	private final ConcurrentLruCache<Property, CombinableArbitrary<?>> javaArbitrariesByProperty;
-	private final ConcurrentLruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
+	private final ConcurrentLruCache<TreeRootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
 	private final List<MatcherOperator<? extends ObjectBuilder<?>>> registeredArbitraryBuilders;
 	private final FixtureMonkeyOptions fixtureMonkeyOptions;
 
 	public MonkeyContext(
 		ConcurrentLruCache<Property, CombinableArbitrary<?>> arbitrariesByProperty,
 		ConcurrentLruCache<Property, CombinableArbitrary<?>> javaArbitrariesByProperty,
-		ConcurrentLruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty,
+		ConcurrentLruCache<TreeRootProperty, MonkeyGeneratorContext> generatorContextByRootProperty,
 		List<MatcherOperator<? extends ObjectBuilder<?>>> registeredArbitraryBuilders,
 		FixtureMonkeyOptions fixtureMonkeyOptions
 	) {
@@ -89,7 +89,7 @@ public final class MonkeyContext {
 	}
 
 	public MonkeyGeneratorContext newGeneratorContext(
-		RootProperty rootProperty
+		TreeRootProperty rootProperty
 	) {
 		return generatorContextByRootProperty.computeIfAbsent(
 			rootProperty,

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/context/MonkeyContextBuilder.java
@@ -30,7 +30,7 @@ import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class MonkeyContextBuilder {
@@ -38,7 +38,7 @@ public final class MonkeyContextBuilder {
 
 	private ConcurrentLruCache<Property, CombinableArbitrary<?>> arbitrariesByProperty;
 	private ConcurrentLruCache<Property, CombinableArbitrary<?>> javaArbitrariesByProperty;
-	private ConcurrentLruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
+	private ConcurrentLruCache<TreeRootProperty, MonkeyGeneratorContext> generatorContextByRootProperty;
 	private List<MatcherOperator<? extends ObjectBuilder<?>>> registeredObjectBuilders;
 	private int cacheSize = 2048;
 	private int generatorContextSize = 1000;
@@ -62,7 +62,7 @@ public final class MonkeyContextBuilder {
 	}
 
 	public MonkeyContextBuilder generatorContextByRootProperty(
-		ConcurrentLruCache<RootProperty, MonkeyGeneratorContext> generatorContextByRootProperty
+		ConcurrentLruCache<TreeRootProperty, MonkeyGeneratorContext> generatorContextByRootProperty
 	) {
 		this.generatorContextByRootProperty = generatorContextByRootProperty;
 		return this;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ContainerPropertyGeneratorContext.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ContainerPropertyGeneratorContext {
@@ -58,6 +58,6 @@ public final class ContainerPropertyGeneratorContext {
 	}
 
 	public boolean isRootContext() {
-		return this.property instanceof RootProperty;
+		return this.property instanceof TreeRootProperty;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectProperty.java
@@ -27,7 +27,7 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ObjectProperty {
@@ -66,7 +66,7 @@ public final class ObjectProperty {
 	}
 
 	public boolean isRoot() {
-		return this.property instanceof RootProperty;
+		return this.property instanceof TreeRootProperty;
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/generator/ObjectPropertyGeneratorContext.java
@@ -25,7 +25,7 @@ import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class ObjectPropertyGeneratorContext {
@@ -74,6 +74,6 @@ public final class ObjectPropertyGeneratorContext {
 	}
 
 	public boolean isRootContext() {
-		return this.property instanceof RootProperty;
+		return this.property instanceof TreeRootProperty;
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ComparableRootProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/ComparableRootProperty.java
@@ -1,6 +1,7 @@
 package com.navercorp.fixturemonkey.api.property;
 
 import java.lang.reflect.AnnotatedType;
+import java.util.Objects;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -9,20 +10,12 @@ import org.apiguardian.api.API.Status;
  * It is a property for a root type.
  * It does not support the equivalence of the type.
  */
-@API(since = "0.4.0", status = Status.MAINTAINED)
-public final class RootProperty implements TreeRootProperty {
+@API(since = "1.1.6", status = Status.EXPERIMENTAL)
+public final class ComparableRootProperty implements TreeRootProperty {
 	private final Property delgeatedProperty;
 
-	/**
-	 * It is deprecated. Use {@link #RootProperty(Property)} instead.
-	 */
-	@Deprecated
-	public RootProperty(AnnotatedType annotatedType) {
+	public ComparableRootProperty(AnnotatedType annotatedType) {
 		this.delgeatedProperty = new TypeParameterProperty(annotatedType);
-	}
-
-	public RootProperty(Property delgeatedProperty) {
-		this.delgeatedProperty = delgeatedProperty;
 	}
 
 	@Override
@@ -34,5 +27,22 @@ public final class RootProperty implements TreeRootProperty {
 	public String toString() {
 		return "RootProperty{"
 			+ "annotatedType=" + delgeatedProperty.getAnnotatedType() + '}';
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		ComparableRootProperty that = (ComparableRootProperty)obj;
+		return Objects.equals(delgeatedProperty, that.delgeatedProperty);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(delgeatedProperty);
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyPath.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/PropertyPath.java
@@ -67,7 +67,7 @@ public final class PropertyPath implements Comparable<PropertyPath> {
 	}
 
 	private String getCurrentPropertyExpression() {
-		if (property instanceof RootProperty || property instanceof MapEntryElementProperty) {
+		if (property instanceof TreeRootProperty || property instanceof MapEntryElementProperty) {
 			return "";
 		} else if (property instanceof MapKeyElementProperty) {
 			return "{key}";
@@ -81,7 +81,7 @@ public final class PropertyPath implements Comparable<PropertyPath> {
 
 	private String getDelimiter() {
 		if (property instanceof ContainerElementProperty
-			|| property instanceof RootProperty
+			|| property instanceof TreeRootProperty
 			|| property instanceof MapEntryElementProperty
 			|| property instanceof MapKeyElementProperty
 			|| property instanceof MapValueElementProperty

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/TreeRootProperty.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/TreeRootProperty.java
@@ -1,0 +1,79 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.property;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.type.Types;
+
+/**
+ * It is the property of the root node within the object tree.
+ */
+@API(since = "1.1.6", status = Status.EXPERIMENTAL)
+public interface TreeRootProperty extends Property {
+	/**
+	 * Retrieves the actual property of the root node.
+	 * Type, annotations are included in the returned property.
+	 *
+	 * @return the actual property of the root node
+	 */
+	Property getDelgatedProperty();
+
+	@Override
+	default Type getType() {
+		return getAnnotatedType().getType();
+	}
+
+	@Override
+	default AnnotatedType getAnnotatedType() {
+		return getDelgatedProperty().getAnnotatedType();
+	}
+
+	@Override
+	default String getName() {
+		return "$";
+	}
+
+	@Override
+	default List<Annotation> getAnnotations() {
+		return Collections.emptyList();
+	}
+
+	@Nullable
+	@Override
+	default Object getValue(Object instance) {
+		if (Types.getActualType(this.getType()) == instance.getClass()) {
+			return instance;
+		}
+
+		throw new IllegalArgumentException(
+			"RootProperty obj is not a root type. annotatedType: " + this.getAnnotatedType()
+				+ ", objType: " + instance.getClass()
+		);
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/tree/DefaultTraverseNode.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/tree/DefaultTraverseNode.java
@@ -48,12 +48,12 @@ import com.navercorp.fixturemonkey.api.property.MapEntryElementProperty;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator;
 import com.navercorp.fixturemonkey.api.property.PropertyPath;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.property.TypeDefinition;
 
 @API(since = "1.1.4", status = Status.EXPERIMENTAL)
 public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMetadata {
-	private final RootProperty rootProperty;
+	private final TreeRootProperty rootProperty;
 
 	@Nullable
 	private final Property resolvedParentProperty;
@@ -85,7 +85,7 @@ public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMeta
 	});
 
 	DefaultTraverseNode(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		@Nullable Property resolvedParentProperty,
 		TypeDefinition resolvedTypeDefinition,
 		TreeProperty treeProperty,
@@ -176,7 +176,7 @@ public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMeta
 		return parent;
 	}
 
-	public RootProperty getRootProperty() {
+	public TreeRootProperty getRootProperty() {
 		return rootProperty;
 	}
 
@@ -303,7 +303,7 @@ public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMeta
 	}
 
 	public static DefaultTraverseNode generateRootNode(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		TraverseContext traverseContext
 	) {
 		return DefaultTraverseNode.generateObjectNode(
@@ -317,7 +317,7 @@ public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMeta
 	}
 
 	static DefaultTraverseNode generateObjectNode(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		@Nullable Property resolvedParentProperty,
 		Property property,
 		@Nullable Integer propertySequence,
@@ -481,7 +481,7 @@ public final class DefaultTraverseNode implements TraverseNode, TraverseNodeMeta
 		List<ObjectProperty> objectProperties
 	) {
 		if (!container || objectProperties.isEmpty()
-			|| !(objectProperties.get(0).getProperty() instanceof RootProperty)) {
+			|| !(objectProperties.get(0).getProperty() instanceof TreeRootProperty)) {
 			return null;
 		}
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/tree/TraverseNodeMetadata.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/tree/TraverseNodeMetadata.java
@@ -28,12 +28,12 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyPath;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.property.TypeDefinition;
 
 @API(since = "1.1.4", status = Status.EXPERIMENTAL)
 public interface TraverseNodeMetadata {
-	RootProperty getRootProperty();
+	TreeRootProperty getRootProperty();
 
 	@Nullable
 	Property getResolvedParentProperty();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -34,6 +34,8 @@ import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
+import com.navercorp.fixturemonkey.api.property.TypeParameterProperty;
 import com.navercorp.fixturemonkey.api.type.LazyAnnotatedType;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
 import com.navercorp.fixturemonkey.builder.ArbitraryBuilderContext;
@@ -81,7 +83,7 @@ public final class FixtureMonkey {
 	}
 
 	public <T> ArbitraryBuilder<T> giveMeBuilder(TypeReference<T> type) {
-		RootProperty rootProperty = new RootProperty(type.getAnnotatedType());
+		TreeRootProperty rootProperty = new RootProperty(new TypeParameterProperty(type.getAnnotatedType()));
 
 		ArbitraryBuilderContext builderContext = monkeyContext.getRegisteredArbitraryBuilders().stream()
 			.filter(it -> it.match(rootProperty))
@@ -113,7 +115,7 @@ public final class FixtureMonkey {
 		context.addManipulator(arbitraryManipulator);
 
 		return new DefaultArbitraryBuilder<>(
-			new RootProperty(new LazyAnnotatedType<>(() -> value)),
+			new RootProperty(new TypeParameterProperty(new LazyAnnotatedType<>(() -> value))),
 			new ArbitraryResolver(
 				manipulatorOptimizer,
 				monkeyManipulatorFactory,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -61,6 +61,8 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.PropertySelector;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
+import com.navercorp.fixturemonkey.api.property.TypeParameterProperty;
 import com.navercorp.fixturemonkey.api.tree.TreeNodeManipulator;
 import com.navercorp.fixturemonkey.api.type.LazyAnnotatedType;
 import com.navercorp.fixturemonkey.api.type.TypeReference;
@@ -77,7 +79,7 @@ import com.navercorp.fixturemonkey.resolver.ArbitraryResolver;
 @API(since = "0.4.0", status = Status.MAINTAINED)
 public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, ExperimentalArbitraryBuilder<T>,
 	ObjectBuilder<T>, ArbitraryBuilderContextProvider {
-	private final RootProperty rootProperty;
+	private final TreeRootProperty rootProperty;
 	private final ArbitraryResolver resolver;
 	private final MonkeyManipulatorFactory monkeyManipulatorFactory;
 	private final ArbitraryBuilderContext context;
@@ -85,7 +87,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 	private final InstantiatorProcessor instantiatorProcessor;
 
 	public DefaultArbitraryBuilder(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		ArbitraryResolver resolver,
 		MonkeyManipulatorFactory monkeyManipulatorFactory,
 		ArbitraryBuilderContext context,
@@ -543,7 +545,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		context.addManipulator(arbitraryManipulator);
 
 		return new DefaultArbitraryBuilder<>(
-			new RootProperty(new LazyAnnotatedType<>(lazyArbitrary::getValue)),
+			new RootProperty(new TypeParameterProperty(new LazyAnnotatedType<>(lazyArbitrary::getValue))),
 			resolver,
 			monkeyManipulatorFactory,
 			context,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -30,7 +30,7 @@ import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.matcher.DefaultTreeMatcherMetadata;
 import com.navercorp.fixturemonkey.api.matcher.TreeMatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.builder.ArbitraryBuilderContext;
 import com.navercorp.fixturemonkey.customizer.ArbitraryManipulator;
 import com.navercorp.fixturemonkey.customizer.MonkeyManipulatorFactory;
@@ -53,7 +53,7 @@ public final class ArbitraryResolver {
 	}
 
 	public CombinableArbitrary<?> resolve(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		ArbitraryBuilderContext builderContext
 	) {
 		FixtureMonkeyOptions fixtureMonkeyOptions = monkeyContext.getFixtureMonkeyOptions();

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ResolvedCombinableArbitrary.java
@@ -30,7 +30,7 @@ import com.navercorp.fixturemonkey.api.exception.ContainerSizeFilterMissExceptio
 import com.navercorp.fixturemonkey.api.exception.FixedValueFilterMissException;
 import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.validator.ArbitraryValidator;
 import com.navercorp.fixturemonkey.tree.ObjectTree;
 
@@ -38,7 +38,7 @@ import com.navercorp.fixturemonkey.tree.ObjectTree;
 final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 	private static final int VALIDATION_ANNOTATION_FILTERING_COUNT = 1;
 
-	private final RootProperty rootProperty;
+	private final TreeRootProperty rootProperty;
 	private final LazyArbitrary<ObjectTree> objectTree;
 	private final int generateMaxTries;
 	private final LazyArbitrary<CombinableArbitrary<T>> arbitrary;
@@ -48,7 +48,7 @@ final class ResolvedCombinableArbitrary<T> implements CombinableArbitrary<T> {
 	private Exception lastException = null;
 
 	public ResolvedCombinableArbitrary(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		Supplier<ObjectTree> regenerateTree,
 		Function<ObjectTree, CombinableArbitrary<T>> generateArbitrary,
 		int generateMaxTries,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectNode.java
@@ -32,7 +32,7 @@ import com.navercorp.fixturemonkey.api.generator.ArbitraryProperty;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.PropertyPath;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.property.TypeDefinition;
 import com.navercorp.fixturemonkey.api.tree.TraverseNode;
 import com.navercorp.fixturemonkey.api.tree.TraverseNodeMetadata;
@@ -114,7 +114,7 @@ public final class ObjectNode implements TraverseNode, TraverseNodeMetadata {
 	}
 
 	@Override
-	public RootProperty getRootProperty() {
+	public TreeRootProperty getRootProperty() {
 		return this.getMetadata().getRootProperty();
 	}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTree.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
-import com.navercorp.fixturemonkey.api.property.RootProperty;
+import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.api.tree.DefaultTraverseNode;
 import com.navercorp.fixturemonkey.api.tree.TraverseContext;
 import com.navercorp.fixturemonkey.customizer.NodeManipulator;
@@ -36,7 +36,7 @@ public final class ObjectTree {
 	private final GenerateFixtureContext generateFixtureContext;
 
 	public ObjectTree(
-		RootProperty rootProperty,
+		TreeRootProperty rootProperty,
 		GenerateFixtureContext generateFixtureContext,
 		TraverseContext traverseContext
 	) {


### PR DESCRIPTION
## Summary
Add TreeRootProperty

## (Optional): Description
TreeRootProperty is the interface to reference the root node of the object tree.
It may be field or java beans getter or type parameter etc.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
Not yet
