### PR TITLE
Refactor splits active context and standby contexts

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
@@ -596,5 +596,6 @@ open class KotlinTypeDefaultArbitraryBuilder<T> internal constructor(val delegat
 
 class InternalKotlinTypeDefaultArbitraryBuilder<T>(delegate: ArbitraryBuilder<T>) :
     KotlinTypeDefaultArbitraryBuilder<T>(delegate), ArbitraryBuilderContextProvider, ObjectBuilder<T> {
-    override fun getContext(): ArbitraryBuilderContext = (delegate as ArbitraryBuilderContextProvider).context
+    override fun getActiveContext(): ArbitraryBuilderContext =
+        (delegate as ArbitraryBuilderContextProvider).activeContext
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -90,7 +90,7 @@ public final class FixtureMonkey {
 	public <T> ArbitraryBuilder<T> giveMeBuilder(TypeReference<T> type) {
 		TreeRootProperty rootProperty = new RootProperty(new TypeParameterProperty(type.getAnnotatedType()));
 
-		List<MatcherOperator<ArbitraryBuilderContext>> possibleContexts =
+		List<MatcherOperator<ArbitraryBuilderContext>> standByContexts =
 			monkeyContext.getRegisteredArbitraryBuilders().stream()
 				.filter(it -> it.match(rootProperty))
 				.map(it ->
@@ -114,7 +114,7 @@ public final class FixtureMonkey {
 			monkeyManipulatorFactory,
 			monkeyExpressionFactory,
 			newActiveBuilderContext,
-			possibleContexts,
+			standByContexts,
 			monkeyContext,
 			fixtureMonkeyOptions.getInstantiatorProcessor()
 		);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkey.java
@@ -101,6 +101,9 @@ public final class FixtureMonkey {
 				)
 				.collect(toList());
 
+		ArbitraryBuilderContext newActiveBuilderContext =
+			ArbitraryBuilderContext.newBuilderContext(monkeyContext);
+
 		return new DefaultArbitraryBuilder<>(
 			rootProperty,
 			new ArbitraryResolver(
@@ -110,7 +113,7 @@ public final class FixtureMonkey {
 			),
 			monkeyManipulatorFactory,
 			monkeyExpressionFactory,
-			ArbitraryBuilderContext.newBuilderContext(monkeyContext),
+			newActiveBuilderContext,
 			possibleContexts,
 			monkeyContext,
 			fixtureMonkeyOptions.getInstantiatorProcessor()
@@ -118,11 +121,11 @@ public final class FixtureMonkey {
 	}
 
 	public <T> ArbitraryBuilder<T> giveMeBuilder(T value) {
-		ArbitraryBuilderContext context = ArbitraryBuilderContext.newBuilderContext(monkeyContext);
+		ArbitraryBuilderContext newActiveBuilderContext = ArbitraryBuilderContext.newBuilderContext(monkeyContext);
 
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(monkeyExpressionFactory.from("$").toNodeResolver(), value);
-		context.addManipulator(arbitraryManipulator);
+		newActiveBuilderContext.addManipulator(arbitraryManipulator);
 
 		return new DefaultArbitraryBuilder<>(
 			new RootProperty(new TypeParameterProperty(new LazyAnnotatedType<>(() -> value))),
@@ -133,7 +136,7 @@ public final class FixtureMonkey {
 			),
 			monkeyManipulatorFactory,
 			monkeyExpressionFactory,
-			context,
+			newActiveBuilderContext,
 			Collections.emptyList(),
 			monkeyContext,
 			fixtureMonkeyOptions.getInstantiatorProcessor()

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContext.java
@@ -224,7 +224,8 @@ public final class ArbitraryBuilderContext {
 				.stream()
 				.map(it -> new MatcherOperator<>(
 					it.getMatcher(),
-					((ArbitraryBuilderContextProvider)it.getOperator()).getContext().getContainerInfoManipulators()
+					((ArbitraryBuilderContextProvider)it.getOperator()).getActiveContext()
+						.getContainerInfoManipulators()
 				))
 				.collect(Collectors.toList());
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContextProvider.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContextProvider.java
@@ -28,5 +28,10 @@ import org.apiguardian.api.API.Status;
  **/
 @API(since = "1.1.2", status = Status.INTERNAL)
 public interface ArbitraryBuilderContextProvider {
-	ArbitraryBuilderContext getContext();
+	/**
+	 * Get the current context of {@link com.navercorp.fixturemonkey.ArbitraryBuilder}
+	 *
+	 * @return the current context of {@link com.navercorp.fixturemonkey.ArbitraryBuilder}
+	 */
+	ArbitraryBuilderContext getActiveContext();
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/DefaultArbitraryBuilder.java
@@ -58,6 +58,7 @@ import com.navercorp.fixturemonkey.api.instantiator.Instantiator;
 import com.navercorp.fixturemonkey.api.instantiator.InstantiatorProcessResult;
 import com.navercorp.fixturemonkey.api.instantiator.InstantiatorProcessor;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver;
 import com.navercorp.fixturemonkey.api.property.PropertySelector;
 import com.navercorp.fixturemonkey.api.property.RootProperty;
@@ -87,7 +88,18 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 	private final ArbitraryResolver resolver;
 	private final MonkeyManipulatorFactory monkeyManipulatorFactory;
 	private final MonkeyExpressionFactory monkeyExpressionFactory;
-	private final ArbitraryBuilderContext context;
+	/**
+	 * It is actual active context for the builder.
+	 * It has the actual applied manipulators.
+	 */
+	private final ArbitraryBuilderContext activeContext;
+	/**
+	 * It is used to resolve the root registered manipulators.
+	 * It should be resolved lazily like any other registered context.
+	 * It may not apply to the builder, which means its manipulators are not applied.
+	 * It is split from {@link #activeContext} to avoid the stack overflow caused by {@code thenApply} in the register.
+	 */
+	private final List<MatcherOperator<ArbitraryBuilderContext>> possibleContexts;
 	private final MonkeyContext monkeyContext;
 	private final InstantiatorProcessor instantiatorProcessor;
 
@@ -97,21 +109,23 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		MonkeyManipulatorFactory monkeyManipulatorFactory,
 		MonkeyExpressionFactory monkeyExpressionFactory,
 		ArbitraryBuilderContext context,
+		List<MatcherOperator<ArbitraryBuilderContext>> possibleContexts,
 		MonkeyContext monkeyContext,
 		InstantiatorProcessor instantiatorProcessor
 	) {
 		this.rootProperty = rootProperty;
 		this.resolver = resolver;
-		this.context = context;
+		this.activeContext = context;
 		this.monkeyManipulatorFactory = monkeyManipulatorFactory;
 		this.monkeyExpressionFactory = monkeyExpressionFactory;
 		this.monkeyContext = monkeyContext;
+		this.possibleContexts = possibleContexts;
 		this.instantiatorProcessor = instantiatorProcessor;
 	}
 
 	@Override
 	public ArbitraryBuilder<T> validOnly(boolean validOnly) {
-		this.context.setCustomizedValidOnly(validOnly);
+		this.activeContext.setCustomizedValidOnly(validOnly);
 		return this;
 	}
 
@@ -145,7 +159,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		} else {
 			ArbitraryManipulator arbitraryManipulator =
 				monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, value, limit);
-			this.context.addManipulator(arbitraryManipulator);
+			this.activeContext.addManipulator(arbitraryManipulator);
 		}
 		return this;
 	}
@@ -170,7 +184,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		NodeResolver nodeResolver = toMonkeyExpression(propertySelector).toNodeResolver();
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, supplier, limit);
-		this.context.addManipulator(arbitraryManipulator);
+		this.activeContext.addManipulator(arbitraryManipulator);
 		return this;
 	}
 
@@ -185,8 +199,8 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		List<ArbitraryManipulator> arbitraryManipulators = manipulatorSet.getArbitraryManipulators();
 		List<ContainerInfoManipulator> containerInfoManipulators = manipulatorSet.getContainerInfoManipulators();
 
-		this.context.addManipulators(arbitraryManipulators);
-		this.context.addContainerInfoManipulators(containerInfoManipulators);
+		this.activeContext.addManipulators(arbitraryManipulators);
+		this.activeContext.addContainerInfoManipulators(containerInfoManipulators);
 		return this;
 	}
 
@@ -239,22 +253,22 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 				minSize,
 				maxSize
 			);
-		this.context.addContainerInfoManipulator(containerInfoManipulator);
+		this.activeContext.addContainerInfoManipulator(containerInfoManipulator);
 
 		return this;
 	}
 
 	@Override
 	public ArbitraryBuilder<T> fixed() {
-		this.context.getContainerInfoManipulators().forEach(TreeNodeManipulator::fixed);
+		this.activeContext.getContainerInfoManipulators().forEach(TreeNodeManipulator::fixed);
 
-		this.context.markFixed();
+		this.activeContext.markFixed();
 		return this;
 	}
 
 	@Override
 	public ArbitraryBuilder<T> thenApply(BiConsumer<T, ArbitraryBuilder<T>> biConsumer) {
-		this.context.getContainerInfoManipulators().forEach(TreeNodeManipulator::fixed);
+		this.activeContext.getContainerInfoManipulators().forEach(TreeNodeManipulator::fixed);
 
 		ArbitraryBuilder<T> appliedBuilder = this.copy();
 
@@ -270,7 +284,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		NodeResolver nodeResolver = monkeyExpressionFactory.from("$").toNodeResolver();
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, lazyArbitrary);
-		this.context.addManipulator(arbitraryManipulator);
+		this.activeContext.addManipulator(arbitraryManipulator);
 		return this;
 	}
 
@@ -296,7 +310,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		NodeResolver nodeResolver = toMonkeyExpression(propertySelector).toNodeResolver();
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, null);
-		this.context.addManipulator(arbitraryManipulator);
+		this.activeContext.addManipulator(arbitraryManipulator);
 		return this;
 	}
 
