### PR TITLE
Fix Kotlin type not directly using javaType

### DIFF
--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/ArbExtension.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/ArbExtension.kt
@@ -23,22 +23,17 @@ package com.navercorp.fixturemonkey.kotest
 import com.navercorp.fixturemonkey.ArbitraryBuilder
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.property.PropertySelector
-import com.navercorp.fixturemonkey.api.type.TypeReference
-import com.navercorp.fixturemonkey.api.type.Types
 import com.navercorp.fixturemonkey.kotlin.KotlinTypeDefaultArbitraryBuilder
-import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.navercorp.fixturemonkey.kotlin.propertyExpressionGenerator
+import com.navercorp.fixturemonkey.kotlin.type.toTypeReference
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.single
-import java.lang.reflect.AnnotatedType
-import java.lang.reflect.Type
 import java.util.function.Supplier
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.isSubtypeOf
-import kotlin.reflect.jvm.javaType
 import kotlin.reflect.typeOf
 
 @Suppress("UNCHECKED_CAST")
@@ -48,20 +43,7 @@ inline fun <reified T> FixtureMonkey.giveMeArb(): Arb<T> {
     return if (type.isSubtypeOf(typeOf<ArbitraryBuilder<*>>())) {
         val typeParameter = type.arguments[0]
 
-        arbitrary {
-            val javaType = typeParameter.type!!.javaType
-            giveMeBuilder(
-                object : TypeReference<T>() {
-                    override fun getType(): Type {
-                        return javaType
-                    }
-
-                    override fun getAnnotatedType(): AnnotatedType {
-                        return Types.generateAnnotatedTypeWithoutAnnotation(javaType)
-                    }
-                },
-            )
-        } as Arb<T>
+        arbitrary { giveMeBuilder(typeParameter.type!!.toTypeReference()) } as Arb<T>
     } else {
         arbitrary {
             this@giveMeArb.giveMeOne()

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -5,15 +5,15 @@ package com.navercorp.fixturemonkey.kotlin
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
 import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
+import com.navercorp.fixturemonkey.kotlin.type.actualType
 import com.navercorp.fixturemonkey.kotlin.type.getPropertyName
+import com.navercorp.fixturemonkey.kotlin.type.toTypeReference
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Field
-import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.jvm.javaField
-import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinProperty
 
 // property
@@ -488,13 +488,8 @@ private class KotlinProperty<V, R>(private val property: KProperty1<V, R>) : Pro
 }
 
 private class KotlinGetterProperty<V, R>(private val getter: KFunction1<V, R>) : Property {
-    private val callerType = getter.parameters[0].type.javaType as Class<*>
-    private val returnJavaType = getter.returnType.javaType
-    private val type: Class<*> = if (returnJavaType is ParameterizedType) {
-        returnJavaType.rawType as Class<*>
-    } else {
-        returnJavaType as Class<*>
-    }
+    private val callerType = getter.parameters[0].type.toTypeReference().type.actualType()
+    private val type: Class<*> = getter.returnType.toTypeReference().type.actualType()
     private val propertyName: String = resolvePropertyName()
 
     private fun resolvePropertyName(): String = getter.getPropertyName()

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/InterfaceKFunctionPropertyGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/generator/InterfaceKFunctionPropertyGenerator.kt
@@ -24,15 +24,16 @@ import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyGenerator
 import com.navercorp.fixturemonkey.api.type.Types
 import com.navercorp.fixturemonkey.kotlin.property.InterfaceKFunctionProperty
+import com.navercorp.fixturemonkey.kotlin.type.actualType
 import com.navercorp.fixturemonkey.kotlin.type.getPropertyName
 import com.navercorp.fixturemonkey.kotlin.type.isKotlinType
 import com.navercorp.fixturemonkey.kotlin.type.kotlinMemberFunctions
+import com.navercorp.fixturemonkey.kotlin.type.toTypeReference
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
 import kotlin.reflect.KParameter.Kind.INSTANCE
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaMethod
-import kotlin.reflect.jvm.javaType
 
 /**
  * A property generator for generating no-argument Kotlin interface method.
@@ -47,7 +48,7 @@ class InterfaceKFunctionPropertyGenerator : PropertyGenerator {
             val methods = type.kotlinMemberFunctions()
                 .filter { it.parameters.none { parameter -> parameter.kind != INSTANCE } }
                 .filter { !DATA_CLASS_METHOD_NAMES.contains(it.name) }
-                .filter { it.returnType.javaType != Void.TYPE }
+                .filter { it.returnType.toTypeReference().type.actualType() != Void.TYPE }
                 .map {
                     InterfaceKFunctionProperty(
                         it.returnType,

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/instantiator/KotlinInstantiator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/instantiator/KotlinInstantiator.kt
@@ -56,7 +56,6 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.javaType
 
 class KotlinInstantiatorProcessor :
     InstantiatorProcessor {
@@ -82,7 +81,7 @@ class KotlinInstantiatorProcessor :
 
         val inputParameterTypes = instantiator.inputParameterTypes
         val inputParameterNames = instantiator.inputParameterNames
-        val parameterTypeReferences = parameters.map { it.type.javaType.toTypeReference() }
+        val parameterTypeReferences = parameters.map { it.type.toTypeReference() }
         val parameterNames = parameters.map { it.name }
 
         val resolveParameterTypes = resolveParameterTypes(parameterTypeReferences, inputParameterTypes)
@@ -235,7 +234,7 @@ class KotlinInstantiatorProcessor :
     private fun hasAnyParameterMatchingFunction(function: KFunction<*>, inputParameterTypes: Array<Class<*>>): Boolean =
         function.parameters
             .filter { parameter -> parameter.kind != KParameter.Kind.INSTANCE }
-            .map { parameter -> parameter.type.javaType.actualType() }
+            .map { parameter -> parameter.type.toTypeReference().type.actualType() }
             .let {
                 inputParameterTypes.isEmpty() || Types.isAssignableTypes(it.toTypedArray(), inputParameterTypes)
             }

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/InterfaceKFunctionProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/InterfaceKFunctionProperty.kt
@@ -19,13 +19,13 @@
 package com.navercorp.fixturemonkey.kotlin.property
 
 import com.navercorp.fixturemonkey.api.property.MethodProperty
+import com.navercorp.fixturemonkey.kotlin.type.toTypeReference
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Type
 import java.util.Optional
 import kotlin.reflect.KType
-import kotlin.reflect.jvm.javaType
 
 /**
  * An interface method property for kotlin.
@@ -37,7 +37,7 @@ data class InterfaceKFunctionProperty(
     private val methodName: String,
     private val annotations: List<Annotation>,
 ) : MethodProperty {
-    override fun getType(): Type = type.javaType
+    override fun getType(): Type = type.toTypeReference().type
 
     override fun getAnnotatedType(): AnnotatedType = object : AnnotatedType {
         override fun getType(): Type = this@InterfaceKFunctionProperty.getType()

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/type/KotlinTypes.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/type/KotlinTypes.kt
@@ -149,7 +149,7 @@ fun Class<*>.declaredConstructor(
         Types.isAssignableTypes(
             arguments,
             constructor.parameters.filter { it.kind != KParameter.Kind.INSTANCE }
-                .map { it.type.javaType.actualType() }
+                .map { it.type.toTypeReference().type.actualType() }
                 .toTypedArray(),
         )
     } ?: this.kotlin.constructors.first()

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
@@ -102,6 +102,17 @@ class ValueClassTest {
         then(actual).isNotNull
     }
 
+    @Test
+    fun factoryParameterWithTypeValueClass() {
+        val actual = SUT.giveMeKotlinBuilder<ConcreteClass>()
+            .instantiateBy<ConcreteClass> { factory<ConcreteClass>("factory"){
+                parameter<Foo>("id")
+            } }
+            .sample()
+
+        then(actual).isNotNull
+    }
+
     @JvmInline
     value class Foo(
         val bar: String,


### PR DESCRIPTION
## Summary
Fix Kotlin type not directly using javaType due to `value class`

## How Has This Been Tested?
* existing tests

## Is the Document updated?
Later
