### PR TITLE
Add StringCombinableArbitrary for easy efficient customisation

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -39,8 +39,11 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 public interface CombinableArbitrary<T> {
 	CombinableArbitrary<?> NOT_GENERATED = CombinableArbitrary.from((Object)null);
 	int DEFAULT_MAX_TRIES = 1_000;
+
 	ServiceLoader<IntegerCombinableArbitrary> INTEGER_COMBINABLE_ARBITRARY_SERVICE_LOADER =
 		ServiceLoader.load(IntegerCombinableArbitrary.class);
+	ServiceLoader<StringCombinableArbitrary> STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(StringCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -199,5 +202,16 @@ public interface CombinableArbitrary<T> {
 	@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 	static IntegerCombinableArbitrary integers() {
 		return INTEGER_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
+
+	/**
+	 * Generates a {@link StringCombinableArbitrary} which returns a randomly generated String.
+	 * You can customize the generated String by using {@link StringCombinableArbitrary}.
+	 *
+	 * @return a {@link CombinableArbitrary} returns a randomly generated String
+	 */
+	@API(since = "1.1.12", status = Status.EXPERIMENTAL)
+	static StringCombinableArbitrary strings() {
+		return STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -1,0 +1,119 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
+	int STRING_DEFAULT_MIN_LENGTH = 0;
+	int STRING_DEFAULT_MAX_LENGTH = 100;
+
+	@Override
+	String combined();
+
+	@Override
+	String rawValue();
+
+	StringCombinableArbitrary withLength(int min, int max);
+
+	/**
+	 * Generates a StringCombinableArbitrary which contains only alphabetic characters.
+	 * It conflicts with {@link #ascii()} and {@link #numeric()} and {@link #korean()}.
+	 *
+	 * @return the StringCombinableArbitrary which contains only alphabetic characters
+	 */
+	StringCombinableArbitrary alphabetic();
+
+	/**
+	 * Generates a StringCombinableArbitrary which contains only ASCII characters.
+	 * It conflicts with {@link #alphabetic()} and {@link #numeric()} and {@link #korean()}.
+	 *
+	 * @return the StringCombinableArbitrary which contains only ASCII characters
+	 */
+	StringCombinableArbitrary ascii();
+
+	/**
+	 * Generates a StringCombinableArbitrary which contains only numeric characters.
+	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #korean()}.
+	 *
+	 * @return the StringCombinableArbitrary which contains only numeric characters
+	 */
+	StringCombinableArbitrary numeric();
+
+	/**
+	 * Generates a StringCombinableArbitrary which contains only Korean characters.
+	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #numeric()}.
+	 *
+	 * @return the StringCombinableArbitrary which contains only Korean characters
+	 */
+	StringCombinableArbitrary korean();
+
+	default StringCombinableArbitrary withMinLength(int min) {
+		return this.withLength(min, STRING_DEFAULT_MAX_LENGTH);
+	}
+
+	default StringCombinableArbitrary withMaxLength(int max) {
+		return this.withLength(STRING_DEFAULT_MIN_LENGTH, max);
+	}
+
+	@Override
+	default StringCombinableArbitrary filter(Predicate<String> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default StringCombinableArbitrary filter(int tries, Predicate<String> predicate) {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	default StringCombinableArbitrary filterCharacter(Predicate<Character> predicate) {
+		return this.filterCharacter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate);
+
+	/**
+	 * Generates the pattern matched arbitrary String.
+	 * Its performance differs from the generation engine you're using.
+	 *
+	 * @param stringPattern the regular expression pattern
+	 * @return the pattern matched StringCombinableArbitrary
+	 */
+	default StringCombinableArbitrary pattern(int tries, String stringPattern) {
+		Pattern pattern = Pattern.compile(stringPattern);
+		return this.filter(tries, it -> pattern.matcher(it).matches());
+	}
+
+	@Override
+	default StringCombinableArbitrary injectNull(double nullProbability) {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default StringCombinableArbitrary unique() {
+		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -24,17 +24,21 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	int STRING_DEFAULT_MIN_LENGTH = 0;
 	int STRING_DEFAULT_MAX_LENGTH = 100;
 
-	@Override
-	String combined();
-
-	@Override
-	String rawValue();
-
 	StringCombinableArbitrary withLength(int min, int max);
 
 	/**
 	 * Generates a StringCombinableArbitrary which contains only alphabetic characters.
 	 * It conflicts with {@link #ascii()} and {@link #numeric()} and {@link #korean()}.
+	 * Calling this method will ignore any previously called character set methods.
+	 * 
+	 * <p>Example:
+	 * <pre>{@code
+	 * // Only the last character set method (alphabetic) will be applied
+	 * stringArbitrary.numeric().alphabetic() // generates alphabetic characters only
+	 * 
+	 * // Other configuration methods are also ignored when character set method is called
+	 * stringArbitrary.withMinLength(5).alphabetic() // withMinLength(5) is ignored
+	 * }</pre>
 	 *
 	 * @return the StringCombinableArbitrary which contains only alphabetic characters
 	 */
@@ -43,6 +47,16 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	/**
 	 * Generates a StringCombinableArbitrary which contains only ASCII characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #numeric()} and {@link #korean()}.
+	 * Calling this method will ignore any previously called character set methods.
+	 * 
+	 * <p>Example:
+	 * <pre>{@code
+	 * // Only the last character set method (ascii) will be applied
+	 * stringArbitrary.korean().ascii() // generates ASCII characters only
+	 * 
+	 * // Other configuration methods are also ignored when character set method is called
+	 * stringArbitrary.withMaxLength(10).ascii() // withMaxLength(10) is ignored
+	 * }</pre>
 	 *
 	 * @return the StringCombinableArbitrary which contains only ASCII characters
 	 */
@@ -51,6 +65,16 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	/**
 	 * Generates a StringCombinableArbitrary which contains only numeric characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #korean()}.
+	 * Calling this method will ignore any previously called character set methods.
+	 * 
+	 * <p>Example:
+	 * <pre>{@code
+	 * // Only the last character set method (numeric) will be applied
+	 * stringArbitrary.alphabetic().numeric() // generates numeric characters only
+	 * 
+	 * // Other configuration methods are also ignored when character set method is called
+	 * stringArbitrary.withLength(3, 7).numeric() // withLength(3, 7) is ignored
+	 * }</pre>
 	 *
 	 * @return the StringCombinableArbitrary which contains only numeric characters
 	 */
@@ -59,6 +83,16 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	/**
 	 * Generates a StringCombinableArbitrary which contains only Korean characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #numeric()}.
+	 * Calling this method will ignore any previously called character set methods.
+	 * 
+	 * <p>Example:
+	 * <pre>{@code
+	 * // Only the last character set method (korean) will be applied
+	 * stringArbitrary.ascii().korean() // generates Korean characters only
+	 * 
+	 * // Other configuration methods are also ignored when character set method is called
+	 * stringArbitrary.withMinLength(5).korean() // withMinLength(5) is ignored
+	 * }</pre>
 	 *
 	 * @return the StringCombinableArbitrary which contains only Korean characters
 	 */
@@ -72,20 +106,54 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 		return this.withLength(STRING_DEFAULT_MIN_LENGTH, max);
 	}
 
+	/**
+	 * Filters the generated strings using the given predicate.
+	 * This method sets an invariant condition for string generation.
+	 * This method can conflict with other methods and should be used carefully.
+	 *
+	 * @param predicate the predicate to filter strings
+	 * @return the filtered StringCombinableArbitrary
+	 */
 	@Override
 	default StringCombinableArbitrary filter(Predicate<String> predicate) {
 		return this.filter(DEFAULT_MAX_TRIES, predicate);
 	}
 
+	/**
+	 * Filters the generated strings using the given predicate with specified retry attempts.
+	 * This method sets an invariant condition for string generation.
+	 * This method can conflict with other methods and should be used carefully.
+	 *
+	 * @param tries the maximum number of tries to generate a valid string
+	 * @param predicate the predicate to filter strings
+	 * @return the filtered StringCombinableArbitrary
+	 */
 	@Override
 	default StringCombinableArbitrary filter(int tries, Predicate<String> predicate) {
 		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
 	}
 
+	/**
+	 * Filters individual characters in the generated strings using the given predicate.
+	 * This method sets an invariant condition for character generation.
+	 * This method can conflict with other methods and should be used carefully.
+	 *
+	 * @param predicate the predicate to filter characters
+	 * @return the filtered StringCombinableArbitrary
+	 */
 	default StringCombinableArbitrary filterCharacter(Predicate<Character> predicate) {
 		return this.filterCharacter(DEFAULT_MAX_TRIES, predicate);
 	}
 
+	/**
+	 * Filters individual characters in the generated strings using the given predicate with specified retry attempts.
+	 * This method sets an invariant condition for character generation.
+	 * This method can conflict with other methods and should be used carefully.
+	 *
+	 * @param tries the maximum number of tries to generate a valid character
+	 * @param predicate the predicate to filter characters
+	 * @return the filtered StringCombinableArbitrary
+	 */
 	StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate);
 
 	@Override
@@ -97,10 +165,4 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	default StringCombinableArbitrary unique() {
 		return new StringCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
 	}
-
-	@Override
-	void clear();
-
-	@Override
-	boolean fixed();
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -19,7 +19,6 @@
 package com.navercorp.fixturemonkey.api.arbitrary;
 
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	int STRING_DEFAULT_MIN_LENGTH = 0;
@@ -88,18 +87,6 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	}
 
 	StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate);
-
-	/**
-	 * Generates the pattern matched arbitrary String.
-	 * Its performance differs from the generation engine you're using.
-	 *
-	 * @param stringPattern the regular expression pattern
-	 * @return the pattern matched StringCombinableArbitrary
-	 */
-	default StringCombinableArbitrary pattern(int tries, String stringPattern) {
-		Pattern pattern = Pattern.compile(stringPattern);
-		return this.filter(tries, it -> pattern.matcher(it).matches());
-	}
 
 	@Override
 	default StringCombinableArbitrary injectNull(double nullProbability) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -20,6 +20,13 @@ package com.navercorp.fixturemonkey.api.arbitrary;
 
 import java.util.function.Predicate;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * A combinable arbitrary for generating strings with various character sets and constraints.
+ */
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	int STRING_DEFAULT_MIN_LENGTH = 0;
 	int STRING_DEFAULT_MAX_LENGTH = 100;
@@ -30,12 +37,12 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	 * Generates a StringCombinableArbitrary which contains only alphabetic characters.
 	 * It conflicts with {@link #ascii()} and {@link #numeric()} and {@link #korean()}.
 	 * Calling this method will ignore any previously called character set methods.
-	 * 
+	 *
 	 * <p>Example:
 	 * <pre>{@code
 	 * // Only the last character set method (alphabetic) will be applied
 	 * stringArbitrary.numeric().alphabetic() // generates alphabetic characters only
-	 * 
+	 *
 	 * // Other configuration methods are also ignored when character set method is called
 	 * stringArbitrary.withMinLength(5).alphabetic() // withMinLength(5) is ignored
 	 * }</pre>
@@ -48,12 +55,12 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	 * Generates a StringCombinableArbitrary which contains only ASCII characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #numeric()} and {@link #korean()}.
 	 * Calling this method will ignore any previously called character set methods.
-	 * 
+	 *
 	 * <p>Example:
 	 * <pre>{@code
 	 * // Only the last character set method (ascii) will be applied
 	 * stringArbitrary.korean().ascii() // generates ASCII characters only
-	 * 
+	 *
 	 * // Other configuration methods are also ignored when character set method is called
 	 * stringArbitrary.withMaxLength(10).ascii() // withMaxLength(10) is ignored
 	 * }</pre>
@@ -66,12 +73,12 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	 * Generates a StringCombinableArbitrary which contains only numeric characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #korean()}.
 	 * Calling this method will ignore any previously called character set methods.
-	 * 
+	 *
 	 * <p>Example:
 	 * <pre>{@code
 	 * // Only the last character set method (numeric) will be applied
 	 * stringArbitrary.alphabetic().numeric() // generates numeric characters only
-	 * 
+	 *
 	 * // Other configuration methods are also ignored when character set method is called
 	 * stringArbitrary.withLength(3, 7).numeric() // withLength(3, 7) is ignored
 	 * }</pre>
@@ -84,12 +91,12 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	 * Generates a StringCombinableArbitrary which contains only Korean characters.
 	 * It conflicts with {@link #alphabetic()} and {@link #ascii()} and {@link #numeric()}.
 	 * Calling this method will ignore any previously called character set methods.
-	 * 
+	 *
 	 * <p>Example:
 	 * <pre>{@code
 	 * // Only the last character set method (korean) will be applied
 	 * stringArbitrary.ascii().korean() // generates Korean characters only
-	 * 
+	 *
 	 * // Other configuration methods are also ignored when character set method is called
 	 * stringArbitrary.withMinLength(5).korean() // withMinLength(5) is ignored
 	 * }</pre>

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitrary.java
@@ -31,6 +31,9 @@ public interface StringCombinableArbitrary extends CombinableArbitrary<String> {
 	int STRING_DEFAULT_MIN_LENGTH = 0;
 	int STRING_DEFAULT_MAX_LENGTH = 100;
 
+	@Override
+	String rawValue();
+
 	StringCombinableArbitrary withLength(int min, int max);
 
 	/**

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/StringCombinableArbitraryDelegator.java
@@ -1,0 +1,89 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+
+final class StringCombinableArbitraryDelegator implements StringCombinableArbitrary {
+	private final CombinableArbitrary<String> delegate;
+
+	public StringCombinableArbitraryDelegator(CombinableArbitrary<String> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public String combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public String rawValue() {
+		return delegate.combined();
+	}
+
+	@Override
+	public StringCombinableArbitrary withLength(int min, int max) {
+		return new StringCombinableArbitraryDelegator(delegate.filter(it -> min <= it.length() && it.length() <= max));
+	}
+
+	@Override
+	public StringCombinableArbitrary alphabetic() {
+		return CombinableArbitrary.strings().alphabetic();
+	}
+
+	@Override
+	public StringCombinableArbitrary ascii() {
+		return CombinableArbitrary.strings().ascii();
+	}
+
+	@Override
+	public StringCombinableArbitrary numeric() {
+		return CombinableArbitrary.strings().numeric();
+	}
+
+	@Override
+	public StringCombinableArbitrary korean() {
+		return CombinableArbitrary.strings().korean();
+	}
+
+	@Override
+	public StringCombinableArbitrary filter(int tries, Predicate<String> predicate) {
+		return new StringCombinableArbitraryDelegator(delegate.filter(tries, predicate));
+	}
+
+	@Override
+	public StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate) {
+		return this.filter(tries, it -> it.chars().mapToObj(Character.class::cast).allMatch(predicate));
+	}
+
+	@Override
+	public StringCombinableArbitrary unique() {
+		return new StringCombinableArbitraryDelegator(delegate.unique());
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaTypeArbitraryGeneratorSet.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikJavaTypeArbitraryGeneratorSet.java
@@ -46,7 +46,9 @@ public final class JqwikJavaTypeArbitraryGeneratorSet implements JavaTypeArbitra
 
 	@Override
 	public CombinableArbitrary<String> strings(ArbitraryGeneratorContext context) {
-		return ArbitraryUtils.toCombinableArbitrary(arbitraryResolver.strings(arbitraryGenerator.strings(), context));
+		return ArbitraryUtils.toCombinableArbitrary(
+			arbitraryResolver.strings(arbitraryGenerator.strings(), context)
+		);
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
@@ -23,12 +23,16 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.arbitraries.ListArbitrary;
 
 import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
 
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 public final class JqwikStringCombinableArbitrary implements StringCombinableArbitrary {
 	private final Arbitrary<Character> characterArbitrary;
 	@Nullable

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikStringCombinableArbitrary.java
@@ -1,0 +1,114 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.ListArbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
+
+public final class JqwikStringCombinableArbitrary implements StringCombinableArbitrary {
+	private final Arbitrary<Character> characterArbitrary;
+	@Nullable
+	private Integer minSize = null;
+	@Nullable
+	private Integer maxSize = null;
+
+	public JqwikStringCombinableArbitrary() {
+		this.characterArbitrary = Arbitraries.chars();
+	}
+
+	private JqwikStringCombinableArbitrary(Arbitrary<Character> characterArbitrary) {
+		this.characterArbitrary = characterArbitrary;
+	}
+
+	@Override
+	public String combined() {
+		ListArbitrary<Character> characterListArbitrary = characterArbitrary.list();
+		if (this.minSize != null) {
+			characterListArbitrary = characterListArbitrary.ofMinSize(this.minSize);
+		}
+
+		if (this.maxSize != null) {
+			characterListArbitrary = characterListArbitrary.ofMaxSize(this.maxSize);
+		}
+
+		List<Character> characters = characterListArbitrary.sample();
+		StringBuilder stringBuilder = new StringBuilder();
+		for (Character character : characters) {
+			stringBuilder.append(character);
+		}
+		return stringBuilder.toString();
+	}
+
+	@Override
+	public String rawValue() {
+		return this.combined();
+	}
+
+	@Override
+	public StringCombinableArbitrary withLength(int minSize, int maxSize) {
+		this.minSize = minSize;
+		this.maxSize = maxSize;
+		return this;
+	}
+
+	@Override
+	public StringCombinableArbitrary alphabetic() {
+		return new JqwikStringCombinableArbitrary(Arbitraries.chars().alpha());
+	}
+
+	@Override
+	public StringCombinableArbitrary ascii() {
+		return new JqwikStringCombinableArbitrary(Arbitraries.chars().ascii());
+	}
+
+	@Override
+	public StringCombinableArbitrary numeric() {
+		return new JqwikStringCombinableArbitrary(Arbitraries.chars().numeric());
+	}
+
+	@Override
+	public StringCombinableArbitrary korean() {
+		return new JqwikStringCombinableArbitrary(Arbitraries.chars().filter(
+			it -> '가' <= it && it <= '힣'
+		));
+	}
+
+	@Override
+	public StringCombinableArbitrary filterCharacter(int tries, Predicate<Character> predicate) {
+		return new JqwikStringCombinableArbitrary(this.characterArbitrary.filter(tries, predicate));
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+}

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikStringCombinableArbitrary

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
@@ -68,7 +68,9 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
 import kotlin.math.floor
 import kotlin.math.pow
 import kotlin.time.toJavaDuration

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
@@ -19,9 +19,10 @@
 package com.navercorp.fixturemonkey.kotest
 
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
+import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet
-import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import io.kotest.property.Arb
@@ -44,11 +45,10 @@ import io.kotest.property.arbitrary.offsetDateTime
 import io.kotest.property.arbitrary.period
 import io.kotest.property.arbitrary.short
 import io.kotest.property.arbitrary.single
-import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.yearMonth
-import io.kotest.property.arbitrary.zonedDateTime
 import io.kotest.property.arbitrary.zoneId
 import io.kotest.property.arbitrary.zoneOffset
+import io.kotest.property.arbitrary.zonedDateTime
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status
 import java.math.BigDecimal
@@ -68,9 +68,7 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.util.Calendar
-import java.util.Date
-import java.util.GregorianCalendar
+import java.util.*
 import kotlin.math.floor
 import kotlin.math.pow
 import kotlin.time.toJavaDuration
@@ -79,17 +77,16 @@ import kotlin.time.toJavaDuration
 class KotestJavaArbitraryGeneratorSet(
     private val constraintGenerator: JavaConstraintGenerator,
 ) : JavaTypeArbitraryGeneratorSet {
-    override fun strings(context: ArbitraryGeneratorContext): CombinableArbitrary<String> {
+    override fun strings(context: ArbitraryGeneratorContext): StringCombinableArbitrary {
         val stringConstraint = constraintGenerator.generateStringConstraint(context)
 
-        return CombinableArbitrary.from {
-            if (stringConstraint != null) {
-                val minSize = stringConstraint.minSize?.toInt() ?: 0
-                val maxSize = stringConstraint.maxSize?.toInt() ?: 100
-                Arb.string(minSize = minSize, maxSize = maxSize).single()
-            } else {
-                Arb.string().single()
-            }
+        val combinableArbitrary = KotestStringCombinableArbitrary()
+        return if (stringConstraint != null) {
+            val minSize = stringConstraint.minSize?.toInt() ?: 0
+            val maxSize = stringConstraint.maxSize?.toInt() ?: 100
+            combinableArbitrary.withLength(minSize, maxSize)
+        } else {
+            combinableArbitrary
         }
     }
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
@@ -20,11 +20,12 @@ package com.navercorp.fixturemonkey.kotest
 
 import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.ascii
 import io.kotest.property.arbitrary.codepoints
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.string
-import io.kotest.property.arbitrary.stringPattern
 import java.util.function.Predicate
 
 class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string()) : StringCombinableArbitrary {
@@ -40,15 +41,12 @@ class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string(
 
     override fun alphabetic(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
         Arb.string(
-            codepoints = Arb.codepoints().filter { it.value.toChar() in 'a'..'z' }
+            codepoints = Arb.codepoints().filter { it.value.toChar() in 'a'..'z' || it.value.toChar() in 'A'..'Z' }
         )
     )
 
     override fun ascii(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
-        Arb.string(
-            codepoints = Arb.codepoints()
-                .filter { it.value.toChar() in Character.MIN_CODE_POINT.toChar()..MAX_ASCII_CODEPOINT.toChar() }
-        )
+        Arb.string(codepoints = Codepoint.ascii())
     )
 
     override fun numeric(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
@@ -69,9 +67,6 @@ class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string(
                 codepoints = Arb.codepoints().filter { predicate.test(it.value.toChar()) }
             )
         )
-
-    override fun pattern(treis: Int, pattern: String): StringCombinableArbitrary =
-        KotestStringCombinableArbitrary(Arb.stringPattern(pattern))
 
     override fun clear() {
     }

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
@@ -26,8 +26,11 @@ import io.kotest.property.arbitrary.codepoints
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.string
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
 import java.util.function.Predicate
 
+@API(since = "1.1.12", status = EXPERIMENTAL)
 class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string()) : StringCombinableArbitrary {
     override fun combined(): String = arb.single()
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestStringCombinableArbitrary.kt
@@ -1,0 +1,84 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.codepoints
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.single
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.stringPattern
+import java.util.function.Predicate
+
+class KotestStringCombinableArbitrary(private val arb: Arb<String> = Arb.string()) : StringCombinableArbitrary {
+    override fun combined(): String = arb.single()
+
+    override fun rawValue(): String = arb.single()
+
+    override fun filter(tries: Int, predicate: Predicate<String>): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(arb.filter { predicate.test(it) })
+
+    override fun withLength(min: Int, max: Int): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(Arb.string(min..max))
+
+    override fun alphabetic(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints().filter { it.value.toChar() in 'a'..'z' }
+        )
+    )
+
+    override fun ascii(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints()
+                .filter { it.value.toChar() in Character.MIN_CODE_POINT.toChar()..MAX_ASCII_CODEPOINT.toChar() }
+        )
+    )
+
+    override fun numeric(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints().filter { it.value.toChar() in '0'..'9' }
+        )
+    )
+
+    override fun korean(): StringCombinableArbitrary = KotestStringCombinableArbitrary(
+        Arb.string(
+            codepoints = Arb.codepoints().filter { it.value.toChar() in '가'..'힣' }
+        )
+    )
+
+    override fun filterCharacter(tries: Int, predicate: Predicate<Char>): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(
+            Arb.string(
+                codepoints = Arb.codepoints().filter { predicate.test(it.value.toChar()) }
+            )
+        )
+
+    override fun pattern(treis: Int, pattern: String): StringCombinableArbitrary =
+        KotestStringCombinableArbitrary(Arb.stringPattern(pattern))
+
+    override fun clear() {
+    }
+
+    override fun fixed(): Boolean = false
+
+    companion object {
+        private const val MAX_ASCII_CODEPOINT: Int = 0x007F
+    }
+}

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -55,6 +55,7 @@ import net.jqwik.api.Arbitraries;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
+import com.navercorp.fixturemonkey.api.arbitrary.StringCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.exception.RetryableFilterMissException;
 import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospector;
@@ -62,6 +63,7 @@ import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitra
 import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.jqwik.JqwikIntegerCombinableArbitrary;
+import com.navercorp.fixturemonkey.api.jqwik.JqwikStringCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin;
@@ -1608,5 +1610,79 @@ class JavaTest {
 		Integer actual = CombinableArbitrary.integers().negative().withRange(100, 1000).combined();
 
 		then(actual).isBetween(100, 1000);
+	}
+
+	@Test
+	void stringCombinableArbitraryIsJqwik() {
+		StringCombinableArbitrary actual = CombinableArbitrary.strings();
+
+		then(actual).isInstanceOf(JqwikStringCombinableArbitrary.class);
+	}
+
+	@Test
+	void stringCombinableArbitraryInjectNull() {
+		String actual = CombinableArbitrary.strings().injectNull(1).combined();
+
+		then(actual).isNull();
+	}
+
+	@Test
+	void stringCombinableArbitraryFilter() {
+		String actual = CombinableArbitrary.strings().filter(it -> it.length() > 5).combined();
+
+		then(actual).hasSizeGreaterThan(5);
+	}
+
+	@Test
+	void stringCombinableArbitraryFilterCharacter() {
+		String actual = CombinableArbitrary.strings().filterCharacter(it -> 'a' <= it && it <= 'z').combined();
+
+		then(actual.chars()).allMatch(it -> 'a' <= it && it <= 'z');
+	}
+
+	@Test
+	void stringCombinableArbitraryFilterCharacterAndFilter() {
+		String actual = CombinableArbitrary.strings()
+			.filterCharacter(it -> 'a' <= it && it <= 'z')
+			.filter(it -> it.length() < 5)
+			.combined();
+
+		then(actual.chars()).allMatch(it -> 'a' <= it && it <= 'z');
+		then(actual).hasSizeLessThan(5);
+	}
+
+	@Test
+	void stringCombinableArbitraryNumeric() {
+		String actual = CombinableArbitrary.strings().numeric().combined();
+
+		then(actual).matches("[0-9]*");
+	}
+
+	@Test
+	void stringCombinableArbitraryMap() {
+		String actual = CombinableArbitrary.strings().map(it -> "prefix" + it).combined();
+
+		then(actual).startsWith("prefix");
+	}
+
+	@Test
+	void stringCombinableArbitraryKorean() {
+		String actual = CombinableArbitrary.strings().korean().combined();
+
+		then(actual.chars()).allMatch(it -> '가' <= it && it <= '힣');
+	}
+
+	@Test
+	void stringCombinableArbitraryAlphabet() {
+		String actual = CombinableArbitrary.strings().alphabetic().combined();
+
+		then(actual).isAlphabetic();
+	}
+
+	@Test
+	void stringCombinableArbitraryLatterWins() {
+		String actual = CombinableArbitrary.strings().korean().alphabetic().combined();
+
+		then(actual).isAlphabetic();
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -929,7 +929,7 @@ class KotestInJunitTest {
     fun stringCombinableArbitraryAscii() {
         val actual = CombinableArbitrary.strings().ascii().combined()
 
-        then(actual).isInstanceOf(KotestStringCombinableArbitrary::class.java)
+        then(actual).isASCII()
     }
 
     companion object {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -21,8 +21,9 @@ package com.navercorp.fixturemonkey.tests.kotlin
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
-import com.navercorp.fixturemonkey.kotest.KotestPlugin
 import com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary
+import com.navercorp.fixturemonkey.kotest.KotestPlugin
+import com.navercorp.fixturemonkey.kotest.KotestStringCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.giveMeArb
 import com.navercorp.fixturemonkey.kotest.setArb
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
@@ -876,45 +877,59 @@ class KotestInJunitTest {
     }
 
     @Test
-    fun integerCombinableArbitrary(){
+    fun integerCombinableArbitrary() {
         val actual = CombinableArbitrary.integers()
 
         then(actual).isInstanceOf(KotestIntegerCombinableArbitrary::class.java)
     }
 
     @RepeatedTest(TEST_COUNT)
-    fun integerCombinableArbitraryPositive(){
+    fun integerCombinableArbitraryPositive() {
         val actual = CombinableArbitrary.integers().positive().combined()
 
         then(actual).isPositive()
     }
 
     @RepeatedTest(TEST_COUNT)
-    fun integerCombinableArbitraryNegative(){
+    fun integerCombinableArbitraryNegative() {
         val actual = CombinableArbitrary.integers().negative().combined()
 
         then(actual).isNegative()
     }
 
     @RepeatedTest(TEST_COUNT)
-    fun integerCombinableArbitraryEven(){
+    fun integerCombinableArbitraryEven() {
         val actual = CombinableArbitrary.integers().even().combined()
 
         then(actual).isEven()
     }
 
     @RepeatedTest(TEST_COUNT)
-    fun integerCombinableArbitraryOdd(){
+    fun integerCombinableArbitraryOdd() {
         val actual = CombinableArbitrary.integers().odd().combined()
 
         then(actual).isOdd()
     }
 
     @RepeatedTest(TEST_COUNT)
-    fun integerCombinableArbitraryWithRange(){
+    fun integerCombinableArbitraryWithRange() {
         val actual = CombinableArbitrary.integers().withRange(10, 20).combined()
 
         then(actual).isBetween(10, 20)
+    }
+
+    @Test
+    fun stringCombinableArbitrary() {
+        val actual = CombinableArbitrary.strings()
+
+        then(actual).isInstanceOf(KotestStringCombinableArbitrary::class.java)
+    }
+
+    @Test
+    fun stringCombinableArbitraryAscii() {
+        val actual = CombinableArbitrary.strings().ascii().combined()
+
+        then(actual).isInstanceOf(KotestStringCombinableArbitrary::class.java)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Add StringCombinableArbitrary for easy efficient customisation

## (Optional): Description
providing below APIs to customize the randomly generated String

- alphabetic
- korean
- ascii
- numeric
- pattern
- withLength
- withMinLength
- withMaxLength

## How Has This Been Tested?
* stringCombinableArbitraryIsJqwik
* stringCombinableArbitraryInjectNull
* stringCombinableArbitraryFilter
* stringCombinableArbitraryFilterCharacter
* stringCombinableArbitraryFilterCharacterAndFilter
* stringCombinableArbitraryNumeric
* stringCombinableArbitraryMap
* stringCombinableArbitraryKorean
* stringCombinableArbitraryAlphabet
* stringCombinableArbitraryLatterWins
* stringCombinableArbitrary
* stringCombinableArbitraryAscii

## Is the Document updated?
Later