@@ -312,7 +326,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, NOT_NULL);
 
-		this.context.addManipulator(arbitraryManipulator);
+		this.activeContext.addManipulator(arbitraryManipulator);
 		return this;
 	}
 
@@ -351,7 +365,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		NodeResolver nodeResolver = toMonkeyExpression(propertySelector).toNodeResolver();
 		ArbitraryManipulator arbitraryManipulator =
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, type, predicate, limit);
-		this.context.addManipulator(arbitraryManipulator);
+		this.activeContext.addManipulator(arbitraryManipulator);
 		return this;
 	}
 
@@ -456,8 +470,8 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		InstantiatorProcessResult result = instantiatorProcessor.process(typeReference, instantiator);
 
 		Class<?> type = Types.getActualType(typeReference.getType());
-		context.putArbitraryIntrospector(type, result.getIntrospector());
-		context.putPropertyConfigurer(type, result.getProperties());
+		activeContext.putArbitraryIntrospector(type, result.getIntrospector());
+		activeContext.putPropertyConfigurer(type, result.getProperties());
 		return this;
 	}
 
@@ -467,7 +481,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 		Function<CombinableArbitrary<? extends U>, CombinableArbitrary<? extends U>> combinableArbitraryCustomizer
 	) {
 		NodeResolver nodeResolver = toMonkeyExpression(propertySelector).toNodeResolver();
-		context.addManipulator(
+		activeContext.addManipulator(
 			monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, combinableArbitraryCustomizer)
 		);
 		return this;
@@ -476,7 +490,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 	@SuppressWarnings("unchecked")
 	@Override
 	public Arbitrary<T> build() {
-		ArbitraryBuilderContext buildContext = context.copy();
+		ArbitraryBuilderContext buildContext = activeContext.copy();
 
 		return Arbitraries.ofSuppliers(() -> (T)resolveArbitrary(buildContext).combined());
 	}
@@ -484,7 +498,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 	@SuppressWarnings("unchecked")
 	@Override
 	public T sample() {
-		return (T)resolveArbitrary(context).combined();
+		return (T)resolveArbitrary(activeContext).combined();
 	}
 
 	@Override
@@ -504,36 +518,39 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 			resolver,
 			monkeyManipulatorFactory,
 			monkeyExpressionFactory,
-			context.copy(),
+			activeContext.copy(),
+			possibleContexts,
 			monkeyContext,
 			instantiatorProcessor
 		);
 	}
 
 	@Override
