### PR TITLE
Add compatibility with TypedPropertySelector and path expression DSL

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/expression/JavaGetterPropertySelector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/expression/JavaGetterPropertySelector.java
@@ -26,7 +26,7 @@ import org.apiguardian.api.API.Status;
 import com.navercorp.fixturemonkey.api.property.PropertySelector;
 
 @API(since = "1.0.0", status = Status.EXPERIMENTAL)
-interface JavaGetterPropertySelector<T, U> extends PropertySelector, ExpressionGenerator {
+interface JavaGetterPropertySelector<T, U> extends PropertySelector, ExpressionGenerator, TypedPropertySelector<U> {
 	default <R> JoinJavaGetterPropertySelector<U, R> into(JavaGetterMethodReference<U, R> methodReference) {
 		JavaGetterMethodPropertySelector<U, R> next =
 			JavaGetterPropertySelectors.resolvePropertySelector(methodReference);

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/ExpressionGenerators.kt
@@ -3,6 +3,7 @@
 package com.navercorp.fixturemonkey.kotlin
 
 import com.navercorp.fixturemonkey.api.expression.ExpressionGenerator
+import com.navercorp.fixturemonkey.api.expression.TypedPropertySelector
 import com.navercorp.fixturemonkey.api.property.Property
 import com.navercorp.fixturemonkey.api.property.PropertyNameResolver
 import com.navercorp.fixturemonkey.kotlin.type.actualType
@@ -259,10 +260,10 @@ infix operator fun <T, E : Any> JoinableExpressionGenerator<T, Array<Array<E>>>.
     )
 
 // ExpressionGenerator factory
-fun <R, E> propertyExpressionGenerator(property: KProperty1<R, E?>): ExpressionGenerator =
+fun <R, E> propertyExpressionGenerator(property: KProperty1<R, E?>): PropertyExpressionGenerator<R, E?> =
     PropertyExpressionGenerator(KotlinProperty(property))
 
-fun <R, E> propertyExpressionGenerator(function: KFunction1<R, E?>): ExpressionGenerator =
+fun <R, E> propertyExpressionGenerator(function: KFunction1<R, E?>): PropertyExpressionGenerator<R, E?> =
     PropertyExpressionGenerator(KotlinGetterProperty(function))
 
 @JvmName("propertyIndexExpressionGenerator")
@@ -355,13 +356,13 @@ internal fun <T> allIndexExpressionGenerator(property: KFunction1<T, Class<T>>, 
         key
     )
 
-private class PropertyExpressionGenerator(private val property: Property) : ExpressionGenerator {
+class PropertyExpressionGenerator<F, T>(private val property: Property) : ExpressionGenerator, TypedPropertySelector<T> {
     override fun generate(propertyNameResolver: PropertyNameResolver): String =
         propertyNameResolver.resolve(property)
 }
 
 // ExpressionGenerator
-interface JoinableExpressionGenerator<F, T> : ExpressionGenerator {
+interface JoinableExpressionGenerator<F, T> : ExpressionGenerator, TypedPropertySelector<T> {
     infix fun <R> into(property: KProperty1<T, R?>): JoinableExpressionGenerator<F, R>
 
     infix fun <R> intoGetter(getter: KFunction1<T, R?>): JoinableExpressionGenerator<F, R>

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
@@ -592,6 +592,16 @@ open class KotlinTypeDefaultArbitraryBuilder<T> internal constructor(val delegat
         supplier: Supplier<Any?>,
     ): KotlinTypeDefaultArbitraryBuilder<T> =
         this.setLazy(propertySelector, supplier)
+
+    fun <U> customizeProperty(
+        property: KProperty1<T, U?>,
+        combinableArbitraryCustomizer: Function<CombinableArbitrary<out U>, CombinableArbitrary<out U>>
+    ): ArbitraryBuilder<T> = this.apply { delegate.customizeProperty(propertyExpressionGenerator(property), combinableArbitraryCustomizer) }
+
+    fun <U> customizeProperty(
+        property: KFunction1<T, U?>,
+        combinableArbitraryCustomizer: Function<CombinableArbitrary<out U>, CombinableArbitrary<out U>>
+    ): ArbitraryBuilder<T> = this.apply { delegate.customizeProperty(propertyExpressionGenerator(property), combinableArbitraryCustomizer) }
 }
 
 class InternalKotlinTypeDefaultArbitraryBuilder<T>(delegate: ArbitraryBuilder<T>) :

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -1462,4 +1462,45 @@ class JavaTest {
 			.isExactlyInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("should be interface");
 	}
+
+	@Test
+	void typedJavaGetter() {
+		String expected = "expected";
+
+		String actual = SUT.giveMeBuilder(JavaTypeObject.class)
+			.customizeProperty(javaGetter(JavaTypeObject::getString), arb -> arb.map(it -> expected))
+			.sample()
+			.getString();
+
+		then(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void nestedTypedJavaGetter() {
+		String expected = "expected";
+
+		String actual = SUT.giveMeBuilder(RootJavaTypeObject.class)
+			.customizeProperty(javaGetter(RootJavaTypeObject::getValue).into(JavaTypeObject::getString),
+				arb -> arb.map(it -> expected))
+			.sample()
+			.getValue()
+			.getString();
+
+		then(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void indexTypedJavaGetter() {
+		String expected = "expected";
+
+		String actual = SUT.giveMeBuilder(ContainerObject.class)
+			.size("list", 1)
+			.customizeProperty(javaGetter(ContainerObject::getList).index(String.class, 0),
+				arb -> arb.map(it -> expected))
+			.sample()
+			.getList()
+			.get(0);
+
+		then(actual).isEqualTo(expected);
+	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/java/com/navercorp/fixturemonkey/tests/kotlin/ImmutableJavaTestSpecs.java
+++ b/fixture-monkey-tests/kotlin-tests/src/test/java/com/navercorp/fixturemonkey/tests/kotlin/ImmutableJavaTestSpecs.java
@@ -18,6 +18,8 @@
 
 package com.navercorp.fixturemonkey.tests.kotlin;
 
+import java.beans.ConstructorProperties;
+
 class ImmutableJavaTestSpecs {
 	public static class ArrayObject {
 		private final String[] array;
@@ -43,4 +45,29 @@ class ImmutableJavaTestSpecs {
 		}
 	}
 
+	public static class JavaStringObject {
+		private final String string;
+
+		@ConstructorProperties("string")
+		public JavaStringObject(String string) {
+			this.string = string;
+		}
+
+		public String getString() {
+			return string;
+		}
+	}
+
+	public static class RootJavaStringObject {
+		private final JavaStringObject obj;
+
+		@ConstructorProperties("obj")
+		public RootJavaStringObject(JavaStringObject obj) {
+			this.obj = obj;
+		}
+
+		public JavaStringObject getObj() {
+			return obj;
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Add compatibility with TypedPropertySelector and path expression DSL

## How Has This Been Tested?
- typedJavaGetter
- nestedTypedJavaGetter
- indexTypedJavaGetter
- typedKotlinPropertySelector
- typedNestedKotlinPropertySelector
- typedJavaPropertySelector
- typedRootIsKotlinNestedJavaPropertySelector
- typedRootIsJavaNestedJavaPropertySelector

## Is the Document updated?
Later
