### PR TITLE
Fix recursive invocation of Kotlin customizeProperty function

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/FixtureMonkeyExtensions.kt
@@ -635,13 +635,13 @@ open class KotlinTypeDefaultArbitraryBuilder<T> internal constructor(val delegat
     fun <U> customizeProperty(
         property: KProperty1<T, U?>,
         combinableArbitraryCustomizer: Function<CombinableArbitrary<out U>, CombinableArbitrary<out U>>
-    ): ArbitraryBuilder<T> =
+    ): KotlinTypeDefaultArbitraryBuilder<T> =
         this.apply { delegate.customizeProperty(propertyExpressionGenerator(property), combinableArbitraryCustomizer) }
 
     fun <U> customizeProperty(
         property: KFunction1<T, U?>,
         combinableArbitraryCustomizer: Function<CombinableArbitrary<out U>, CombinableArbitrary<out U>>
-    ): ArbitraryBuilder<T> =
+    ): KotlinTypeDefaultArbitraryBuilder<T> =
         this.apply { delegate.customizeProperty(propertyExpressionGenerator(property), combinableArbitraryCustomizer) }
 }
 

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/PropertySelectorTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/PropertySelectorTest.kt
@@ -42,6 +42,7 @@ import com.navercorp.fixturemonkey.tests.kotlin.ImmutableJavaTestSpecs.JavaStrin
 import com.navercorp.fixturemonkey.tests.kotlin.ImmutableJavaTestSpecs.NestedArrayObject
 import com.navercorp.fixturemonkey.tests.kotlin.ImmutableJavaTestSpecs.RootJavaStringObject
 import com.navercorp.fixturemonkey.tests.kotlin.JavaConstructorTestSpecs.JavaTypeObject
+import java.math.BigDecimal
 import org.assertj.core.api.BDDAssertions.then
 import org.assertj.core.api.BDDAssertions.thenThrownBy
 import org.junit.jupiter.api.RepeatedTest
@@ -384,6 +385,26 @@ class PropertySelectorTest {
     }
 
     @Test
+    fun typedKotlinPropertySelectorRecursively() {
+        // given
+        class StringObject(val string: String)
+
+        val expected = "test"
+
+        // when
+        val actual = SUT.giveMeKotlinBuilder<StringObject>()
+            .customizeProperty(StringObject::string) {
+                it.map { _ -> expected }
+            }.customizeProperty(StringObject::string) {
+                it.map { _ -> expected }
+            }
+            .sample()
+
+        // then
+        then(actual.string).isEqualTo(expected)
+    }
+
+    @Test
     fun typedNestedKotlinPropertySelector() {
         // given
         class StringObject(val string: String)
@@ -417,6 +438,29 @@ class PropertySelectorTest {
         // when
         val actual = sut.giveMeKotlinBuilder<JavaStringObject>()
             .customizeProperty(JavaStringObject::getString) {
+                it.map { _ -> expected }
+            }
+            .sample()
+            .string
+
+        // then
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun typedJavaPropertySelectorRecursively() {
+        // given
+        val expected = "test"
+
+        val sut = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+
+        // when
+        val actual = sut.giveMeKotlinBuilder<JavaStringObject>()
+            .customizeProperty(JavaStringObject::getString) {
+                it.map { _ -> expected }
+            }.customizeProperty(JavaStringObject::getString) {
                 it.map { _ -> expected }
             }
             .sample()


### PR DESCRIPTION
## Summary
*Describe what feature is implemented by this PR.*
*If there is a related issue, write the issue number and link*

- #1211 

Support recursive calls to customizeProperty in the Kotlin builder like [real-world-testing-scenarios](https://naver.github.io/fixture-monkey/v1-1-0/docs/customizing-objects/apis/#real-world-testing-scenarios)

## (Optional): Description
*Describe your changes in detail*

## How Has This Been Tested?
*Please describe the tests that you ran to verify your changes.*

I called customizeProperty twice in kotlin builder
- typedJavaPropertySelectorRecursively
- typedKotlinPropertySelectorRecursively

## Is the Document updated?
*We recommend that the corresponding documentation for this feature or change is updated within the pull request*
*If the update is scheduled for later, please specify and add the necessary information to the [discussion page](https://github.com/naver/fixture-monkey/discussions/858).*
