### PR TITLE
rlaxowns7916: fix/arbitrary-builder-conext-copy

### DIFF
--- a/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/AnnotationTest.java
+++ b/fixture-monkey-tests/java-tests/src/test/java/com/navercorp/fixturemonkey/tests/java/AnnotationTest.java
@@ -53,4 +53,16 @@ class AnnotationTest {
 
 		then(actual).isNull();
 	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleNotValidAnnotationWithCopy() {
+		String actual = SUT.giveMeBuilder(StringNotNullAnnotationObject.class)
+			.set("value", null)
+			.validOnly(false)
+			.copy()
+			.sample()
+			.getValue();
+
+		then(actual).isNull();
+	}
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/builder/ArbitraryBuilderContext.java
@@ -121,7 +121,7 @@ public final class ArbitraryBuilderContext {
 			.map(ContainerInfoManipulator::copy)
 			.collect(Collectors.toList());
 
-		return new ArbitraryBuilderContext(
+		ArbitraryBuilderContext copiedContext = new ArbitraryBuilderContext(
 			new ArrayList<>(this.manipulators),
 			copiedContainerInfoManipulators,
 			new HashMap<>(propertyConfigurers),
@@ -130,6 +130,11 @@ public final class ArbitraryBuilderContext {
 			fixedCombinableArbitrary,
 			monkeyContext
 		);
+
+		copiedContext.setCustomizedValidOnly(customizedValidOnly);
+		copiedContext.setOptionValidOnly(optionValidOnly);
+
+		return copiedContext;
 	}
 
 	public void addManipulator(ArbitraryManipulator arbitraryManipulator) {


### PR DESCRIPTION
Summary
Fix issue where ArbitraryBuilderContext.copy() did not copy optionValidOnly and customizedValueOnly settings, and add corresponding tests.

Related issues:
N/A

Description
Previously, the copy() method of ArbitraryBuilderContext did not properly copy the optionValidOnly and customizedValueOnly settings. This caused issues when creating objects using DefaultArbitraryBuilder.copy(), as these configuration settings were not propagated correctly.

This PR ensures that optionValidOnly and customizedValueOnly are properly copied, ensuring consistent behavior when copying and creating new builder instances.

How Has This Been Tested?
	•	Added an additional copy operation to an existing test in AnnotationTest to verify that the settings are correctly copied and propagated.
	•	Considered adding tests directly to ArbitraryBuilderContext, but decided it was more meaningful and representative of intended usage to include the tests in validation-related modules.

If tests within ArbitraryBuilderContext are deemed necessary, please indicate this clearly, and I will reinstate the previously removed test commit.

## befire
<img width="1732" height="331" alt="beforeFix" src="https://github.com/user-attachments/assets/68a46ab2-bb2a-4687-8e0c-205bb1a7370b" />

## after
<img width="1020" height="304" alt="afterfix" src="https://github.com/user-attachments/assets/9600fb80-5c69-4a5f-b039-bc3c275ed8c4" />


Is the Document updated?
N/A
