### PR TITLE
Fix generate Kotlin object, sealed object instance

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -43,7 +43,8 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector, Matcher {
     override fun match(property: Property): Boolean =
         property.type.actualType().isKotlinType() &&
             !property.type.actualType().cachedKotlin().isKotlinLambda() &&
-            property.type.actualType().cachedKotlin() != Unit::class
+            property.type.actualType().cachedKotlin() != Unit::class &&
+            property.type.actualType().cachedKotlin().objectInstance == null
 
     override fun introspect(context: ArbitraryGeneratorContext): ArbitraryIntrospectorResult {
         val type = Types.getActualType(context.resolvedType)

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotlinTest.kt
@@ -1374,6 +1374,14 @@ class KotlinTest {
             .isThrownBy { SUT.giveMeOne<FunctionObject>().toString() }
     }
 
+    @RepeatedTest(TEST_COUNT)
+    fun generateObjectInstanceThrows() {
+        // when
+        val actual: KotlinObject = SUT.giveMeOne()
+
+        then(actual).isInstanceOf(KotlinObject::class.java)
+    }
+
     companion object {
         private val SUT: FixtureMonkey = FixtureMonkey.builder()
             .plugin(KotlinPlugin())

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ObjectSpecs.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ObjectSpecs.kt
@@ -1,0 +1,3 @@
+package com.navercorp.fixturemonkey.tests.kotlin
+
+object KotlinObject

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SealedClassTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/SealedClassTest.kt
@@ -69,6 +69,22 @@ class SealedClassTest {
         then((actual as SealedInterfaceImplementation).stringObject.string).isEqualTo("expected")
     }
 
+    @RepeatedTest(TEST_COUNT)
+    fun sealedObject() {
+        val actual: ObjectSealedClass = SUT.giveMeOne()
+
+        then(actual).isInstanceOf(ObjectSealedClass::class.java)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun sealedObjectThenApply() {
+        val actual = SUT.giveMeBuilder<ObjectSealedClass>()
+            .thenApply { obj, builder ->  }
+            .sample()
+
+        then(actual).isInstanceOf(ObjectSealedClass::class.java)
+    }
+
     sealed class SealedClass
 
     object ObjectSealedClass : SealedClass()


### PR DESCRIPTION
## Summary
Fix generate Kotlin object, sealed object instance

## (Optional): Description
*Describe your changes in detail*

## How Has This Been Tested?
* generateObjectInstanceThrows
* sealedObject
* sealedObjectThenApply

## Is the Document updated?
Later