### PR TITLE
Fix negativeMin self-comparison to decimalMin in Jakarta/Javax validation

### DIFF
--- a/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
+++ b/fixture-monkey-jakarta-validation/src/main/java/com/navercorp/fixturemonkey/jakarta/validation/introspector/JakartaValidationConstraintGenerator.java
@@ -362,7 +362,7 @@ public final class JakartaValidationConstraintGenerator implements JavaConstrain
 				if (negativeMin == null) {
 					negativeMin = decimalMin;
 				} else {
-					negativeMin = negativeMin.min(negativeMin);
+					negativeMin = negativeMin.min(decimalMin);
 				}
 				if (!decimalMinAnnotation.map(DecimalMin::inclusive).get()) {
 					negativeMinInclusive = false;

--- a/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGenerator.java
+++ b/fixture-monkey-javax-validation/src/main/java/com/navercorp/fixturemonkey/javax/validation/introspector/JavaxValidationConstraintGenerator.java
@@ -361,7 +361,7 @@ public final class JavaxValidationConstraintGenerator implements JavaConstraintG
 				if (negativeMin == null) {
 					negativeMin = decimalMin;
 				} else {
-					negativeMin = negativeMin.min(negativeMin);
+					negativeMin = negativeMin.min(decimalMin);
 				}
 				if (!decimalMinAnnotation.map(DecimalMin::inclusive).get()) {
 					negativeMinInclusive = false;


### PR DESCRIPTION
## Summary
Fix incorrect self-comparison operation in JakartaValidationConstraintGenerator where negativeMin was being compared with itself instead of decimalMin.

Related issue: #1127 

## How Has This Been Tested?
Since Fixture Monkey implements two validation flows as mentioned in the issue discussion, we can be confident this fix won't affect existing behavior. While the second validation flow has been correctly handling the validation, this fix ensures the JakartaValidationConstraintGenerator (first flow) also works as intended.

## Is the Document updated?
No documentation update is required as this is a bug fix for internal implementation.