### PR TITLE
Remove default FixtureMonkeyOptions

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/option/FixtureMonkeyOptions.java
@@ -133,7 +133,6 @@ public final class FixtureMonkeyOptions {
 				context -> NOT_NULL_INJECT
 			)
 		);
-	public static final FixtureMonkeyOptions DEFAULT_GENERATE_OPTIONS = FixtureMonkeyOptions.builder().build();
 
 	static {
 		List<String> defaultJavaPackages = new ArrayList<>();


### PR DESCRIPTION
## Summary
Remove default FixtureMonkeyOptions

## (Optional): Description
It may be the breaking change. But it compels me for the following reasons.
1. The default `FixtureMonkeyOptions` initializes if added in dependency, it causes the unnecessary costs.
2. It forces the jqwik depenedency in `fixture-monkey-api` module. 

We'll recommend to use `FixtureMonkeyOptions.builder().build()` instead.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
Later
