### PR TITLE
Return proxy for self-type returning methods on interface instances

### DIFF
--- a/docs/docs/generating-objects/generating-interface.md
+++ b/docs/docs/generating-objects/generating-interface.md
@@ -84,7 +84,11 @@ Fixture Monkey only generates property values for methods that:
 - Follow the naming convention of getters (like `getValue()`, `getName()`, etc.)
 - Have no parameters
 
-Other methods will always return `null` or default primitive values.
+Other methods will return `null` or default primitive values, with one exception:
+methods whose return type is the interface itself — either by exact match or via
+a self-typed type variable (`T extends Spec<T>`) — yield the proxy instance.
+This allows `default` methods that chain through abstract wither/setter methods
+to run without producing a `NullPointerException`.
 :::
 
 You can customize the generated properties using the same API as for regular classes:

--- a/docs/docs/release-notes/v1.1.x.md
+++ b/docs/docs/release-notes/v1.1.x.md
@@ -5,6 +5,13 @@ sidebar_position: 2
 
 # v1.1.x
 
+## v1.1.20
+
+##### Bug Fixes
+- Fix NPE on self-type returning methods of anonymous interface proxies; abstract `withX`/setter methods returning the interface itself (or a self-typed `T extends Spec<T>`) now yield the proxy instance instead of `null`
+
+---
+
 ## v1.1.19
 
 #### Bug Fixes

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/generating-objects/generating-interface.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/generating-objects/generating-interface.md
@@ -130,7 +130,11 @@ Fixture Monkey는 다음 조건을 만족하는 메서드에 대해서만 속성
 - getter 네이밍 규칙을 따르는 메서드(`getValue()`, `getName()` 등)
 - 매개변수가 없는 메서드
 
-다른 메서드는 항상 `null` 또는 기본 원시값을 반환합니다.
+그 외의 메서드는 `null` 또는 기본 원시값을 반환하지만, 한 가지 예외가 있습니다:
+반환 타입이 인터페이스 자기 자신인 메서드(정확한 타입 일치 또는 `T extends Spec<T>`
+같은 self-typed 타입 변수)는 proxy 인스턴스 자체를 반환합니다. 이를 통해 `default`
+메서드가 인자 있는 abstract wither/setter 메서드를 호출하더라도 `NullPointerException`
+없이 동작합니다.
 :::
 
 일반 클래스와 마찬가지로 생성된 속성을 커스터마이징할 수 있습니다:

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/release-notes/v1.1.x.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/release-notes/v1.1.x.md
@@ -5,6 +5,13 @@ sidebar_position: 2
 
 # v1.1.x
 
