### PR TITLE
Refactor benchmark.yml to run modules in parallel

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,17 +15,37 @@ jobs:
   jmh:
     name: Run benchmark
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        benchmark-module: 
+          - 'fixture-monkey-benchmark'
+          - 'fixture-monkey-benchmark-kotlin'
     steps:
       - uses: actions/checkout@v2
-      - name: Execute benchmark
+      - name: Execute benchmark for ${{ matrix.benchmark-module }}
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: jmh
+          arguments: :${{ matrix.benchmark-module }}:jmh
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-results-${{ matrix.benchmark-module }}
+          path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/results/jmh/results.csv
+
+  merge-results:
+    name: Merge benchmark results
+    needs: jmh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all benchmark results
+        uses: actions/download-artifact@v3
+        with:
+          path: ./benchmark-results
       - name: Merge benchmark results
         id: merge
         run: |
           echo "" > merged_results.csv
-          find ./fixture-monkey-benchmarks -name 'results.csv' | while read line; do
+          find ./benchmark-results -name 'results.csv' | while read line; do
             cat "$line" >> merged_results.csv
             echo "" >> merged_results.csv
           done

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Execute benchmark for ${{ matrix.benchmark-module }}
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: :${{ matrix.benchmark-module }}:jmh
+          arguments: :fixture-monkey-benchmarks:${{ matrix.benchmark-module }}:jmh
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ matrix.benchmark-module }}
-          path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/results/jmh/results.csv
+          path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/reports/jmh/results.csv
 
   merge-results:
     name: Merge benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ matrix.benchmark-module }}
-          path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/reports/jmh/results.csv
+          path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/results/jmh/results.csv
 
   merge-results:
     name: Merge benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           arguments: :${{ matrix.benchmark-module }}:jmh
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ matrix.benchmark-module }}
           path: ./fixture-monkey-benchmarks/${{ matrix.benchmark-module }}/build/results/jmh/results.csv
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all benchmark results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./benchmark-results
       - name: Merge benchmark results


### PR DESCRIPTION
## Summary

The benchmark workflow previously executed jobs sequentially, taking 33 minutes to complete.
so this pr refactors the workflow using strategy.matrix for parallel execution.

## (Optional): Description

If the JMH plugin is applied in Gradle, it automatically generates a jmh task.
Since JMH executes each benchmark method sequentially, I split the benchmarks into seperate modules to enable parallel execution.
I also considered method-level parallel execution, but JMH runs sequentially by design to avoid side effects from CPU cache, GC, and JIt. etc. so I didn't apply it.

## How Has This Been Tested?
- this actions is to execute on push or pull request to main or release branch.

## Is the Document updated?
.