### PR TITLE
Add IntegerCombinableArbitrary for easy Integer customization

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -18,6 +18,7 @@
 
 package com.navercorp.fixturemonkey.api.arbitrary;
 
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -38,6 +39,8 @@ import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 public interface CombinableArbitrary<T> {
 	CombinableArbitrary<?> NOT_GENERATED = CombinableArbitrary.from((Object)null);
 	int DEFAULT_MAX_TRIES = 1_000;
+	ServiceLoader<IntegerCombinableArbitrary> INTEGER_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(IntegerCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -186,4 +189,15 @@ public interface CombinableArbitrary<T> {
 	 * @return fixed
 	 */
 	boolean fixed();
+
+	/**
+	 * Generates a {@link IntegerCombinableArbitrary} which returns a randomly generated Integer.
+	 * You can customize the generated Integer by using {@link IntegerCombinableArbitrary}.
+	 *
+	 * @return a {@link CombinableArbitrary} returns a randomly generated Integer
+	 */
+	@API(since = "1.1.12", status = Status.EXPERIMENTAL)
+	static IntegerCombinableArbitrary integers() {
+		return INTEGER_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
@@ -1,0 +1,92 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.util.function.Predicate;
+
+public interface IntegerCombinableArbitrary extends CombinableArbitrary<Integer> {
+	@Override
+	Integer combined();
+
+	@Override
+	Integer rawValue();
+
+	/**
+	 * Generates an IntegerCombinableArbitrary which produces integers within the specified range.
+	 *
+	 * @param min the minimum value (inclusive)
+	 * @param max the maximum value (inclusive)
+	 * @return the IntegerCombinableArbitrary producing integers between {@code min} and {@code max}
+	 */
+	IntegerCombinableArbitrary withRange(int min, int max);
+
+	/**
+	 * Generates an IntegerCombinableArbitrary which produces only positive integers.
+	 *
+	 * @return the IntegerCombinableArbitrary producing positive integers
+	 */
+	IntegerCombinableArbitrary positive();
+
+	/**
+	 * Generates an IntegerCombinableArbitrary which produces only negative integers.
+	 *
+	 * @return the IntegerCombinableArbitrary producing negative integers
+	 */
+	IntegerCombinableArbitrary negative();
+
+	/**
+	 * Generates an IntegerCombinableArbitrary which produces only even integers.
+	 *
+	 * @return the IntegerCombinableArbitrary producing even integers
+	 */
+	IntegerCombinableArbitrary even();
+
+	/**
+	 * Generates an IntegerCombinableArbitrary which produces only odd integers.
+	 *
+	 * @return the IntegerCombinableArbitrary producing odd integers
+	 */
+	IntegerCombinableArbitrary odd();
+
+	@Override
+	default IntegerCombinableArbitrary filter(Predicate<Integer> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default IntegerCombinableArbitrary filter(int tries, Predicate<Integer> predicate) {
+		return new IntegerCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	@Override
+	default IntegerCombinableArbitrary injectNull(double nullProbability) {
+		return new IntegerCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default IntegerCombinableArbitrary unique() {
+		return new IntegerCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
@@ -29,7 +29,7 @@ public interface IntegerCombinableArbitrary extends CombinableArbitrary<Integer>
 	Integer combined();
 
 	@Override
-	IntegerCombinableArbitrary rawValue();
+	Integer rawValue();
 
 	/**
 	 * Generates an IntegerCombinableArbitrary which produces integers within the specified range.

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitrary.java
@@ -20,12 +20,16 @@ package com.navercorp.fixturemonkey.api.arbitrary;
 
 import java.util.function.Predicate;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 public interface IntegerCombinableArbitrary extends CombinableArbitrary<Integer> {
 	@Override
 	Integer combined();
 
 	@Override
-	Integer rawValue();
+	IntegerCombinableArbitrary rawValue();
 
 	/**
 	 * Generates an IntegerCombinableArbitrary which produces integers within the specified range.

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
@@ -31,8 +31,8 @@ final class IntegerCombinableArbitraryDelegator implements IntegerCombinableArbi
 	}
 
 	@Override
-	public IntegerCombinableArbitrary rawValue() {
-		return CombinableArbitrary.integers();
+	public Integer rawValue() {
+		return delegate.combined();
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
@@ -1,0 +1,72 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+final class IntegerCombinableArbitraryDelegator implements IntegerCombinableArbitrary {
+	private final CombinableArbitrary<Integer> delegate;
+
+	public IntegerCombinableArbitraryDelegator(CombinableArbitrary<Integer> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Integer combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public Integer rawValue() {
+		return delegate.combined();
+	}
+
+	@Override
+	public IntegerCombinableArbitrary withRange(int min, int max) {
+		return CombinableArbitrary.integers().withRange(min, max);
+	}
+
+	@Override
+	public IntegerCombinableArbitrary positive() {
+		return CombinableArbitrary.integers().positive();
+	}
+
+	@Override
+	public IntegerCombinableArbitrary negative() {
+		return CombinableArbitrary.integers().negative();
+	}
+
+	@Override
+	public IntegerCombinableArbitrary even() {
+		return CombinableArbitrary.integers().even();
+	}
+
+	@Override
+	public IntegerCombinableArbitrary odd() {
+		return CombinableArbitrary.integers().odd();
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/IntegerCombinableArbitraryDelegator.java
@@ -31,8 +31,8 @@ final class IntegerCombinableArbitraryDelegator implements IntegerCombinableArbi
 	}
 
 	@Override
-	public Integer rawValue() {
-		return delegate.combined();
+	public IntegerCombinableArbitrary rawValue() {
+		return CombinableArbitrary.integers();
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
@@ -18,11 +18,15 @@
 
 package com.navercorp.fixturemonkey.api.jqwik;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 
 import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary;
 
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 public final class JqwikIntegerCombinableArbitrary implements IntegerCombinableArbitrary {
 	private final Arbitrary<Integer> integerArbitrary;
 
@@ -40,25 +44,25 @@ public final class JqwikIntegerCombinableArbitrary implements IntegerCombinableA
 	}
 
 	@Override
-	public Integer rawValue() {
-		return this.combined();
+	public IntegerCombinableArbitrary rawValue() {
+		return this;
 	}
 
 	@Override
 	public IntegerCombinableArbitrary withRange(int minValue, int maxValue) {
 		return new JqwikIntegerCombinableArbitrary(
-			Arbitraries.integers().filter(it -> minValue <= it && it <= maxValue)
+			Arbitraries.integers().between(minValue, maxValue)
 		);
 	}
 
 	@Override
 	public IntegerCombinableArbitrary positive() {
-		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> 0 < it));
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().greaterOrEqual(1));
 	}
 
 	@Override
 	public IntegerCombinableArbitrary negative() {
-		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> it < 0));
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().lessOrEqual(-1));
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
@@ -1,0 +1,83 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary;
+
+public final class JqwikIntegerCombinableArbitrary implements IntegerCombinableArbitrary {
+	private final Arbitrary<Integer> integerArbitrary;
+
+	public JqwikIntegerCombinableArbitrary() {
+		this.integerArbitrary = Arbitraries.integers();
+	}
+
+	private JqwikIntegerCombinableArbitrary(Arbitrary<Integer> integerArbitrary) {
+		this.integerArbitrary = integerArbitrary;
+	}
+
+	@Override
+	public Integer combined() {
+		return this.integerArbitrary.sample();
+	}
+
+	@Override
+	public Integer rawValue() {
+		return this.combined();
+	}
+
+	@Override
+	public IntegerCombinableArbitrary withRange(int minValue, int maxValue) {
+		return new JqwikIntegerCombinableArbitrary(
+			Arbitraries.integers().filter(it -> minValue <= it && it <= maxValue)
+		);
+	}
+
+	@Override
+	public IntegerCombinableArbitrary positive() {
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> 0 < it));
+	}
+
+	@Override
+	public IntegerCombinableArbitrary negative() {
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> it < 0));
+	}
+
+	@Override
+	public IntegerCombinableArbitrary even() {
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> it % 2 == 0));
+	}
+
+	@Override
+	public IntegerCombinableArbitrary odd() {
+		return new JqwikIntegerCombinableArbitrary(Arbitraries.integers().filter(it -> it % 2 != 0));
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikIntegerCombinableArbitrary.java
@@ -44,8 +44,8 @@ public final class JqwikIntegerCombinableArbitrary implements IntegerCombinableA
 	}
 
 	@Override
-	public IntegerCombinableArbitrary rawValue() {
-		return this;
+	public Integer rawValue() {
+		return this.combined();
 	}
 
 	@Override

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikIntegerCombinableArbitrary

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestArbitraryGeneratorSet.kt
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.kotest
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTimeArbitraryGeneratorSet
 import com.navercorp.fixturemonkey.api.arbitrary.JavaTypeArbitraryGeneratorSet
+import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
 import com.navercorp.fixturemonkey.api.constraint.JavaConstraintGenerator
 import com.navercorp.fixturemonkey.api.generator.ArbitraryGeneratorContext
 import io.kotest.property.Arb
@@ -34,7 +35,6 @@ import io.kotest.property.arbitrary.duration
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.float
 import io.kotest.property.arbitrary.instant
-import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.localDate
 import io.kotest.property.arbitrary.localDateTime
 import io.kotest.property.arbitrary.localTime
@@ -192,18 +192,17 @@ class KotestJavaArbitraryGeneratorSet(
         }
     }
 
-    override fun integers(context: ArbitraryGeneratorContext): CombinableArbitrary<Int> {
+    override fun integers(context: ArbitraryGeneratorContext): IntegerCombinableArbitrary {
         val integerConstraint = constraintGenerator.generateIntegerConstraint(context)
+        val combinableArbitrary = KotestIntegerCombinableArbitrary()
 
-        return CombinableArbitrary.from {
-            if (integerConstraint != null) {
-                val min = integerConstraint.min?.toInt() ?: Int.MIN_VALUE
-                val max = integerConstraint.max?.toInt() ?: Int.MAX_VALUE
+        return if (integerConstraint != null) {
+            val min = integerConstraint.min?.toInt() ?: Int.MIN_VALUE
+            val max = integerConstraint.max?.toInt() ?: Int.MAX_VALUE
 
-                Arb.int(min = min, max = max).single()
-            } else {
-                Arb.int().single()
-            }
+            combinableArbitrary.withRange(min, max)
+        } else {
+            combinableArbitrary
         }
     }
 

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
@@ -1,0 +1,57 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.negativeInt
+import io.kotest.property.arbitrary.positiveInt
+import io.kotest.property.arbitrary.single
+import java.util.function.Predicate
+
+class KotestIntegerCombinableArbitrary(private val arb: Arb<Int> = Arb.int()) : IntegerCombinableArbitrary {
+    override fun combined(): Int = arb.single()
+
+    override fun rawValue(): Int = arb.single()
+
+    override fun withRange(min: Int, max: Int): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.int(min..max))
+
+    override fun positive(): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.positiveInt())
+
+    override fun negative(): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.negativeInt())
+
+    override fun even(): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.int().filter { it % 2 == 0 })
+
+    override fun odd(): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.int().filter { it % 2 != 0 })
+
+    override fun filter(tries: Int, predicate: Predicate<Int>): IntegerCombinableArbitrary =
+        KotestIntegerCombinableArbitrary(Arb.int().filter { predicate.test(it) })
+
+    override fun clear() {
+    }
+
+    override fun fixed(): Boolean = false
+}

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
@@ -25,12 +25,15 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.negativeInt
 import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.arbitrary.single
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status
 import java.util.function.Predicate
 
+@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 class KotestIntegerCombinableArbitrary(private val arb: Arb<Int> = Arb.int()) : IntegerCombinableArbitrary {
     override fun combined(): Int = arb.single()
 
-    override fun rawValue(): IntegerCombinableArbitrary = KotestIntegerCombinableArbitrary(arb)
+    override fun rawValue(): Int = this.combined()
 
     override fun withRange(min: Int, max: Int): IntegerCombinableArbitrary =
         KotestIntegerCombinableArbitrary(Arb.int(min..max))

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestIntegerCombinableArbitrary.kt
@@ -30,7 +30,7 @@ import java.util.function.Predicate
 class KotestIntegerCombinableArbitrary(private val arb: Arb<Int> = Arb.int()) : IntegerCombinableArbitrary {
     override fun combined(): Int = arb.single()
 
-    override fun rawValue(): Int = arb.single()
+    override fun rawValue(): IntegerCombinableArbitrary = KotestIntegerCombinableArbitrary(arb)
 
     override fun withRange(min: Int, max: Int): IntegerCombinableArbitrary =
         KotestIntegerCombinableArbitrary(Arb.int(min..max))

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.IntegerCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -1533,7 +1533,7 @@ class JavaTest {
 		then(actual).isInstanceOf(JqwikIntegerCombinableArbitrary.class);
 	}
 
-	@Test
+	@RepeatedTest(TEST_COUNT)
 	void integerCombinableArbitraryInjectNull() {
 		Integer actual = CombinableArbitrary.integers().injectNull(1).combined();
 

--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/JavaTest.java
@@ -61,6 +61,7 @@ import com.navercorp.fixturemonkey.api.introspector.CompositeArbitraryIntrospect
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.jqwik.JqwikIntegerCombinableArbitrary;
 import com.navercorp.fixturemonkey.api.lazy.LazyArbitrary;
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator;
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin;
@@ -1523,5 +1524,89 @@ class JavaTest {
 		});
 
 		then(actual).hasSizeLessThan(3);
+	}
+
+	@Test
+	void integerCombinableArbitraryIsJqwik() {
+		CombinableArbitrary<Integer> actual = CombinableArbitrary.integers();
+
+		then(actual).isInstanceOf(JqwikIntegerCombinableArbitrary.class);
+	}
+
+	@Test
+	void integerCombinableArbitraryInjectNull() {
+		Integer actual = CombinableArbitrary.integers().injectNull(1).combined();
+
+		then(actual).isNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryFilter() {
+		Integer actual = CombinableArbitrary.integers().filter(it -> it > 10000).combined();
+
+		then(actual).isGreaterThan(10000);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryPositive() {
+		Integer actual = CombinableArbitrary.integers().positive().combined();
+
+		then(actual).isPositive();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryNegative() {
+		Integer actual = CombinableArbitrary.integers().negative().combined();
+
+		then(actual).isNegative();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryWithRange() {
+		Integer actual = CombinableArbitrary.integers().withRange(10, 100).combined();
+
+		then(actual).isBetween(10, 100);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryWithRangeAndFilter() {
+		Integer actual = CombinableArbitrary.integers().withRange(10, 100).filter(it -> 75 <= it).combined();
+
+		then(actual).isBetween(75, 100);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryEven() {
+		Integer actual = CombinableArbitrary.integers().even().combined();
+
+		then(actual).isEven();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryOdd() {
+		Integer actual = CombinableArbitrary.integers().odd().combined();
+
+		then(actual).isOdd();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryLastOperationWinsWithPositiveAndNegative() {
+		Integer actual = CombinableArbitrary.integers().positive().negative().combined();
+
+		then(actual).isNegative();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryLastOperationWinsWithEvenAndOdd() {
+		Integer actual = CombinableArbitrary.integers().even().odd().combined();
+
+		then(actual).isOdd();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void integerCombinableArbitraryLastOperationWinsWithNegativeAndRange() {
+		Integer actual = CombinableArbitrary.integers().negative().withRange(100, 1000).combined();
+
+		then(actual).isBetween(100, 1000);
 	}
 }

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -19,8 +19,10 @@
 package com.navercorp.fixturemonkey.tests.kotlin
 
 import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
 import com.navercorp.fixturemonkey.kotest.KotestPlugin
+import com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.giveMeArb
 import com.navercorp.fixturemonkey.kotest.setArb
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
@@ -33,6 +35,7 @@ import io.kotest.property.arbitrary.single
 import io.kotest.property.arbs.geo.zipcodes
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.BigInteger
 import javax.validation.constraints.DecimalMax
@@ -870,6 +873,48 @@ class KotestInJunitTest {
             .string
 
         then(actual).hasSize(5)
+    }
+
+    @Test
+    fun integerCombinableArbitrary(){
+        val actual = CombinableArbitrary.integers()
+
+        then(actual).isInstanceOf(KotestIntegerCombinableArbitrary::class.java)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun integerCombinableArbitraryPositive(){
+        val actual = CombinableArbitrary.integers().positive().combined()
+
+        then(actual).isPositive()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun integerCombinableArbitraryNegative(){
+        val actual = CombinableArbitrary.integers().negative().combined()
+
+        then(actual).isNegative()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun integerCombinableArbitraryEven(){
+        val actual = CombinableArbitrary.integers().even().combined()
+
+        then(actual).isEven()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun integerCombinableArbitraryOdd(){
+        val actual = CombinableArbitrary.integers().odd().combined()
+
+        then(actual).isOdd()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun integerCombinableArbitraryWithRange(){
+        val actual = CombinableArbitrary.integers().withRange(10, 20).combined()
+
+        then(actual).isBetween(10, 20)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Add `IntegerCombinableArbitrary` to allow easy customization of randomly generated Integer values, similar to the existing `StringCombinableArbitrary`. (#1188)

## (Optional): Description
providing below APIs to customize the randomly generated Integer

`.positive()` - only positive numbers
`.negative()` - only negative numbers
`.withRange(min, max)` - numbers within range
`.even()` - only even numbers
`.odd()` - only odd numbers

## How Has This Been Tested?
- `integerCombinableArbitraryIsJqwik`
- `integerCombinableArbitraryInjectNull`
- `integerCombinableArbitraryFilter`
- `integerCombinableArbitraryPositive`
- `integerCombinableArbitraryNegative`
- `integerCombinableArbitraryWithRange`
- `integerCombinableArbitraryWithRangeAndFilter`
- `integerCombinableArbitraryEven`
- `integerCombinableArbitraryOdd`
- `integerCombinableArbitraryLastOperationWinsWithPositiveAndNegative`
- `integerCombinableArbitraryLastOperationWinsWithEvenAndOdd`
- `integerCombinableArbitraryLastOperationWinsWithNegativeAndRange`

## Is the Document updated?
No. Once all code reviews are complete, would it be OK if I update and push the documentation just before merging this PR? 
If that is not acceptable, I will update the documentation right away. Thank you for your understanding.