### PR TITLE
Add BigDecimalCombinableArbitrary

### DIFF
--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitrary.java
@@ -1,0 +1,130 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.math.BigDecimal;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
+public interface BigDecimalCombinableArbitrary extends CombinableArbitrary<BigDecimal> {
+	@Override
+	BigDecimal combined();
+
+	@Override
+	BigDecimal rawValue();
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces BigDecimals within the specified range.
+	 *
+	 * @param min the minimum value (inclusive)
+	 * @param max the maximum value (inclusive)
+	 * @return the BigDecimalCombinableArbitrary producing BigDecimals between {@code min} and {@code max}
+	 */
+	BigDecimalCombinableArbitrary withRange(BigDecimal min, BigDecimal max);
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces only positive BigDecimals.
+	 *
+	 * @return the BigDecimalCombinableArbitrary producing positive BigDecimals
+	 */
+	BigDecimalCombinableArbitrary positive();
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces only negative BigDecimals.
+	 *
+	 * @return the BigDecimalCombinableArbitrary producing negative BigDecimals
+	 */
+	BigDecimalCombinableArbitrary negative();
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces only non-zero BigDecimals.
+	 *
+	 * @return the BigDecimalCombinableArbitrary producing non-zero BigDecimals
+	 */
+	BigDecimalCombinableArbitrary nonZero();
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces BigDecimals as percentage values (0.0-100.0).
+	 *
+	 * @return the BigDecimalCombinableArbitrary producing percentage BigDecimals
+	 */
+	BigDecimalCombinableArbitrary percentage();
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces BigDecimals as score values within the specified range.
+	 *
+	 * @param min the minimum score (inclusive)
+	 * @param max the maximum score (inclusive)
+	 * @return the BigDecimalCombinableArbitrary producing score BigDecimals
+	 */
+	BigDecimalCombinableArbitrary score(BigDecimal min, BigDecimal max);
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces BigDecimals with the specified precision.
+	 *
+	 * @param precision the number of significant digits
+	 * @return the BigDecimalCombinableArbitrary producing BigDecimals with {@code precision} significant digits
+	 */
+	BigDecimalCombinableArbitrary withPrecision(int precision);
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces BigDecimals with the specified scale.
+	 *
+	 * @param scale the number of digits to the right of the decimal point
+	 * @return the BigDecimalCombinableArbitrary producing BigDecimals with {@code scale} decimal places
+	 */
+	BigDecimalCombinableArbitrary withScale(int scale);
+
+	/**
+	 * Generates a BigDecimalCombinableArbitrary which produces normalized BigDecimals.
+	 * Normalized BigDecimals have trailing zeros removed and scale adjusted accordingly.
+	 *
+	 * @return the BigDecimalCombinableArbitrary producing normalized BigDecimals
+	 */
+	BigDecimalCombinableArbitrary normalized();
+
+	@Override
+	default BigDecimalCombinableArbitrary filter(Predicate<BigDecimal> predicate) {
+		return this.filter(DEFAULT_MAX_TRIES, predicate);
+	}
+
+	@Override
+	default BigDecimalCombinableArbitrary filter(int tries, Predicate<BigDecimal> predicate) {
+		return new BigDecimalCombinableArbitraryDelegator(CombinableArbitrary.super.filter(tries, predicate));
+	}
+
+	@Override
+	default BigDecimalCombinableArbitrary injectNull(double nullProbability) {
+		return new BigDecimalCombinableArbitraryDelegator(CombinableArbitrary.super.injectNull(nullProbability));
+	}
+
+	@Override
+	default BigDecimalCombinableArbitrary unique() {
+		return new BigDecimalCombinableArbitraryDelegator(CombinableArbitrary.super.unique());
+	}
+
+	@Override
+	void clear();
+
+	@Override
+	boolean fixed();
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryDelegator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryDelegator.java
@@ -1,0 +1,98 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import java.math.BigDecimal;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
+final class BigDecimalCombinableArbitraryDelegator implements BigDecimalCombinableArbitrary {
+	private final CombinableArbitrary<BigDecimal> delegate;
+
+	public BigDecimalCombinableArbitraryDelegator(CombinableArbitrary<BigDecimal> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public BigDecimal combined() {
+		return delegate.combined();
+	}
+
+	@Override
+	public BigDecimal rawValue() {
+		return delegate.combined();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withRange(BigDecimal min, BigDecimal max) {
+		return CombinableArbitrary.bigDecimals().withRange(min, max);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary positive() {
+		return CombinableArbitrary.bigDecimals().positive();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary negative() {
+		return CombinableArbitrary.bigDecimals().negative();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary nonZero() {
+		return CombinableArbitrary.bigDecimals().nonZero();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary percentage() {
+		return CombinableArbitrary.bigDecimals().percentage();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary score(BigDecimal min, BigDecimal max) {
+		return CombinableArbitrary.bigDecimals().score(min, max);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withPrecision(int precision) {
+		return CombinableArbitrary.bigDecimals().withPrecision(precision);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withScale(int scale) {
+		return CombinableArbitrary.bigDecimals().withScale(scale);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary normalized() {
+		return CombinableArbitrary.bigDecimals().normalized();
+	}
+
+	@Override
+	public void clear() {
+		delegate.clear();
+	}
+
+	@Override
+	public boolean fixed() {
+		return delegate.fixed();
+	}
+}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/arbitrary/CombinableArbitrary.java
@@ -46,6 +46,8 @@ public interface CombinableArbitrary<T> {
 		ServiceLoader.load(StringCombinableArbitrary.class);
 	ServiceLoader<ByteCombinableArbitrary> BYTE_COMBINABLE_ARBITRARY_SERVICE_LOADER =
 		ServiceLoader.load(ByteCombinableArbitrary.class);
+	ServiceLoader<BigDecimalCombinableArbitrary> BIG_DECIMAL_COMBINABLE_ARBITRARY_SERVICE_LOADER =
+		ServiceLoader.load(BigDecimalCombinableArbitrary.class);
 
 	/**
 	 * Generates a {@link FixedCombinableArbitrary} which returns always same value.
@@ -226,6 +228,17 @@ public interface CombinableArbitrary<T> {
 	@API(since = "1.1.12", status = Status.EXPERIMENTAL)
 	static StringCombinableArbitrary strings() {
 		return STRING_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
+	}
+
+	/**
+	 * Generates a {@link BigDecimalCombinableArbitrary} which returns a randomly generated BigDecimal.
+	 * You can customize the generated BigDecimal by using {@link BigDecimalCombinableArbitrary}.
+	 *
+	 * @return a {@link CombinableArbitrary} returns a randomly generated BigDecimal
+	 */
+	@API(since = "1.1.16", status = Status.EXPERIMENTAL)
+	static BigDecimalCombinableArbitrary bigDecimals() {
+		return BIG_DECIMAL_COMBINABLE_ARBITRARY_SERVICE_LOADER.iterator().next();
 	}
 
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikBigDecimalCombinableArbitrary.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/jqwik/JqwikBigDecimalCombinableArbitrary.java
@@ -1,0 +1,124 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.jqwik;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+import com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary;
+
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
+public final class JqwikBigDecimalCombinableArbitrary implements BigDecimalCombinableArbitrary {
+	private final Arbitrary<BigDecimal> bigDecimalArbitrary;
+
+	public JqwikBigDecimalCombinableArbitrary() {
+		this(Arbitraries.bigDecimals());
+	}
+
+	private JqwikBigDecimalCombinableArbitrary(Arbitrary<BigDecimal> bigDecimalArbitrary) {
+		this.bigDecimalArbitrary = bigDecimalArbitrary;
+	}
+
+	@Override
+	public BigDecimal combined() {
+		return this.bigDecimalArbitrary.sample();
+	}
+
+	@Override
+	public BigDecimal rawValue() {
+		return this.combined();
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withRange(BigDecimal min, BigDecimal max) {
+		return new JqwikBigDecimalCombinableArbitrary(
+			Arbitraries.bigDecimals().between(min, max)
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary positive() {
+		return new JqwikBigDecimalCombinableArbitrary(
+			Arbitraries.bigDecimals().greaterOrEqual(BigDecimal.ONE)
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary negative() {
+		return new JqwikBigDecimalCombinableArbitrary(
+			Arbitraries.bigDecimals().lessOrEqual(BigDecimal.valueOf(-1))
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary nonZero() {
+		return new JqwikBigDecimalCombinableArbitrary(
+			this.bigDecimalArbitrary.filter(it -> it.compareTo(BigDecimal.ZERO) != 0)
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary percentage() {
+		return new JqwikBigDecimalCombinableArbitrary(
+			Arbitraries.bigDecimals().between(BigDecimal.ZERO, BigDecimal.valueOf(100))
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary score(BigDecimal min, BigDecimal max) {
+		return withRange(min, max);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withPrecision(int precision) {
+		return new JqwikBigDecimalCombinableArbitrary(
+			this.bigDecimalArbitrary.map(it -> it.round(new java.math.MathContext(precision)))
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary withScale(int scale) {
+		return new JqwikBigDecimalCombinableArbitrary(
+			this.bigDecimalArbitrary.map(it -> it.setScale(scale, RoundingMode.HALF_UP))
+		);
+	}
+
+	@Override
+	public BigDecimalCombinableArbitrary normalized() {
+		return new JqwikBigDecimalCombinableArbitrary(
+			this.bigDecimalArbitrary.map(BigDecimal::stripTrailingZeros)
+		);
+	}
+
+	@Override
+	public void clear() {
+		// ignored
+	}
+
+	@Override
+	public boolean fixed() {
+		return false;
+	}
+}

--- a/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary
+++ b/fixture-monkey-api/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary
@@ -1,0 +1,2 @@
+com.navercorp.fixturemonkey.api.jqwik.JqwikBigDecimalCombinableArbitrary
+

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryTest.java
@@ -86,7 +86,8 @@ class BigDecimalCombinableArbitraryTest {
 		// when
 		boolean allInPercentageRange = IntStream.range(0, 100)
 			.mapToObj(i -> CombinableArbitrary.bigDecimals().percentage().combined())
-			.allMatch(b -> b.compareTo(BigDecimal.ZERO) >= 0 && b.compareTo(BigDecimal.valueOf(100)) <= 0);
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) >= 0
+				&& b.compareTo(BigDecimal.valueOf(100)) <= 0);
 
 		// then
 		then(allInPercentageRange).isTrue();
@@ -114,7 +115,9 @@ class BigDecimalCombinableArbitraryTest {
 
 		// when
 		boolean allWithCorrectPrecision = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(precision).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.withPrecision(precision)
+				.combined())
 			.allMatch(b -> b.precision() <= precision);
 
 		// then
@@ -128,7 +131,9 @@ class BigDecimalCombinableArbitraryTest {
 
 		// when
 		boolean allWithCorrectScale = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().withScale(scale).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.withScale(scale)
+				.combined())
 			.allMatch(b -> b.scale() == scale);
 
 		// then
@@ -139,7 +144,9 @@ class BigDecimalCombinableArbitraryTest {
 	void normalized() {
 		// when
 		boolean allNormalized = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.normalized()
+				.combined())
 			.allMatch(b -> b.equals(b.stripTrailingZeros()));
 
 		// then
@@ -153,7 +160,10 @@ class BigDecimalCombinableArbitraryTest {
 		BigDecimal max = BigDecimal.valueOf(-10.5);
 
 		// when - positive().withRange() => withRange()
-		BigDecimal actual = CombinableArbitrary.bigDecimals().positive().withRange(min, max).combined();
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.positive()
+			.withRange(min, max)
+			.combined();
 
 		// then
 		then(actual).isBetween(min, max);
@@ -192,7 +202,8 @@ class BigDecimalCombinableArbitraryTest {
 		// when
 		BigDecimal actual = CombinableArbitrary.bigDecimals()
 			.positive()
-			.filter(b -> b.remainder(BigDecimal.valueOf(0.5)).compareTo(BigDecimal.ZERO) == 0)  // multiples of 0.5
+			.filter(b -> b.remainder(BigDecimal.valueOf(0.5))
+				.compareTo(BigDecimal.ZERO) == 0)
 			.combined();
 
 		// then
@@ -205,7 +216,7 @@ class BigDecimalCombinableArbitraryTest {
 		// when
 		BigDecimal actual = CombinableArbitrary.bigDecimals()
 			.positive()
-			.injectNull(1.0)  // 100% null
+			.injectNull(1.0)
 			.combined();
 
 		// then
@@ -217,7 +228,7 @@ class BigDecimalCombinableArbitraryTest {
 		// when
 		BigDecimal actual = CombinableArbitrary.bigDecimals()
 			.positive()
-			.injectNull(0.0)  // 0% null
+			.injectNull(0.0)
 			.combined();
 
 		// then
@@ -230,7 +241,7 @@ class BigDecimalCombinableArbitraryTest {
 		// when - combine multiple operations
 		String actual = CombinableArbitrary.bigDecimals()
 			.percentage()
-			.filter(b -> b.compareTo(BigDecimal.valueOf(50)) >= 0)  // >= 50
+			.filter(b -> b.compareTo(BigDecimal.valueOf(50)) >= 0)
 			.map(b -> "percentage:" + b)
 			.combined();
 
@@ -245,7 +256,7 @@ class BigDecimalCombinableArbitraryTest {
 	void bigDecimalUniqueWithDifferentValues() {
 		// when - unique() works with different values
 		BigDecimal actual = CombinableArbitrary.bigDecimals()
-			.withRange(BigDecimal.ZERO, BigDecimal.valueOf(1000))  // wide range
+			.withRange(BigDecimal.ZERO, BigDecimal.valueOf(1000))
 			.unique()
 			.combined();
 
@@ -266,8 +277,12 @@ class BigDecimalCombinableArbitraryTest {
 	void lastMethodWinsRangeOverPositive() {
 		// when - positive().withRange() => withRange()
 		boolean allInRange = IntStream.range(0, 30)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().positive().withRange(BigDecimal.valueOf(-10.5), BigDecimal.valueOf(-1.5)).combined())
-			.allMatch(b -> b.compareTo(BigDecimal.valueOf(-10.5)) >= 0 && b.compareTo(BigDecimal.valueOf(-1.5)) <= 0);
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.positive()
+				.withRange(BigDecimal.valueOf(-10.5), BigDecimal.valueOf(-1.5))
+				.combined())
+			.allMatch(b -> b.compareTo(BigDecimal.valueOf(-10.5)) >= 0
+				&& b.compareTo(BigDecimal.valueOf(-1.5)) <= 0);
 
 		// then
 		then(allInRange).isTrue();
@@ -277,7 +292,10 @@ class BigDecimalCombinableArbitraryTest {
 	void lastMethodWinsPrecisionOverScale() {
 		// when - withPrecision().withScale() => withScale()
 		boolean allWithCorrectScale = IntStream.range(0, 30)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(5).withScale(2).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.withPrecision(5)
+				.withScale(2)
+				.combined())
 			.allMatch(b -> b.scale() == 2);
 
 		// then
@@ -291,8 +309,11 @@ class BigDecimalCombinableArbitraryTest {
 			.mapToObj(i -> CombinableArbitrary.bigDecimals()
 				.positive()
 				.withScale(2)
-				.filter(b -> b.compareTo(BigDecimal.valueOf(10)) >= 0).combined())
-			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0 && b.scale() == 2 && b.compareTo(BigDecimal.valueOf(10)) >= 0);
+				.filter(b -> b.compareTo(BigDecimal.valueOf(10)) >= 0)
+				.combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0
+				&& b.scale() == 2
+				&& b.compareTo(BigDecimal.valueOf(10)) >= 0);
 
 		// then
 		then(allPositiveWithScale).isTrue();
@@ -302,7 +323,10 @@ class BigDecimalCombinableArbitraryTest {
 	void nonZeroWithPrecision() {
 		// when - nonZero().withPrecision() => withPrecision()
 		boolean allWithCorrectPrecision = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().withPrecision(3).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.withPrecision(3)
+				.combined())
 			.allMatch(b -> b.precision() <= 3);
 
 		// then
@@ -313,7 +337,10 @@ class BigDecimalCombinableArbitraryTest {
 	void nonZeroWithScale() {
 		// when - nonZero().withScale() => withScale()
 		boolean allWithCorrectScale = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().withScale(2).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.withScale(2)
+				.combined())
 			.allMatch(b -> b.scale() == 2);
 
 		// then
@@ -324,7 +351,10 @@ class BigDecimalCombinableArbitraryTest {
 	void nonZeroWithPositive() {
 		// when
 		boolean allNonZeroAndPositive = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.positive()
+				.combined())
 			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0);
 
 		// then
@@ -335,7 +365,10 @@ class BigDecimalCombinableArbitraryTest {
 	void nonZeroWithNegative() {
 		// when - nonZero().negative() => negative()
 		boolean allNegative = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().negative().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.negative()
+				.combined())
 			.allMatch(b -> b.compareTo(BigDecimal.ZERO) < 0);
 
 		// then
@@ -346,7 +379,10 @@ class BigDecimalCombinableArbitraryTest {
 	void negativeWithNonZero() {
 		// when - negative().nonZero() => nonZero()
 		boolean allNonZero = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().negative().nonZero().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.negative()
+				.nonZero()
+				.combined())
 			.allMatch(b -> b.compareTo(BigDecimal.ZERO) != 0);
 
 		// then
@@ -357,7 +393,10 @@ class BigDecimalCombinableArbitraryTest {
 	void positiveWithNegativeCombination() {
 		// when - positive().negative() => negative()
 		boolean allNegative = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().positive().negative().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.positive()
+				.negative()
+				.combined())
 			.allMatch(b -> b.compareTo(BigDecimal.ZERO) < 0);
 
 		// then
@@ -368,7 +407,11 @@ class BigDecimalCombinableArbitraryTest {
 	void complexApiCombination() {
 		// when - nonZero().positive().withScale() => withScale()
 		boolean allWithCorrectScale = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().withScale(2).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.positive()
+				.withScale(2)
+				.combined())
 			.allMatch(b -> b.scale() == 2);
 
 		// then
@@ -381,7 +424,12 @@ class BigDecimalCombinableArbitraryTest {
 		BigDecimal min = BigDecimal.valueOf(-50.5);
 		BigDecimal max = BigDecimal.valueOf(-10.5);
 		boolean allInRange = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().withScale(3).withRange(min, max).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.nonZero()
+				.positive()
+				.withScale(3)
+				.withRange(min, max)
+				.combined())
 			.allMatch(b -> b.compareTo(min) >= 0 && b.compareTo(max) <= 0);
 
 		// then
@@ -392,7 +440,10 @@ class BigDecimalCombinableArbitraryTest {
 	void normalizedWithScale() {
 		// when - normalized().withScale() => withScale()
 		boolean allWithCorrectScale = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().withScale(2).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.normalized()
+				.withScale(2)
+				.combined())
 			.allMatch(b -> b.scale() == 2);
 
 		// then
@@ -403,7 +454,10 @@ class BigDecimalCombinableArbitraryTest {
 	void scaleWithNormalized() {
 		// when - withScale().normalized() => normalized()
 		boolean allNormalized = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().withScale(2).normalized().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.withScale(2)
+				.normalized()
+				.combined())
 			.allMatch(b -> b.equals(b.stripTrailingZeros()));
 
 		// then
@@ -414,7 +468,10 @@ class BigDecimalCombinableArbitraryTest {
 	void precisionWithNormalized() {
 		// when - withPrecision().normalized() => normalized()
 		boolean allNormalized = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(5).normalized().combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.withPrecision(5)
+				.normalized()
+				.combined())
 			.allMatch(b -> b.equals(b.stripTrailingZeros()));
 
 		// then
@@ -425,7 +482,10 @@ class BigDecimalCombinableArbitraryTest {
 	void normalizedWithPrecision() {
 		// when - normalized().withPrecision() => withPrecision()
 		boolean allWithCorrectPrecision = IntStream.range(0, 100)
-			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().withPrecision(3).combined())
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.normalized()
+				.withPrecision(3)
+				.combined())
 			.allMatch(b -> b.precision() <= 3);
 
 		// then

--- a/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryTest.java
+++ b/fixture-monkey-api/src/test/java/com/navercorp/fixturemonkey/api/arbitrary/BigDecimalCombinableArbitraryTest.java
@@ -1,0 +1,434 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.api.arbitrary;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.math.BigDecimal;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+class BigDecimalCombinableArbitraryTest {
+	@Test
+	void combined() {
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals().combined();
+
+		// then
+		then(actual).isInstanceOf(BigDecimal.class);
+	}
+
+	@Test
+	void withRange() {
+		// given
+		BigDecimal min = BigDecimal.valueOf(10.5);
+		BigDecimal max = BigDecimal.valueOf(50.5);
+
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals().withRange(min, max).combined();
+
+		// then
+		then(actual).isBetween(min, max);
+	}
+
+	@Test
+	void positive() {
+		// when
+		boolean allPositive = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().positive().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0);
+
+		// then
+		then(allPositive).isTrue();
+	}
+
+	@Test
+	void negative() {
+		// when
+		boolean allNegative = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().negative().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) < 0);
+
+		// then
+		then(allNegative).isTrue();
+	}
+
+	@Test
+	void nonZero() {
+		// when
+		boolean allNonZero = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) != 0);
+
+		// then
+		then(allNonZero).isTrue();
+	}
+
+	@Test
+	void percentage() {
+		// when
+		boolean allInPercentageRange = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().percentage().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) >= 0 && b.compareTo(BigDecimal.valueOf(100)) <= 0);
+
+		// then
+		then(allInPercentageRange).isTrue();
+	}
+
+	@Test
+	void score() {
+		// given
+		BigDecimal min = BigDecimal.valueOf(80.5);
+		BigDecimal max = BigDecimal.valueOf(100.0);
+
+		// when
+		boolean allInScoreRange = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().score(min, max).combined())
+			.allMatch(b -> b.compareTo(min) >= 0 && b.compareTo(max) <= 0);
+
+		// then
+		then(allInScoreRange).isTrue();
+	}
+
+	@Test
+	void withPrecision() {
+		// given
+		int precision = 3;
+
+		// when
+		boolean allWithCorrectPrecision = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(precision).combined())
+			.allMatch(b -> b.precision() <= precision);
+
+		// then
+		then(allWithCorrectPrecision).isTrue();
+	}
+
+	@Test
+	void withScale() {
+		// given
+		int scale = 2;
+
+		// when
+		boolean allWithCorrectScale = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().withScale(scale).combined())
+			.allMatch(b -> b.scale() == scale);
+
+		// then
+		then(allWithCorrectScale).isTrue();
+	}
+
+	@Test
+	void normalized() {
+		// when
+		boolean allNormalized = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().combined())
+			.allMatch(b -> b.equals(b.stripTrailingZeros()));
+
+		// then
+		then(allNormalized).isTrue();
+	}
+
+	@Test
+	void lastMethodWinsWithPositiveAndRange() {
+		// given
+		BigDecimal min = BigDecimal.valueOf(-50.5);
+		BigDecimal max = BigDecimal.valueOf(-10.5);
+
+		// when - positive().withRange() => withRange()
+		BigDecimal actual = CombinableArbitrary.bigDecimals().positive().withRange(min, max).combined();
+
+		// then
+		then(actual).isBetween(min, max);
+	}
+
+	@Test
+	void bigDecimalMapping() {
+		// when
+		String actual = CombinableArbitrary.bigDecimals()
+			.positive()
+			.map(x -> "bigdecimal:" + x)
+			.combined();
+
+		// then
+		then(actual).startsWith("bigdecimal:");
+		String numberPart = actual.substring(11);
+		BigDecimal value = new BigDecimal(numberPart);
+		then(value).isGreaterThan(BigDecimal.ZERO);
+	}
+
+	@Test
+	void bigDecimalFiltering() {
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.withRange(BigDecimal.ZERO, BigDecimal.valueOf(100))
+			.filter(b -> b.compareTo(BigDecimal.valueOf(50)) > 0)
+			.combined();
+
+		// then
+		then(actual).isGreaterThan(BigDecimal.valueOf(50));
+		then(actual).isLessThanOrEqualTo(BigDecimal.valueOf(100));
+	}
+
+	@Test
+	void bigDecimalFilteringWithMultipleConditions() {
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.positive()
+			.filter(b -> b.remainder(BigDecimal.valueOf(0.5)).compareTo(BigDecimal.ZERO) == 0)  // multiples of 0.5
+			.combined();
+
+		// then
+		then(actual).isGreaterThan(BigDecimal.ZERO);
+		then(actual.remainder(BigDecimal.valueOf(0.5))).isEqualTo(BigDecimal.ZERO);
+	}
+
+	@Test
+	void bigDecimalInjectNull() {
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.positive()
+			.injectNull(1.0)  // 100% null
+			.combined();
+
+		// then
+		then(actual).isNull();
+	}
+
+	@Test
+	void bigDecimalInjectNullWithZeroProbability() {
+		// when
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.positive()
+			.injectNull(0.0)  // 0% null
+			.combined();
+
+		// then
+		then(actual).isNotNull();
+		then(actual).isGreaterThan(BigDecimal.ZERO);
+	}
+
+	@Test
+	void bigDecimalCombinationWithMultipleOperations() {
+		// when - combine multiple operations
+		String actual = CombinableArbitrary.bigDecimals()
+			.percentage()
+			.filter(b -> b.compareTo(BigDecimal.valueOf(50)) >= 0)  // >= 50
+			.map(b -> "percentage:" + b)
+			.combined();
+
+		// then
+		then(actual).startsWith("percentage:");
+		String numberPart = actual.substring(11);
+		BigDecimal value = new BigDecimal(numberPart);
+		then(value).isBetween(BigDecimal.valueOf(50), BigDecimal.valueOf(100));
+	}
+
+	@Test
+	void bigDecimalUniqueWithDifferentValues() {
+		// when - unique() works with different values
+		BigDecimal actual = CombinableArbitrary.bigDecimals()
+			.withRange(BigDecimal.ZERO, BigDecimal.valueOf(1000))  // wide range
+			.unique()
+			.combined();
+
+		// then
+		then(actual).isBetween(BigDecimal.ZERO, BigDecimal.valueOf(1000));
+	}
+
+	@Test
+	void fixed() {
+		// when
+		boolean actual = CombinableArbitrary.bigDecimals().fixed();
+
+		// then
+		then(actual).isFalse();
+	}
+
+	@Test
+	void lastMethodWinsRangeOverPositive() {
+		// when - positive().withRange() => withRange()
+		boolean allInRange = IntStream.range(0, 30)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().positive().withRange(BigDecimal.valueOf(-10.5), BigDecimal.valueOf(-1.5)).combined())
+			.allMatch(b -> b.compareTo(BigDecimal.valueOf(-10.5)) >= 0 && b.compareTo(BigDecimal.valueOf(-1.5)) <= 0);
+
+		// then
+		then(allInRange).isTrue();
+	}
+
+	@Test
+	void lastMethodWinsPrecisionOverScale() {
+		// when - withPrecision().withScale() => withScale()
+		boolean allWithCorrectScale = IntStream.range(0, 30)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(5).withScale(2).combined())
+			.allMatch(b -> b.scale() == 2);
+
+		// then
+		then(allWithCorrectScale).isTrue();
+	}
+
+	@Test
+	void bigDecimalFilterWithPositiveAndScale() {
+		// when - filter positive with specific scale
+		boolean allPositiveWithScale = IntStream.range(0, 30)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals()
+				.positive()
+				.withScale(2)
+				.filter(b -> b.compareTo(BigDecimal.valueOf(10)) >= 0).combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0 && b.scale() == 2 && b.compareTo(BigDecimal.valueOf(10)) >= 0);
+
+		// then
+		then(allPositiveWithScale).isTrue();
+	}
+
+	@Test
+	void nonZeroWithPrecision() {
+		// when - nonZero().withPrecision() => withPrecision()
+		boolean allWithCorrectPrecision = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().withPrecision(3).combined())
+			.allMatch(b -> b.precision() <= 3);
+
+		// then
+		then(allWithCorrectPrecision).isTrue();
+	}
+
+	@Test
+	void nonZeroWithScale() {
+		// when - nonZero().withScale() => withScale()
+		boolean allWithCorrectScale = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().withScale(2).combined())
+			.allMatch(b -> b.scale() == 2);
+
+		// then
+		then(allWithCorrectScale).isTrue();
+	}
+
+	@Test
+	void nonZeroWithPositive() {
+		// when
+		boolean allNonZeroAndPositive = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) > 0);
+
+		// then
+		then(allNonZeroAndPositive).isTrue();
+	}
+
+	@Test
+	void nonZeroWithNegative() {
+		// when - nonZero().negative() => negative()
+		boolean allNegative = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().negative().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) < 0);
+
+		// then
+		then(allNegative).isTrue();
+	}
+
+	@Test
+	void negativeWithNonZero() {
+		// when - negative().nonZero() => nonZero()
+		boolean allNonZero = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().negative().nonZero().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) != 0);
+
+		// then
+		then(allNonZero).isTrue();
+	}
+
+	@Test
+	void positiveWithNegativeCombination() {
+		// when - positive().negative() => negative()
+		boolean allNegative = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().positive().negative().combined())
+			.allMatch(b -> b.compareTo(BigDecimal.ZERO) < 0);
+
+		// then
+		then(allNegative).isTrue();
+	}
+
+	@Test
+	void complexApiCombination() {
+		// when - nonZero().positive().withScale() => withScale()
+		boolean allWithCorrectScale = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().withScale(2).combined())
+			.allMatch(b -> b.scale() == 2);
+
+		// then
+		then(allWithCorrectScale).isTrue();
+	}
+
+	@Test
+	void rangeOverridesOtherConstraints() {
+		// when
+		BigDecimal min = BigDecimal.valueOf(-50.5);
+		BigDecimal max = BigDecimal.valueOf(-10.5);
+		boolean allInRange = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().nonZero().positive().withScale(3).withRange(min, max).combined())
+			.allMatch(b -> b.compareTo(min) >= 0 && b.compareTo(max) <= 0);
+
+		// then
+		then(allInRange).isTrue();
+	}
+
+	@Test
+	void normalizedWithScale() {
+		// when - normalized().withScale() => withScale()
+		boolean allWithCorrectScale = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().withScale(2).combined())
+			.allMatch(b -> b.scale() == 2);
+
+		// then
+		then(allWithCorrectScale).isTrue();
+	}
+
+	@Test
+	void scaleWithNormalized() {
+		// when - withScale().normalized() => normalized()
+		boolean allNormalized = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().withScale(2).normalized().combined())
+			.allMatch(b -> b.equals(b.stripTrailingZeros()));
+
+		// then
+		then(allNormalized).isTrue();
+	}
+
+	@Test
+	void precisionWithNormalized() {
+		// when - withPrecision().normalized() => normalized()
+		boolean allNormalized = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().withPrecision(5).normalized().combined())
+			.allMatch(b -> b.equals(b.stripTrailingZeros()));
+
+		// then
+		then(allNormalized).isTrue();
+	}
+
+	@Test
+	void normalizedWithPrecision() {
+		// when - normalized().withPrecision() => withPrecision()
+		boolean allWithCorrectPrecision = IntStream.range(0, 100)
+			.mapToObj(i -> CombinableArbitrary.bigDecimals().normalized().withPrecision(3).combined())
+			.allMatch(b -> b.precision() <= 3);
+
+		// then
+		then(allWithCorrectPrecision).isTrue();
+	}
+}

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestBigDecimalCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestBigDecimalCombinableArbitrary.kt
@@ -1,0 +1,93 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotest
+
+import com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.single
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+import java.util.function.Predicate
+
+@API(since = "1.1.16", status = Status.EXPERIMENTAL)
+class KotestBigDecimalCombinableArbitrary(
+    private val arb: Arb<BigDecimal> = Arb.bigDecimal()
+) : BigDecimalCombinableArbitrary {
+
+    override fun combined(): BigDecimal = arb.single()
+
+    override fun rawValue(): BigDecimal = this.combined()
+
+    override fun withRange(min: BigDecimal, max: BigDecimal): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            Arb.bigDecimal().filter { it >= min && it <= max }
+        )
+
+    override fun positive(): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            Arb.bigDecimal().filter { it > BigDecimal.ZERO }
+        )
+
+    override fun negative(): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            Arb.bigDecimal().filter { it < BigDecimal.ZERO }
+        )
+
+    override fun nonZero(): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            Arb.bigDecimal().filter { it.compareTo(BigDecimal.ZERO) != 0 }
+        )
+
+    override fun percentage(): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            Arb.bigDecimal().filter { it >= BigDecimal.ZERO && it <= BigDecimal.valueOf(100) }
+        )
+
+    override fun score(min: BigDecimal, max: BigDecimal): BigDecimalCombinableArbitrary =
+        withRange(min, max)
+
+    override fun withPrecision(precision: Int): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            arb.map { it.round(MathContext(precision)) }
+        )
+
+    override fun withScale(scale: Int): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            arb.map { it.setScale(scale, RoundingMode.HALF_UP) }
+        )
+
+    override fun normalized(): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(
+            arb.map { it.stripTrailingZeros() }
+        )
+
+    override fun filter(tries: Int, predicate: Predicate<BigDecimal>): BigDecimalCombinableArbitrary =
+        KotestBigDecimalCombinableArbitrary(arb.filter(predicate::test))
+
+    override fun clear() {
+    }
+
+    override fun fixed(): Boolean = false
+}

--- a/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestBigDecimalCombinableArbitrary.kt
+++ b/fixture-monkey-kotest/src/main/kotlin/com/navercorp/fixturemonkey/kotest/KotestBigDecimalCombinableArbitrary.kt
@@ -70,17 +70,17 @@ class KotestBigDecimalCombinableArbitrary(
 
     override fun withPrecision(precision: Int): BigDecimalCombinableArbitrary =
         KotestBigDecimalCombinableArbitrary(
-            arb.map { it.round(MathContext(precision)) }
+            Arb.bigDecimal().map { it.round(MathContext(precision)) }
         )
 
     override fun withScale(scale: Int): BigDecimalCombinableArbitrary =
         KotestBigDecimalCombinableArbitrary(
-            arb.map { it.setScale(scale, RoundingMode.HALF_UP) }
+            Arb.bigDecimal().map { it.setScale(scale, RoundingMode.HALF_UP) }
         )
 
     override fun normalized(): BigDecimalCombinableArbitrary =
         KotestBigDecimalCombinableArbitrary(
-            arb.map { it.stripTrailingZeros() }
+            Arb.bigDecimal().map { it.stripTrailingZeros() }
         )
 
     override fun filter(tries: Int, predicate: Predicate<BigDecimal>): BigDecimalCombinableArbitrary =

--- a/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary
+++ b/fixture-monkey-kotest/src/main/resources/META-INF/services/com.navercorp.fixturemonkey.api.arbitrary.BigDecimalCombinableArbitrary
@@ -1,0 +1,1 @@
+com.navercorp.fixturemonkey.kotest.KotestBigDecimalCombinableArbitrary

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.tests.kotlin
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.arbitrary.CombinableArbitrary
 import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin
+import com.navercorp.fixturemonkey.kotest.KotestBigDecimalCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestIntegerCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestByteCombinableArbitrary
 import com.navercorp.fixturemonkey.kotest.KotestPlugin
@@ -1071,6 +1072,54 @@ class KotestInJunitTest {
         val actual = CombinableArbitrary.integers().negative().withRange(100, 1000).combined()
 
         then(actual).isBetween(100, 1000)
+    }
+
+    // new test for BigDecimal CombinableArbitrary
+    @Test
+    fun bigDecimalCombinableArbitrary() {
+        val actual = CombinableArbitrary.bigDecimals()
+
+        then(actual).isInstanceOf(KotestBigDecimalCombinableArbitrary::class.java)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun bigDecimalCombinableArbitraryPositive() {
+        val actual = CombinableArbitrary.bigDecimals().positive().combined()
+
+        then(actual).isPositive()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun bigDecimalCombinableArbitraryNegative() {
+        val actual = CombinableArbitrary.bigDecimals().negative().combined()
+
+        then(actual).isNegative()
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun bigDecimalCombinableArbitraryWithRange() {
+        val actual = CombinableArbitrary.bigDecimals().withRange(
+            BigDecimal("100.0"), BigDecimal("1000.0")
+        ).combined()
+
+        then(actual).isBetween(BigDecimal("100.0"), BigDecimal("1000.0"))
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun bigDecimalCombinableArbitraryWithPrecision() {
+        val actual = CombinableArbitrary.bigDecimals().withPrecision(2).combined()
+
+        then(actual).hasScaleOf(2)
+    }
+
+    @RepeatedTest(TEST_COUNT)
+    fun bigDecimalCombinableArbitraryLastMethodWins() {
+        val actual = CombinableArbitrary.bigDecimals()
+            .withRange(BigDecimal("10.0"), BigDecimal("20.0"))
+            .negative()
+            .combined()
+
+        then(actual).isNegative()
     }
 
     companion object {

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/KotestInJunitTest.kt
@@ -1109,7 +1109,7 @@ class KotestInJunitTest {
     fun bigDecimalCombinableArbitraryWithPrecision() {
         val actual = CombinableArbitrary.bigDecimals().withPrecision(2).combined()
 
-        then(actual).hasScaleOf(2)
+        then(actual.precision()).isLessThanOrEqualTo(2)
     }
 
     @RepeatedTest(TEST_COUNT)


### PR DESCRIPTION
## Summary
Add BigDecimalCombinableArbitrary wrapping Jqwik and Kotest BigDecimal arbitraries with precision/scale control enhancements following existing CombinableArbitrary pattern.

## Description
Implemented BigDecimalCombinableArbitrary by wrapping existing BigDecimal arbitrary implementations from Jqwik and Kotest frameworks, adding precision/scale constraints and following established CombinableArbitrary patterns.

**Added components:**
- `BigDecimalCombinableArbitrary` interface with precision/scale constraint methods
- `BigDecimalCombinableArbitraryDelegator` for filter/null injection operations  
- `JqwikBigDecimalCombinableArbitrary` wrapping `Arbitraries.bigDecimals()`
- `KotestBigDecimalCombinableArbitrary` wrapping `Arb.bigDecimal()` (fixed from incorrect Byte implementation)
- Factory method `CombinableArbitrary.bigDecimals()` with ServiceLoader integration

**Key features:**
- Standard numeric constraints: `.positive()`, `.negative()`, `.nonZero()`, `.withRange(BigDecimal, BigDecimal)`
- Precision/Scale control: `.withPrecision(int)`, `.withScale(int)`, `.normalized()`
- Specialized ranges: `.percentage()` (0.0-100.0), `.score(min, max)`
- Last-method-wins behavior for constraint precedence (precision/scale constraints override previous ones)
- Full integration with existing filter/map/unique operations

**Usage example:**
```java
BigDecimal nonZeroDecimal = CombinableArbitrary.bigDecimals().nonZero().combined();
BigDecimal twoDecimalPlaces = CombinableArbitrary.bigDecimals().withScale(2).combined();
BigDecimal percentage = CombinableArbitrary.bigDecimals().percentage().withPrecision(3).combined();
```

## How Has This Been Tested?
Added comprehensive test suite in `BigDecimalCombinableArbitraryTest`:
- Basic constraint validation (positive, negative, nonZero, withRange)
- Precision and scale constraint testing with various decimal configurations
- Method chaining and last-method-wins precedence verification
- Integration with filter/map/unique operations
- Complex precision/scale constraint combinations and normalization
- ServiceLoader integration testing for both Jqwik and Kotest implementations

## Is the Document updated?
Documentation will be updated to include BigDecimalCombinableArbitrary usage examples alongside existing numeric arbitrary types, with special emphasis on precision/scale control and framework-specific implementations.