+## v1.1.20
+
+##### Bug Fixes
+- 익명 인터페이스 proxy에서 self-type을 반환하는 메서드의 NPE 수정. 인터페이스 자기 자신(또는 `T extends Spec<T>` 형태의 self-typed 타입 변수)을 반환하는 abstract `withX`/setter 메서드가 이제 `null` 대신 proxy 인스턴스를 반환합니다.
+
+---
+
 ## v1.1.19
 
 #### Bug Fixes

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/AnonymousArbitraryIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/AnonymousArbitraryIntrospector.java
@@ -39,6 +39,11 @@ import com.navercorp.fixturemonkey.api.type.Types;
 /**
  * It generates the anonymous object of interface which has no-argument methods.
  * It is a default fallback {@link ArbitraryIntrospector}, if set none of introspectors in the options.
+ *
+ * <p>Methods returning the proxied interface itself (either by exact type match or via a
+ * self-typed type variable like {@code T extends Spec<T>}) yield the proxy instance.
+ * This avoids {@code NullPointerException} when default methods chain through abstract
+ * wither/setter methods.
  */
 @API(since = "0.5.5", status = Status.MAINTAINED)
 public final class AnonymousArbitraryIntrospector implements ArbitraryIntrospector, Matcher {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/InvocationHandlerBuilder.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/InvocationHandlerBuilder.java
@@ -20,11 +20,15 @@ package com.navercorp.fixturemonkey.api.introspector;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.type.Types;
 
 /**
  * A builder generates {@link InvocationHandler} for generating an anonymous instance of interface dynamically.
@@ -72,12 +76,35 @@ final class InvocationHandlerBuilder {
 				return toString(proxy);
 			}
 
+			if (isSelfTypeReturn(method)) {
+				return proxy;
+			}
+
 			return generatedValuesByMethodName.get(method.getName());
 		};
 	}
 
 	boolean isEmpty() {
 		return generatedValuesByMethodName.isEmpty();
+	}
+
+	private boolean isSelfTypeReturn(Method method) {
+		if (method.getReturnType() == type) {
+			return true;
+		}
+
+		Type genericReturn = method.getGenericReturnType();
+		if (!(genericReturn instanceof TypeVariable)) {
+			return false;
+		}
+
+		for (Type bound : ((TypeVariable<?>)genericReturn).getBounds()) {
+			Class<?> rawBound = Types.getActualType(bound);
+			if (rawBound != Object.class && rawBound.isAssignableFrom(type)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean compareAllReturnValues(Object other) {

--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/introspector/InvocationHandlerBuilder.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/introspector/InvocationHandlerBuilder.java
@@ -20,11 +20,15 @@ package com.navercorp.fixturemonkey.api.introspector;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+
+import com.navercorp.fixturemonkey.api.type.Types;
 
 /**
  * A builder generates {@link InvocationHandler} for generating an anonymous instance of interface dynamically.
@@ -76,12 +80,35 @@ final class InvocationHandlerBuilder {
 				return toString(proxy);
 			}
 
+			if (isSelfTypeReturn(method)) {
+				return proxy;
+			}
+
 			return generatedValuesByMethodName.get(method.getName());
 		};
 	}
 
 	boolean isEmpty() {
 		return generatedValuesByMethodName.isEmpty();
+	}
+
+	private boolean isSelfTypeReturn(Method method) {
+		if (method.getReturnType() == type) {
+			return true;
+		}
+
+		Type genericReturn = method.getGenericReturnType();
+		if (!(genericReturn instanceof TypeVariable)) {
+			return false;
+		}
+
+		for (Type bound : ((TypeVariable<?>)genericReturn).getBounds()) {
+			Class<?> rawBound = Types.getActualType(bound);
+			if (rawBound != Object.class && rawBound.isAssignableFrom(type)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean compareAllReturnValues(Object other) {

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/InterfaceDefaultMethodTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/InterfaceDefaultMethodTest.java
@@ -4,6 +4,7 @@ import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin;
@@ -13,16 +14,103 @@ class InterfaceDefaultMethodTest {
 		.plugin(new InterfacePlugin())
 		.build();
 
-	@RepeatedTest(TEST_COUNT)
+	@Test
 	void defaultMethod() {
 		String actual = SUT.giveMeOne(DefaultMethodInterface.class).defaultMethod();
 
 		then(actual).isEqualTo("test");
 	}
 
+	@Test
+	void defaultMethodDependsOnAbstractMethod() {
+		DependentDefaultMethodInterface instance = SUT.giveMeOne(DependentDefaultMethodInterface.class);
+
+		String actual = instance.defaultMethod();
+
+		then(actual).isEqualTo("test-" + instance.value());
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void defaultMethodReturningThis() {
+		SelfReturningDefaultMethodInterface instance = SUT.giveMeOne(SelfReturningDefaultMethodInterface.class);
+
+		SelfReturningDefaultMethodInterface actual = instance.self();
+
+		then(actual).isSameAs(instance);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void defaultMethodCallingAbstractMethodWithArgument() {
+		ConcreteSelfTypedWither instance = SUT.giveMeOne(ConcreteSelfTypedWither.class);
+
+		ConcreteSelfTypedWither actual = instance.withDefaultContent();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void abstractMethodWithArgumentReturningSelfTypeReturnsProxy() {
+		ConcreteSelfTypedWither instance = SUT.giveMeOne(ConcreteSelfTypedWither.class);
+
+		ConcreteSelfTypedWither actual = instance.withContent("new-content");
+
+		then(actual).isSameAs(instance);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void defaultMethodCallingNoArgAbstractMethod() {
+		ConcreteSelfTypedWither instance = SUT.giveMeOne(ConcreteSelfTypedWither.class);
+
+		ConcreteSelfTypedWither actual = instance.copyViaDefault();
+
+		then(actual).isNotNull();
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void noArgAbstractMethodReturningSelfType() {
+		ConcreteSelfTypedWither instance = SUT.giveMeOne(ConcreteSelfTypedWither.class);
+
+		ConcreteSelfTypedWither actual = instance.copy();
+
+		then(actual).isNotNull();
+	}
+
 	public interface DefaultMethodInterface {
 		default String defaultMethod() {
 			return "test";
 		}
+	}
+
+	public interface DependentDefaultMethodInterface {
+		String value();
+
+		default String defaultMethod() {
+			return "test-" + value();
+		}
+	}
+
+	public interface SelfReturningDefaultMethodInterface {
+		String value();
+
+		default SelfReturningDefaultMethodInterface self() {
+			return this;
+		}
+	}
+
+	public interface SelfTypedWither<T extends SelfTypedWither<T>> {
+		T withContent(String content);
+
+		T copy();
+
+		default T withDefaultContent() {
+			return withContent("x");
+		}
+
+		default T copyViaDefault() {
+			return copy();
+		}
+	}
+
+	public interface ConcreteSelfTypedWither extends SelfTypedWither<ConcreteSelfTypedWither> {
 	}
 }


### PR DESCRIPTION
## Summary
Return proxy for self-type returning methods on interface instances

## How Has This Been Tested?
* noArgAbstractMethodReturningSelfType
* defaultMethodCallingNoArgAbstractMethod
* abstractMethodWithArgumentReturningSelfTypeReturnsProxy
* defaultMethodCallingAbstractMethodWithArgument
* defaultMethodReturningThis
* defaultMethodDependsOnAbstractMethod

## Is the Document updated?
Yes