### PR TITLE
Update actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           detailed_summary: true
 
       - name: Test Summary
-        uses: actions/upload-artifact@v3  # upload test results
+        uses: actions/upload-artifact@v4  # upload test results
         if: always()
         with:
           name: test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,4 @@ jobs:
         with:
           name: test-results
           path: '**/build/test-results/test/TEST-*.xml'
+          overwrite: true


### PR DESCRIPTION
## Summary
Update `actions/upload-artifact` from v3 to v4 due to GitHub's deprecation notice.

Related: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Description
- Changed `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
- Added `overwrite: true` to maintain same artifact behavior as v3

## How Has This Been Tested?
Changes will be tested through this PR's workflow run.

## Is the Document updated?
No documentation updates required as this is an internal workflow change.