### PR TITLE
Optimize Kotlin primary constructor fixture generation

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/introspector/PrimaryConstructorArbitraryIntrospector.kt
@@ -36,15 +36,23 @@ import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.MAINTAINED
 import org.slf4j.LoggerFactory
 import java.lang.reflect.Modifier
+import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 
 @API(since = "0.4.0", status = MAINTAINED)
 class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector, Matcher {
-    override fun match(property: Property): Boolean =
-        property.type.actualType().isKotlinType() &&
-            !property.type.actualType().cachedKotlin().isKotlinLambda() &&
-            property.type.actualType().cachedKotlin() != Unit::class &&
-            property.type.actualType().cachedKotlin().objectInstance == null
+    override fun match(property: Property): Boolean {
+        val actualType = property.type.actualType()
+        if (!actualType.isKotlinType()) {
+            return false
+        }
+
+        val kotlinClass = actualType.cachedKotlin()
+
+        return !kotlinClass.isKotlinLambda() &&
+            kotlinClass != Unit::class &&
+            kotlinClass.objectInstance == null
+    }
 
     override fun introspect(context: ArbitraryGeneratorContext): ArbitraryIntrospectorResult {
         val type = Types.getActualType(context.resolvedType)
@@ -63,20 +71,46 @@ class PrimaryConstructorArbitraryIntrospector : ArbitraryIntrospector, Matcher {
             CombinableArbitrary.objectBuilder()
                 .properties(context.combinableArbitrariesByArbitraryProperty)
                 .build {
-                    val arbitrariesByPropertyName: Map<String?, Any?> =
-                        it.mapKeys { map -> map.key.objectProperty.property.name }
-                    val generatedByParameters = mutableMapOf<KParameter, Any?>()
-
-                    for (parameter in constructor.parameters) {
-                        val resolvedArbitrary = arbitrariesByPropertyName[parameter.name]
-                        if (resolvedArbitrary != null || !parameter.isOptional || parameter.type.isMarkedNullable) {
-                            generatedByParameters[parameter] = resolvedArbitrary
-                        }
+                    val arbitrariesByPropertyName = HashMap<String?, Any?>(it.size)
+                    it.forEach { (arbitraryProperty, value) ->
+                        arbitrariesByPropertyName[arbitraryProperty.objectProperty.property.name] = value
                     }
 
-                    constructor.callBy(generatedByParameters)
+                    callConstructor(constructor, arbitrariesByPropertyName)
                 },
         )
+    }
+
+    private fun callConstructor(
+        constructor: KFunction<*>,
+        arbitrariesByPropertyName: Map<String?, Any?>
+    ): Any? {
+        val parameters = constructor.parameters
+        val arguments = arrayOfNulls<Any>(parameters.size)
+        val includedParameters = BooleanArray(parameters.size)
+        var hasSkippedOptionalParameter = false
+
+        for ((index, parameter) in parameters.withIndex()) {
+            val resolvedArbitrary = arbitrariesByPropertyName[parameter.name]
+            if (resolvedArbitrary != null || !parameter.isOptional || parameter.type.isMarkedNullable) {
+                arguments[index] = resolvedArbitrary
+                includedParameters[index] = true
+            } else {
+                hasSkippedOptionalParameter = true
+            }
+        }
+
+        if (!hasSkippedOptionalParameter) {
+            return constructor.call(*arguments)
+        }
+
+        val generatedByParameters = LinkedHashMap<KParameter, Any?>(parameters.size)
+        for ((index, parameter) in parameters.withIndex()) {
+            if (includedParameters[index]) {
+                generatedByParameters[parameter] = arguments[index]
+            }
+        }
+        return constructor.callBy(generatedByParameters)
     }
 
     override fun getRequiredPropertyGenerator(p: Property): PropertyGenerator = PROPERTY_GENERATOR

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinConstructorParameterPropertyGenerator.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinConstructorParameterPropertyGenerator.kt
@@ -42,7 +42,7 @@ internal class KotlinConstructorParameterPropertyGenerator(
 
     override fun generateChildProperties(property: Property): List<Property> =
         parameterPropertiesCache.computeIfAbsent(property) { _ ->
-            val constructorParameterNames = constructorResolver.invoke(property).parameters.map { it.name }
+            val constructorParameterNames = constructorResolver.invoke(property).parameters.mapTo(HashSet()) { it.name }
 
             val kotlinProperties = getMemberProperties(property) {
                 parameterFilter.invoke(it).and(constructorParameterNames.contains(it.name))

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTest.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTest.kt
@@ -21,8 +21,8 @@ package com.navercorp.fixturemonkey.kotlin.test
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
-import com.navercorp.fixturemonkey.kotlin.set
 import net.jqwik.api.Example
 import org.assertj.core.api.BDDAssertions.then
 import org.assertj.core.api.BDDAssertions.thenNoException
@@ -71,6 +71,26 @@ class PrimaryConstructorArbitraryIntrospectorTest {
     }
 
     @Example
+    fun sampleDefaultValueWhenOptionalParameterIsSkipped() {
+        // when
+        val actual = sut.giveMeKotlinBuilder<DefaultValue>()
+            .set(DefaultValue::stringValue, null)
+            .sample()
+
+        then(actual.stringValue).isEqualTo("default_value")
+    }
+
+    @Example
+    fun sampleNullableDefaultValue() {
+        // when
+        val actual = sut.giveMeKotlinBuilder<NullableDefaultValue>()
+            .set(NullableDefaultValue::stringValue, null)
+            .sample()
+
+        then(actual.stringValue).isNull()
+    }
+
+    @Example
     fun sampleDuration() {
         // when
         val duration = sut.giveMeOne<Duration>()
@@ -92,7 +112,7 @@ class PrimaryConstructorArbitraryIntrospectorTest {
         val duration = Random().nextLong().toDuration(DurationUnit.values().random())
 
         // when
-        val one = sut.giveMeBuilder<DurationValue>()
+        val one = sut.giveMeKotlinBuilder<DurationValue>()
             .set(DurationValue::duration, duration)
             .sample()
 

--- a/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTestSpecs.kt
+++ b/fixture-monkey-kotlin/src/test/kotlin/com/navercorp/fixturemonkey/kotlin/test/PrimaryConstructorArbitraryIntrospectorTestSpecs.kt
@@ -53,6 +53,11 @@ class DefaultValue(
     val stringValue: String = "default_value",
 )
 
+class NullableDefaultValue(
+    val intValue: Int,
+    val stringValue: String? = "default_value",
+)
+
 class SecondaryConstructor(
     val intValue: Int,
     val stringValue: String,


### PR DESCRIPTION
## Summary

This PR optimizes Kotlin primary constructor-based fixture generation without adding new dependencies or changing public APIs.

It reduces per-sample overhead in Kotlin object creation paths, which can become more visible when tests run under JVM instrumentation tools such as Kover.

## (Optional): Description

The previous implementation always used `callBy(...)` and built intermediate maps for every generated Kotlin object. `callBy(...)` is still necessary when optional constructor parameters should be omitted, but it is more expensive than needed when all parameters are already available.

This PR keeps the existing optional-parameter behavior intact and only uses the faster `KFunction.call(*args)` path when every constructor parameter can be provided.

Changes include:

- Reduce repeated `actualType()` / `cachedKotlin()` calls in `PrimaryConstructorArbitraryIntrospector.match()`.
- Avoid `mapKeys` allocation in the constructor invocation path by building the name-value map directly.
- Use `KFunction.call(*args)` when no optional constructor parameter needs to be skipped.
- Keep `callBy(...)` when optional parameters must be skipped.
- Preserve explicit `null` behavior for nullable optional parameters.
- Change constructor parameter name lookup from `List.contains` to `Set.contains`.
- Add regression tests for optional default values and nullable optional default values.

Local quick JMH benchmark:

| Version | Score |
| --- | ---: |
| Before | 1214.915 ms/op |
| After | 904.979 ms/op |

Benchmark command:

```bash
./gradlew :fixture-monkey-benchmarks:fixture-monkey-benchmark-kotlin:jmh \
  -Pjmh.quick \
  '-Pjmh.include=.*primaryConstructorGenerateKotlinOrderSheetWithFixtureMonkey.*'
```

## How Has This Been Tested?

```
./gradlew :fixture-monkey-kotlin:test :fixture-monkey-kotlin:ktlintCheck
./gradlew :fixture-monkey-tests:kotlin-tests:test
```

I also verified the benchmark above locally to compare the Kotlin primary constructor fixture generation path before and after this change.

## Is the Document updated?
No.

This PR does not change public APIs, user-facing behavior, configuration, or documented usage. It only optimizes the existing Kotlin primary constructor generation path.

Please feel free to share any feedback, especially if there are concerns about the constructor invocation behavior or benchmark scope.
