### PR TITLE
Fix Kotlin value class values lost when decomposing a set object

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KPropertyProperty.kt
@@ -23,6 +23,7 @@ import org.apiguardian.api.API
 import org.slf4j.LoggerFactory
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Type
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
@@ -33,6 +34,8 @@ data class KPropertyProperty(
     private val annotatedType: AnnotatedType,
     val kProperty: KProperty<*>,
 ) : Property {
+    private val valueClassReturnType: Boolean = (kProperty.returnType.classifier as? KClass<*>)?.isValue == true
+
     override fun getType(): Type = this.annotatedType.type
 
     override fun getAnnotatedType(): AnnotatedType = this.annotatedType
@@ -42,6 +45,20 @@ data class KPropertyProperty(
     override fun getAnnotations(): List<Annotation> = this.annotatedType.annotations.toList()
 
     override fun getValue(instance: Any): Any? {
+        val rawValue = readRawValue(instance)
+
+        // A value class is inlined into its owner, so the read above yields the underlying value
+        // rather than the value class the property declares. kotlin-reflect re-boxes it, but only
+        // ask it to once the value is known to be non-null: given a null it hands back a value
+        // class wrapping null, which is not constructible.
+        if (valueClassReturnType && rawValue != null) {
+            return this.kProperty.getter.call(instance)
+        }
+
+        return rawValue
+    }
+
+    private fun readRawValue(instance: Any): Any? {
         val javaMethod = this.kProperty.getter.javaMethod
 
         if (javaMethod != null) {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinConstructorParameterProperty.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/property/KotlinConstructorParameterProperty.kt
@@ -24,8 +24,11 @@ import com.navercorp.fixturemonkey.kotlin.type.toTypeReference
 import java.lang.reflect.AnnotatedType
 import java.lang.reflect.Type
 import java.util.Optional
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaMethod
 
 internal data class KotlinConstructorParameterProperty(
     private val annotatedType: AnnotatedType,
@@ -33,6 +36,8 @@ internal data class KotlinConstructorParameterProperty(
     private val parameterName: String?,
     private val constructor: KFunction<*>,
 ) : Property {
+    private val valueClassParameter: Boolean = (kParameter.type.classifier as? KClass<*>)?.isValue == true
+
     override fun getType(): Type = annotatedType.type
 
     override fun getAnnotatedType(): AnnotatedType = annotatedType
@@ -42,9 +47,20 @@ internal data class KotlinConstructorParameterProperty(
     override fun getAnnotations(): List<Annotation> = kParameter.annotations
 
     override fun getValue(obj: Any?): Any? {
-        return getKotlinMemberProperties(constructor.returnType.toTypeReference().type.actualType())
+        val property = getKotlinMemberProperties(constructor.returnType.toTypeReference().type.actualType())
             .firstOrNull { it.name == parameterName }
-            ?.call(obj)
+            ?: return null
+
+        if (!valueClassParameter) {
+            return property.call(obj)
+        }
+
+        // kotlin-reflect boxes a value class unconditionally, so a null underlying value comes back
+        // as a value class wrapping null, which is not constructible. Read the raw value first and
+        // only let kotlin-reflect box it when there is something to box.
+        val getter = property.getter.javaMethod ?: return property.call(obj)
+        getter.isAccessible = true
+        return if (getter.invoke(obj) == null) null else property.call(obj)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
@@ -128,10 +128,70 @@ class ValueClassTest {
         then(actual.fooObject.foo).isNull()
     }
 
+    @Test
+    fun setValueClassObject() {
+        data class ValueClassObject(val foo: Foo)
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = SUT.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun setNestedValueClassObject() {
+        data class ValueClassObject(val foo: Foo)
+
+        data class NestedValueClassObject(val fooObject: ValueClassObject)
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = SUT.giveMeKotlinBuilder<NestedValueClassObject>()
+            .set(NestedValueClassObject::fooObject, expected)
+            .sample()
+
+        then(actual.fooObject).isEqualTo(expected)
+    }
+
+    @Test
+    fun setValueClassObjectWithRenamedProperty() {
+        data class ValueClassObject(val foo: Foo)
+
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .defaultPropertyNameResolver { property -> "renamed_" + property.name }
+            .build()
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = sut.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun setNullableValueClassObjectByConstructorInstantiator() {
+        val expected = NullableValueClassObject(null, "hello")
+
+        val actual = SUT.giveMeKotlinBuilder<NullableValueClassObject>()
+            .instantiateBy<NullableValueClassObject> { constructor<NullableValueClassObject>() }
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
     @JvmInline
     value class Foo(
         val bar: String,
     )
+
+    data class NullableValueClassObject(val foo: Foo?, val name: String)
 
     @JvmInline
     value class FooWithPrivateConstructor private constructor(


### PR DESCRIPTION
## Summary
Fix Kotlin value class values lost when decomposing a set object

## (Optional): Description
*Describe your changes in detail*

## How Has This Been Tested?
* setValueClassObject
* setValueClassObject
* setNullableValueClassObjectByConstructorInstantiator
* setValueClassObjectWithRenamedProperty

## Is the Document updated?
No