-	public ArbitraryBuilderContext getContext() {
-		return this.context;
+	public ArbitraryBuilderContext getActiveContext() {
+		return this.activeContext;
 	}
 
-	private CombinableArbitrary<?> resolveArbitrary(ArbitraryBuilderContext context) {
-		if (context.isFixed()) {
-			if (context.getFixedCombinableArbitrary() == null || context.fixedExpired()) {
+	private CombinableArbitrary<?> resolveArbitrary(ArbitraryBuilderContext activeContext) {
+		if (activeContext.isFixed()) {
+			if (activeContext.getFixedCombinableArbitrary() == null || activeContext.fixedExpired()) {
 				Object fixed = resolver.resolve(
 						rootProperty,
-						context
+						activeContext,
+						possibleContexts
 					)
 					.combined();
 
 				NodeResolver nodeResolver = monkeyExpressionFactory.from("$").toNodeResolver();
-				context.addManipulator(monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, fixed));
-				context.renewFixed(CombinableArbitrary.from(fixed));
+				activeContext.addManipulator(monkeyManipulatorFactory.newArbitraryManipulator(nodeResolver, fixed));
+				activeContext.renewFixed(CombinableArbitrary.from(fixed));
 			}
-			return context.getFixedCombinableArbitrary();
+			return activeContext.getFixedCombinableArbitrary();
 		}
 
 		return resolver.resolve(
 			rootProperty,
-			context
+			activeContext,
+			possibleContexts
 		);
 	}
 
@@ -551,6 +568,7 @@ public final class DefaultArbitraryBuilder<T> implements ArbitraryBuilder<T>, Ex
 			monkeyManipulatorFactory,
 			monkeyExpressionFactory,
 			context,
+			possibleContexts,
 			monkeyContext,
 			instantiatorProcessor
 		);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/JavaTypeDefaultTypeArbitraryBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/JavaTypeDefaultTypeArbitraryBuilder.java
@@ -349,7 +349,7 @@ public final class JavaTypeDefaultTypeArbitraryBuilder<T>
 	}
 
 	@Override
-	public ArbitraryBuilderContext getContext() {
-		return ((ArbitraryBuilderContextProvider)delegate).getContext();
+	public ArbitraryBuilderContext getActiveContext() {
+		return ((ArbitraryBuilderContextProvider)delegate).getActiveContext();
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -62,7 +62,7 @@ public final class ArbitraryResolver {
 	public CombinableArbitrary<?> resolve(
 		TreeRootProperty rootProperty,
 		ArbitraryBuilderContext activeContext,
-		List<MatcherOperator<ArbitraryBuilderContext>> possibilitiesContexts
+		List<MatcherOperator<ArbitraryBuilderContext>> standbyContexts
 	) {
 		FixtureMonkeyOptions fixtureMonkeyOptions = monkeyContext.getFixtureMonkeyOptions();
 
@@ -93,7 +93,7 @@ public final class ArbitraryResolver {
 
 				List<ArbitraryManipulator> registeredRootManipulators =
 					monkeyManipulatorFactory.newRegisteredArbitraryManipulators(
-						possibilitiesContexts,
+						standbyContexts,
 						rootNodesByProperty
 					);
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -18,7 +18,10 @@
 
 package com.navercorp.fixturemonkey.resolver;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,12 +31,16 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary;
 import com.navercorp.fixturemonkey.api.context.MonkeyContext;
 import com.navercorp.fixturemonkey.api.matcher.DefaultTreeMatcherMetadata;
+import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.matcher.TreeMatcherOperator;
 import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptions;
+import com.navercorp.fixturemonkey.api.property.Property;
 import com.navercorp.fixturemonkey.api.property.TreeRootProperty;
 import com.navercorp.fixturemonkey.builder.ArbitraryBuilderContext;
+import com.navercorp.fixturemonkey.builder.ArbitraryBuilderContextProvider;
 import com.navercorp.fixturemonkey.customizer.ArbitraryManipulator;
 import com.navercorp.fixturemonkey.customizer.MonkeyManipulatorFactory;
+import com.navercorp.fixturemonkey.tree.ObjectNode;
 import com.navercorp.fixturemonkey.tree.ObjectTree;
 
 @API(since = "0.4.0", status = Status.MAINTAINED)
@@ -54,38 +61,63 @@ public final class ArbitraryResolver {
 
 	public CombinableArbitrary<?> resolve(
 		TreeRootProperty rootProperty,
-		ArbitraryBuilderContext builderContext
+		ArbitraryBuilderContext activeContext,
+		List<MatcherOperator<ArbitraryBuilderContext>> possibilitiesContexts
 	) {
 		FixtureMonkeyOptions fixtureMonkeyOptions = monkeyContext.getFixtureMonkeyOptions();
 
-		List<ArbitraryManipulator> manipulators = builderContext.getManipulators();
+		List<ArbitraryManipulator> activeManipulators = activeContext.getManipulators();
 
 		return new ResolvedCombinableArbitrary<>(
 			rootProperty,
 			() -> {
 				ObjectTree objectTree = new ObjectTree(
 					rootProperty,
-					builderContext.newGenerateFixtureContext(),
-					builderContext.newTraverseContext()
+					activeContext.newGenerateFixtureContext(),
+					activeContext.newTraverseContext()
 				);
 
 				fixtureMonkeyOptions.getBuilderContextInitializers().stream()
 					.filter(it -> it.match(new DefaultTreeMatcherMetadata(objectTree.getMetadata().getAnnotations())))
 					.findFirst()
 					.map(TreeMatcherOperator::getOperator)
-					.ifPresent(it -> builderContext.setOptionValidOnly(it.isValidOnly()));
+					.ifPresent(it -> activeContext.setOptionValidOnly(it.isValidOnly()));
 
 				return objectTree;
 			},
 			objectTree -> {
-				List<ArbitraryManipulator> registeredManipulators =
+				Map<Property, List<ObjectNode>> rootNodesByProperty = Collections.singletonMap(
+					rootProperty,
+					Collections.singletonList(objectTree.getMetadata().getRootNode())
+				);
+
+				List<ArbitraryManipulator> registeredRootManipulators =
 					monkeyManipulatorFactory.newRegisteredArbitraryManipulators(
-						monkeyContext.getRegisteredArbitraryBuilders(),
+						possibilitiesContexts,
+						rootNodesByProperty
+					);
+
+				List<MatcherOperator<ArbitraryBuilderContext>> registeredPropertyArbitraryBuilderContexts =
+					monkeyContext.getRegisteredArbitraryBuilders()
+						.stream()
+						.map(it -> new MatcherOperator<>(
+							it.getMatcher(),
+							((ArbitraryBuilderContextProvider)it.getOperator()).getActiveContext()
+						))
+						.collect(Collectors.toList());
+
+				List<ArbitraryManipulator> registeredPropertyManipulators =
+					monkeyManipulatorFactory.newRegisteredArbitraryManipulators(
+						registeredPropertyArbitraryBuilderContexts,
 						objectTree.getMetadata().getNodesByProperty()
 					);
 
+				List<ArbitraryManipulator> registeredManipulators = new ArrayList<>();
+				registeredManipulators.addAll(registeredRootManipulators);
+				registeredManipulators.addAll(registeredPropertyManipulators);
+
 				List<ArbitraryManipulator> joinedManipulators =
-					Stream.concat(registeredManipulators.stream(), manipulators.stream())
+					Stream.concat(registeredManipulators.stream(), activeManipulators.stream())
 						.collect(Collectors.toList());
 
 				List<ArbitraryManipulator> optimizedManipulator = manipulatorOptimizer
@@ -99,7 +131,7 @@ public final class ArbitraryResolver {
 			},
 			fixtureMonkeyOptions.getGenerateMaxTries(),
 			fixtureMonkeyOptions.getDefaultArbitraryValidator(),
-			builderContext::isValidOnly
+			activeContext::isValidOnly
 		);
 	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/MetadataCollector.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/MetadataCollector.java
@@ -54,6 +54,7 @@ final class MetadataCollector {
 			collect(child);
 		}
 		return new ObjectTreeMetadata(
+			rootNode,
 			Collections.unmodifiableMap(nodesByProperty),
 			Collections.unmodifiableSet(annotations)
 		);

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTreeMetadata.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/tree/ObjectTreeMetadata.java
@@ -30,12 +30,22 @@ import com.navercorp.fixturemonkey.api.property.Property;
 
 @API(since = "0.4.0", status = Status.INTERNAL)
 public final class ObjectTreeMetadata {
+	private final ObjectNode rootNode;
 	private final Map<Property, List<ObjectNode>> nodesByProperty; // matchOperator
 	private final Set<Annotation> annotations;
 
-	public ObjectTreeMetadata(Map<Property, List<ObjectNode>> nodesByProperty, Set<Annotation> annotations) {
-		this.nodesByProperty = nodesByProperty;
+	public ObjectTreeMetadata(
+		ObjectNode rootNode,
+		Map<Property, List<ObjectNode>> propertyNodesByProperty,
+		Set<Annotation> annotations
+	) {
+		this.rootNode = rootNode;
+		this.nodesByProperty = propertyNodesByProperty;
 		this.annotations = annotations;
+	}
+
+	public ObjectNode getRootNode() {
+		return rootNode;
 	}
 
 	public Map<Property, List<ObjectNode>> getNodesByProperty() {

--- a/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
+++ b/fixture-monkey/src/test/java/com/navercorp/fixturemonkey/test/FixtureMonkeyOptionsTest.java
@@ -699,7 +699,7 @@ class FixtureMonkeyOptionsTest {
 
 		then(actual).hasSizeBetween(1, 3);
 		then(actual2).hasSizeLessThan(5);
-		then(actual3).isEqualTo(RegisterGroup.FIXED_INT_VALUE);
+		then(actual3.getIntValue()).isEqualTo(RegisterGroup.FIXED_INT_VALUE.getIntValue());
 
 	}
 
@@ -717,7 +717,7 @@ class FixtureMonkeyOptionsTest {
 
 		then(actual).hasSizeBetween(1, 3);
 		then(actual2).hasSizeLessThan(5);
-		then(actual3).isEqualTo(ChildBuilderGroup.FIXED_INT_VALUE);
+		then(actual3.getIntValue()).isEqualTo(ChildBuilderGroup.FIXED_INT_VALUE.getIntValue());
 	}
 
 	@Property


### PR DESCRIPTION
## Summary
Refactor splits active context and standby contexts

## (Optional): Description
Maintain consistency with the initialization and application of registering manipulators, which means that registered manipulators are resolved lazily.

## How Has This Been Tested?
* existing tests

## Is the Document updated?
No Needed
