### PR TITLE
Fix link in creating-objects.md

### DIFF
--- a/docs/content/v1.1.x-kor/docs/get-started/creating-objects.md
+++ b/docs/content/v1.1.x-kor/docs/get-started/creating-objects.md
@@ -68,7 +68,7 @@ public class Product {
 }
 ```
 
-(Lombok 의 어노테이션인 `@Value` 는 불변 클래스를 만들기 위해 사용됩니다. 만약 Lombok 을 사용하지 않는다면, [Lombok 없이 테스트 객체 생성하기](../creating-test-objects-without-lombok) 으로 이동하세요.)
+(Lombok 의 어노테이션인 `@Value` 는 불변 클래스를 만들기 위해 사용됩니다. 만약 Lombok 을 사용하지 않는다면, [Lombok 없이 테스트 객체 생성하기](../creating-objects-without-lombok) 으로 이동하세요.)
 
 `ConstructorPropertiesArbitraryIntrospector` 를 사용하려면, 생성될 클래스에는 @ConstructorProperties 가 달린 생성자가 있거나, lombok.config 파일에 `lombok.anyConstructor.addConstructorProperties=true` 가 추가되어 있어야 합니다.
 (다른 Introspector를 사용할 수도 있습니다. 각각의 요구 사항은 [`Introspectors` section](../../generating-objects/introspector) 을 참고하세요.)

--- a/docs/content/v1.1.x/docs/get-started/creating-objects.md
+++ b/docs/content/v1.1.x/docs/get-started/creating-objects.md
@@ -68,7 +68,7 @@ public class Product {
 }
 ```
 
-(Note that the Lombok annotation `@Value` is used to make Immutable classes. If you're working in an environment without Lombok, go to [creating test objects without lombok](../creating-test-objects-without-lombok))
+(Note that the Lombok annotation `@Value` is used to make Immutable classes. If you're working in an environment without Lombok, go to [creating test objects without lombok](../creating-objects-without-lombok))
 
 For `ConstructorPropertiesArbitraryIntrospector`, the generated class should have a constructor with @ConstructorProperties or you can add `lombok.anyConstructor.addConstructorProperties=true` in the lombok.config file.
 (There are alternative Introspectors available, each with their own requirements. Check out the [`Introspectors` section](../../generating-objects/introspector) for more details.)


### PR DESCRIPTION
## Summary
This PR fixes a broken link in the "Creating test objects" guide that pointed to a non-existent page.

## (Optional): Description
The document contained a link to ../creating-objects-without-lombok, which led to a 404 error. This PR removes the broken link.

## How Has This Been Tested?

## Is the Document updated?
