### PR TITLE
Rebuild inlined value types when decomposing a value passed to set(...)

### DIFF
--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/KotlinPlugin.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/KotlinPlugin.kt
@@ -18,7 +18,6 @@
 
 package com.navercorp.fixturemonkey.kotlin
 
-import com.navercorp.fixturemonkey.planner.AssemblyPlanner
 import com.navercorp.fixturemonkey.api.generator.FunctionalInterfaceContainerPropertyGenerator
 import com.navercorp.fixturemonkey.api.generator.MatchPropertyGenerator
 import com.navercorp.fixturemonkey.api.generator.NullInjectGenerator
@@ -37,6 +36,7 @@ import com.navercorp.fixturemonkey.kotlin.generator.PairContainerPropertyGenerat
 import com.navercorp.fixturemonkey.kotlin.generator.PairDecomposedContainerValueFactory
 import com.navercorp.fixturemonkey.kotlin.generator.TripleContainerPropertyGenerator
 import com.navercorp.fixturemonkey.kotlin.generator.TripleDecomposedContainerValueFactory
+import com.navercorp.fixturemonkey.kotlin.input.KotlinValueClassResolver
 import com.navercorp.fixturemonkey.kotlin.instantiator.KotlinInstantiatorProcessor
 import com.navercorp.fixturemonkey.kotlin.introspector.KotlinDurationIntrospector
 import com.navercorp.fixturemonkey.kotlin.introspector.PairIntrospector
@@ -54,7 +54,6 @@ import com.navercorp.fixturemonkey.kotlin.type.KotlinNullabilityUtils
 import com.navercorp.fixturemonkey.kotlin.type.cachedKotlin
 import com.navercorp.fixturemonkey.kotlin.type.isKotlinLambda
 import com.navercorp.fixturemonkey.kotlin.type.isKotlinType
-import com.navercorp.objectfarm.api.tree.JvmNodeCandidateTreeContext
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.MAINTAINED
 import java.lang.reflect.Modifier
@@ -149,15 +148,10 @@ class KotlinPlugin : Plugin, JvmTypeSystemPlugin {
     }
 
     override fun configure(typeSystem: JvmTypeSystem) {
-        typeSystem.assemblyPlanner(
-            AssemblyPlanner(
-                System.nanoTime(),
-                JvmNodeCandidateTreeContext(),
-                KotlinNodePromoters.all(),
-                listOf(KotlinLeafTypeResolver.INSTANCE),
-                { delegate -> KotlinNodeCandidateGenerator(delegate) }
-            )
-        )
+        typeSystem.nodePromoters(KotlinNodePromoters.all())
+        typeSystem.leafTypeResolvers(listOf(KotlinLeafTypeResolver.INSTANCE))
+        typeSystem.candidateGeneratorWrapper { delegate -> KotlinNodeCandidateGenerator(delegate) }
+        typeSystem.inlinedValueResolver(KotlinValueClassResolver())
     }
 
     private fun isKotlinNonNullableProperty(property: com.navercorp.fixturemonkey.api.property.Property): Boolean {

--- a/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/input/KotlinValueClassResolver.kt
+++ b/fixture-monkey-kotlin/src/main/kotlin/com/navercorp/fixturemonkey/kotlin/input/KotlinValueClassResolver.kt
@@ -1,0 +1,103 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.kotlin.input
+
+import com.navercorp.fixturemonkey.api.container.ConcurrentLruCache
+import com.navercorp.fixturemonkey.api.type.KotlinTypeDetector.isKotlinType
+import com.navercorp.fixturemonkey.kotlin.type.cachedKotlin
+import com.navercorp.objectfarm.api.input.InlinedValueResolver
+import com.navercorp.objectfarm.api.input.ExtractedField
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Restores Kotlin value class properties that a raw field read flattens.
+ *
+ * A `@JvmInline value class` is inlined into its owner's field, so the field holds the underlying
+ * value rather than the value class instance. Decomposing a set value through raw field reads
+ * therefore yields the underlying value at the property's path, and the owner's constructor
+ * rejects it because it expects the value class.
+ *
+ * Only properties whose declared Kotlin type is a value class are re-boxed, and only when the field
+ * does not already hold the value class instance. Kotlin does not inline every position: a nullable
+ * value class over a primitive underlying type is stored boxed, while a nullable one over a
+ * reference type still inlines. A field that already holds the boxed instance is left as read.
+ */
+@API(since = "1.2.1", status = EXPERIMENTAL)
+class KotlinValueClassResolver : InlinedValueResolver {
+    override fun resolve(owner: Any, memberName: String, extracted: ExtractedField): ExtractedField {
+        val valueClassProperties = VALUE_CLASS_PROPERTIES_CACHE.computeIfAbsent(owner.javaClass) {
+            if (!isKotlinType(it)) {
+                return@computeIfAbsent emptyMap()
+            }
+
+            try {
+                it.cachedKotlin().memberProperties
+                    .mapNotNull { property ->
+                        val returnClass = property.returnType.classifier as? KClass<*>
+                        if (returnClass != null && returnClass.isValue) property.name to returnClass else null
+                    }
+                    .toMap()
+            } catch (_: Exception) {
+                emptyMap()
+            }
+        }
+
+        val valueClass = valueClassProperties[memberName] ?: return extracted
+        val rawValue = extracted.value ?: return extracted
+
+        if (valueClass.javaObjectType.isInstance(rawValue)) {
+            return extracted
+        }
+
+        val boxed = boxValueClass(rawValue, valueClass) ?: return extracted
+        return ExtractedField(boxed, valueClass.java)
+    }
+
+    /**
+     * Boxes the inlined [rawValue] back into [valueClass], unwinding nested value classes from the
+     * inside out. A value class over another value class is inlined down to the innermost
+     * underlying type, so each level has to be boxed before the next one can accept it.
+     */
+    private fun boxValueClass(rawValue: Any, valueClass: KClass<*>): Any? {
+        val constructor = valueClass.primaryConstructor ?: return null
+        val parameterClass = constructor.parameters.singleOrNull()?.type?.classifier as? KClass<*> ?: return null
+
+        val argument = if (parameterClass.isValue && !parameterClass.javaObjectType.isInstance(rawValue)) {
+            boxValueClass(rawValue, parameterClass) ?: return null
+        } else {
+            rawValue
+        }
+
+        return try {
+            constructor.isAccessible = true
+            constructor.call(argument)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        private val VALUE_CLASS_PROPERTIES_CACHE = ConcurrentLruCache<Class<*>, Map<String, KClass<*>>>(2048)
+    }
+}

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/PluginTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/PluginTest.kt
@@ -21,18 +21,28 @@ package com.navercorp.fixturemonkey.tests.kotlin
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.api.matcher.AssignableTypeMatcher
 import com.navercorp.fixturemonkey.api.matcher.MatcherOperator
+import com.navercorp.fixturemonkey.api.option.FixtureMonkeyOptionsBuilder
 import com.navercorp.fixturemonkey.api.plugin.InterfacePlugin
+import com.navercorp.fixturemonkey.api.plugin.Plugin
 import com.navercorp.fixturemonkey.api.property.ConcreteTypeCandidateConcretePropertyResolver
 import com.navercorp.fixturemonkey.api.property.PropertyUtils
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import com.navercorp.fixturemonkey.plugin.JvmTypeSystem
+import com.navercorp.fixturemonkey.plugin.JvmTypeSystemPlugin
 import com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT
+import com.navercorp.objectfarm.api.node.JvmNodeContext
+import com.navercorp.objectfarm.api.node.LeafTypeResolver
+import com.navercorp.objectfarm.api.nodecandidate.JvmNodeCandidate
+import com.navercorp.objectfarm.api.nodecandidate.JvmNodeCandidateGenerator
+import com.navercorp.objectfarm.api.type.JvmType
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.LinkedList
 import java.util.TreeSet
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PluginTest {
     @Test
@@ -312,4 +322,94 @@ class PluginTest {
 
         then(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun inlinedValueResolverOfLaterPluginKeepsKotlinResolver() {
+        val laterResolverApplied = AtomicBoolean(false)
+
+        class LaterJvmTypeSystemPlugin : Plugin, JvmTypeSystemPlugin {
+            override fun accept(optionsBuilder: FixtureMonkeyOptionsBuilder) = Unit
+
+            override fun configure(typeSystem: JvmTypeSystem) {
+                typeSystem.inlinedValueResolver { _, _, extracted ->
+                    laterResolverApplied.set(true)
+                    extracted
+                }
+            }
+        }
+
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(LaterJvmTypeSystemPlugin())
+            .build()
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = sut.giveMeBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(laterResolverApplied).isTrue
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun jvmTypeSystemPartsOfLaterPluginMergeWithKotlinPlugin() {
+        val leafTypeResolverConsulted = AtomicBoolean(false)
+        val candidateGeneratorWrapped = AtomicBoolean(false)
+
+        class LaterJvmTypeSystemPlugin : Plugin, JvmTypeSystemPlugin {
+            override fun accept(optionsBuilder: FixtureMonkeyOptionsBuilder) = Unit
+
+            override fun configure(typeSystem: JvmTypeSystem) {
+                typeSystem.leafTypeResolvers(
+                    listOf(
+                        LeafTypeResolver {
+                            leafTypeResolverConsulted.set(true)
+                            false
+                        }
+                    )
+                )
+                typeSystem.candidateGeneratorWrapper { delegate ->
+                    object : JvmNodeCandidateGenerator {
+                        override fun generateNextNodeCandidates(jvmType: JvmType): List<JvmNodeCandidate> {
+                            candidateGeneratorWrapped.set(true)
+                            return delegate.generateNextNodeCandidates(jvmType)
+                        }
+
+                        override fun isSupported(jvmType: JvmType): Boolean = delegate.isSupported(jvmType)
+
+                        override fun isSupported(jvmType: JvmType, context: JvmNodeContext): Boolean =
+                            delegate.isSupported(jvmType, context)
+                    }
+                }
+            }
+        }
+
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .plugin(LaterJvmTypeSystemPlugin())
+            .build()
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = sut.giveMeBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+        val leafHolder = sut.giveMeOne<NoPropertyObject>()
+
+        then(candidateGeneratorWrapped).isTrue
+        then(leafTypeResolverConsulted).isTrue
+        then(actual).isEqualTo(expected)
+        then(leafHolder.noProperty).isNotNull
+    }
+
+    @JvmInline
+    value class Foo(val bar: String)
+
+    data class ValueClassObject(val foo: Foo)
+
+    class NoProperty
+
+    data class NoPropertyObject(val noProperty: NoProperty)
 } 

--- a/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
+++ b/fixture-monkey-tests/kotlin-tests/src/test/kotlin/com/navercorp/fixturemonkey/tests/kotlin/ValueClassTest.kt
@@ -128,9 +128,86 @@ class ValueClassTest {
         then(actual.fooObject.foo).isNull()
     }
 
+    @Test
+    fun setValueClassObject() {
+        data class ValueClassObject(val foo: Foo)
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = SUT.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun setNestedValueClassObject() {
+        data class ValueClassObject(val foo: Foo)
+
+        data class NestedValueClassObject(val fooObject: ValueClassObject)
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = SUT.giveMeKotlinBuilder<NestedValueClassObject>()
+            .set(NestedValueClassObject::fooObject, expected)
+            .sample()
+
+        then(actual.fooObject).isEqualTo(expected)
+    }
+
+    @Test
+    fun setValueClassObjectWithRenamedProperty() {
+        data class ValueClassObject(val foo: Foo)
+
+        val sut = FixtureMonkey.builder()
+            .plugin(KotlinPlugin())
+            .defaultPropertyNameResolver { property -> "renamed_" + property.name }
+            .build()
+
+        val expected = ValueClassObject(Foo("hello"))
+
+        val actual = sut.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun setValueClassOverValueClassObject() {
+        data class ValueClassObject(val fooWrapper: FooWrapper)
+
+        val expected = ValueClassObject(FooWrapper(Foo("hello")))
+
+        val actual = SUT.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun setPrivateConstructorValueClassObject() {
+        data class ValueClassObject(val foo: FooWithPrivateConstructor)
+
+        val expected: ValueClassObject = SUT.giveMeOne()
+
+        val actual = SUT.giveMeKotlinBuilder<ValueClassObject>()
+            .set(expected)
+            .sample()
+
+        then(actual).isEqualTo(expected)
+    }
+
     @JvmInline
     value class Foo(
         val bar: String,
+    )
+
+    @JvmInline
+    value class FooWrapper(
+        val foo: Foo
     )
 
     @JvmInline

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/FixtureMonkeyBuilder.java
@@ -63,11 +63,16 @@ import com.navercorp.fixturemonkey.buildergroup.ArbitraryBuilderGroup;
 import com.navercorp.fixturemonkey.customizer.MonkeyDirectiveFactory;
 import com.navercorp.fixturemonkey.experimental.ExperimentalFixtureMonkeyOptions;
 import com.navercorp.fixturemonkey.planner.AssemblyPlanner;
+import com.navercorp.fixturemonkey.plugin.JvmTypeSystem;
 import com.navercorp.fixturemonkey.plugin.JvmTypeSystemPlugin;
 import com.navercorp.fixturemonkey.resolver.ManipulatorOptimizer;
 import com.navercorp.fixturemonkey.resolver.NoneManipulatorOptimizer;
 import com.navercorp.fixturemonkey.seed.SeedFileLoader;
 import com.navercorp.fixturemonkey.tracing.AssemblyTracer;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
+import com.navercorp.objectfarm.api.node.JvmNodePromoter;
+import com.navercorp.objectfarm.api.node.LeafTypeResolver;
+import com.navercorp.objectfarm.api.nodecandidate.JvmNodeCandidateGenerator;
 
 @SuppressWarnings("unused")
 @API(since = "0.4.0", status = Status.MAINTAINED)
@@ -85,7 +90,10 @@ public final class FixtureMonkeyBuilder {
 	private ManipulatorOptimizer manipulatorOptimizer = new NoneManipulatorOptimizer();
 	private boolean experimentalFileSeedEnabled = false;
 	private long seed = System.nanoTime();
-	private @Nullable AssemblyPlanner assemblyPlanner;
+	private final List<JvmNodePromoter> jvmNodePromoters = new ArrayList<>();
+	private final List<LeafTypeResolver> leafTypeResolvers = new ArrayList<>();
+	private @Nullable UnaryOperator<JvmNodeCandidateGenerator> candidateGeneratorWrapper;
+	private @Nullable InlinedValueResolver inlinedValueResolver;
 	private @Nullable AssemblyTracer tracer;
 
 	public FixtureMonkeyBuilder pushPropertyGenerator(MatcherOperator<PropertyGenerator> propertyGenerator) {
@@ -441,7 +449,35 @@ public final class FixtureMonkeyBuilder {
 	public FixtureMonkeyBuilder plugin(Plugin plugin) {
 		fixtureMonkeyOptionsBuilder.plugin(plugin);
 		if (plugin instanceof JvmTypeSystemPlugin) {
-			((JvmTypeSystemPlugin)plugin).configure(planner -> this.assemblyPlanner = planner);
+			((JvmTypeSystemPlugin)plugin).configure(new JvmTypeSystem() {
+				@Override
+				public void nodePromoters(List<JvmNodePromoter> nodePromoters) {
+					FixtureMonkeyBuilder.this.jvmNodePromoters.addAll(nodePromoters);
+				}
+
+				@Override
+				public void leafTypeResolvers(List<LeafTypeResolver> leafTypeResolvers) {
+					FixtureMonkeyBuilder.this.leafTypeResolvers.addAll(leafTypeResolvers);
+				}
+
+				@Override
+				public void candidateGeneratorWrapper(UnaryOperator<JvmNodeCandidateGenerator> wrapper) {
+					UnaryOperator<JvmNodeCandidateGenerator> registered =
+						FixtureMonkeyBuilder.this.candidateGeneratorWrapper;
+					FixtureMonkeyBuilder.this.candidateGeneratorWrapper = registered == null
+						? wrapper
+						: generator -> wrapper.apply(registered.apply(generator));
+				}
+
+				@Override
+				public void inlinedValueResolver(InlinedValueResolver resolver) {
+					InlinedValueResolver registered = FixtureMonkeyBuilder.this.inlinedValueResolver;
+					FixtureMonkeyBuilder.this.inlinedValueResolver = registered == null
+						? resolver
+						: (owner, memberName, extracted) ->
+						resolver.resolve(owner, memberName, registered.resolve(owner, memberName, extracted));
+				}
+			});
 		}
 		return this;
 	}
@@ -617,9 +653,13 @@ public final class FixtureMonkeyBuilder {
 
 		AssemblyTracer resolvedTracer = this.tracer != null ? this.tracer : AssemblyTracer.noOp();
 
-		AssemblyPlanner resolvedPlanner = this.assemblyPlanner != null
-			? this.assemblyPlanner
-			: new AssemblyPlanner(seed);
+		AssemblyPlanner resolvedPlanner = new AssemblyPlanner(
+			seed,
+			jvmNodePromoters,
+			leafTypeResolvers,
+			candidateGeneratorWrapper,
+			this.inlinedValueResolver != null ? this.inlinedValueResolver : InlinedValueResolver.noOp()
+		);
 
 		return new FixtureMonkey(
 			fixtureMonkeyOptions,

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/planner/AssemblyPlanner.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/planner/AssemblyPlanner.java
@@ -50,6 +50,7 @@ import com.navercorp.fixturemonkey.tracing.TraceContext;
 import com.navercorp.fixturemonkey.tracing.TraceContextResolutionListener;
 import com.navercorp.objectfarm.api.expression.PathExpression;
 import com.navercorp.objectfarm.api.input.ContainerDetector;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
 import com.navercorp.objectfarm.api.node.InterfaceResolver;
 import com.navercorp.objectfarm.api.node.JavaNodeContext;
 import com.navercorp.objectfarm.api.node.JvmNodeContext;
@@ -110,6 +111,11 @@ public final class AssemblyPlanner implements RuntimeTreeFactory, LeafTypeRegist
 	// Held here for isLeafType lookups; node-context construction reads them via NodeContextFactory.
 	private final List<LeafTypeResolver> additionalLeafTypeResolvers;
 
+	// Resolves what each field of a value passed to set(...) holds while it is decomposed into child
+	// paths. Installed by JVM language plugins whose declared properties differ from the raw JVM
+	// fields.
+	private final InlinedValueResolver inlinedValueResolver;
+
 	private final ContainerSizeResolverFactory containerSizeResolverFactory;
 	private final ContainerValuePruner containerValuePruner;
 	private final AbstractTypeResolver abstractTypeResolver;
@@ -121,27 +127,30 @@ public final class AssemblyPlanner implements RuntimeTreeFactory, LeafTypeRegist
 	 * @param seed the seed for random generation
 	 */
 	public AssemblyPlanner(long seed) {
-		this(seed, new JvmNodeCandidateTreeContext(), Collections.emptyList(), Collections.emptyList(), null);
+		this(seed, Collections.emptyList(), Collections.emptyList(), null, InlinedValueResolver.noOp());
 	}
 
 	/**
 	 * Creates a new adapter with all configurable components.
 	 *
 	 * @param seed                       the seed for random generation
-	 * @param treeContext                the tree context for caching subtree information
 	 * @param additionalPromoters        additional node promoters (e.g., KotlinNodePromoter)
 	 * @param additionalLeafTypeResolvers additional leaf type resolvers (e.g., KotlinLeafTypeResolver)
 	 * @param candidateGeneratorWrapper  wraps the candidate generator with platform-specific
 	 *                                   isSupported checks (e.g., KotlinNodeCandidateGenerator)
+	 * @param inlinedValueResolver       reconstructs value types a JVM language inlined into the
+	 *                                   owning member's field while a value passed to
+	 *                                   {@code set(...)} is decomposed
 	 */
 	public AssemblyPlanner(
 		long seed,
-		JvmNodeCandidateTreeContext treeContext,
 		List<JvmNodePromoter> additionalPromoters,
 		List<LeafTypeResolver> additionalLeafTypeResolvers,
-		@Nullable UnaryOperator<JvmNodeCandidateGenerator> candidateGeneratorWrapper
+		@Nullable UnaryOperator<JvmNodeCandidateGenerator> candidateGeneratorWrapper,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		this.seedState = new SeedState(seed);
+		this.inlinedValueResolver = inlinedValueResolver;
 		List<JvmNodePromoter> resolvedPromoters = additionalPromoters != null
 			? additionalPromoters
 			: Collections.emptyList();
@@ -156,7 +165,7 @@ public final class AssemblyPlanner implements RuntimeTreeFactory, LeafTypeRegist
 			this.additionalLeafTypeResolvers,
 			candidateGeneratorWrapper
 		);
-		this.treeCache = new TreeContextCache(treeContext, nodeContextFactory);
+		this.treeCache = new TreeContextCache(new JvmNodeCandidateTreeContext(), nodeContextFactory);
 		this.abstractTypeResolver = new AbstractTypeResolver(seedState);
 		this.pathResolverContextFactory = new PathResolverContextFactory(
 			containerSizeResolverFactory,
@@ -256,7 +265,11 @@ public final class AssemblyPlanner implements RuntimeTreeFactory, LeafTypeRegist
 			? property -> options.getPropertyNameResolver(property).resolve(property)
 			: (Property p) -> p.getName();
 		long analyzeStart = System.nanoTime();
-		AnalysisResult analysisResult = ManipulatorAnalyzer.analyze(directives, nameResolver);
+		AnalysisResult analysisResult = ManipulatorAnalyzer.analyze(
+			directives,
+			nameResolver,
+			inlinedValueResolver
+		);
 		long analyzeTimeNanos = System.nanoTime() - analyzeStart;
 
 		// Resolve interface/abstract class to concrete implementation
@@ -497,6 +510,16 @@ public final class AssemblyPlanner implements RuntimeTreeFactory, LeafTypeRegist
 	 */
 	public ConcurrentHashMap<?, ?> nodeMetadataCache() {
 		return nodeMetadataCache;
+	}
+
+	/**
+	 * Returns the {@link InlinedValueResolver} applied while decomposing a value passed to
+	 * {@code set(...)}, so that assembly decomposes the value the same way planning did.
+	 *
+	 * @return the inlined value resolver
+	 */
+	public InlinedValueResolver inlinedValueResolver() {
+		return inlinedValueResolver;
 	}
 
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/planner/ManipulatorAnalyzer.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/planner/ManipulatorAnalyzer.java
@@ -70,6 +70,7 @@ import com.navercorp.objectfarm.api.expression.PathExpression;
 import com.navercorp.objectfarm.api.input.ContainerDetector;
 import com.navercorp.objectfarm.api.input.ExtractedField;
 import com.navercorp.objectfarm.api.input.FieldExtractor;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
 import com.navercorp.objectfarm.api.input.ValueAnalysisResult;
 import com.navercorp.objectfarm.api.input.ValueAnalyzer;
 import com.navercorp.objectfarm.api.node.ContainerSizeResolver;
@@ -101,12 +102,15 @@ public final class ManipulatorAnalyzer {
 	 * plugin-specific naming (e.g., Jackson {@code @JsonProperty}) is preserved on the produced
 	 * child paths. Pass {@code null} to fall back to {@link Property#getName()}.
 	 *
-	 * @param directives   the list of directives to analyze
-	 * @param nameResolver per-property name resolver applied to decomposed child paths
+	 * @param directives              the list of directives to analyze
+	 * @param nameResolver            per-property name resolver applied to decomposed child paths
+	 * @param inlinedValueResolver    reconstructs value types a JVM language inlined into the
+	 *                                decomposed object's fields
 	 */
 	public static AnalysisResult analyze(
 		List<PathDirective> directives,
-		@Nullable Function<Property, String> nameResolver
+		@Nullable Function<Property, String> nameResolver,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		List<PathResolver<InterfaceResolver>> interfaceResolvers = new ArrayList<>();
 		List<PathResolver<GenericTypeResolver>> genericTypeResolvers = new ArrayList<>();
@@ -146,7 +150,8 @@ public final class ManipulatorAnalyzer {
 				valueOrderByPath,
 				customizersByPath,
 				nodeCollisions,
-				nameResolver
+				nameResolver,
+				inlinedValueResolver
 			);
 		}
 
@@ -211,7 +216,8 @@ public final class ManipulatorAnalyzer {
 		Map<PathExpression, Integer> valueOrderByPath,
 		Map<PathExpression, List<PropertyCustomizer>> customizersByPath,
 		List<ResolutionTrace.NodeCollision> nodeCollisions,
-		@Nullable Function<Property, String> nameResolver
+		@Nullable Function<Property, String> nameResolver,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		PathExpression pathExpression = directive.path();
 		int limit = directive.limit();
@@ -252,7 +258,8 @@ public final class ManipulatorAnalyzer {
 				valuesByPath,
 				valueOrderByPath,
 				nodeCollisions,
-				nameResolver
+				nameResolver,
+				inlinedValueResolver
 			);
 			return;
 		}
@@ -305,7 +312,8 @@ public final class ManipulatorAnalyzer {
 				valuesByPath,
 				valueOrderByPath,
 				nodeCollisions,
-				nameResolver
+				nameResolver,
+				inlinedValueResolver
 			);
 			return;
 		}
@@ -384,7 +392,8 @@ public final class ManipulatorAnalyzer {
 		Map<PathExpression, @Nullable Object> valuesByPath,
 		Map<PathExpression, Integer> valueOrderByPath,
 		List<ResolutionTrace.NodeCollision> nodeCollisions,
-		@Nullable Function<Property, String> nameResolver
+		@Nullable Function<Property, String> nameResolver,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		PathExpression pathExpression = directive.path();
 		Object value = directive.value();
@@ -413,7 +422,7 @@ public final class ManipulatorAnalyzer {
 
 		DecomposedContainerValueFactory factory = directive.decomposedContainerValueFactory();
 		ContainerDetector containerDetector = createContainerDetector(factory);
-		FieldExtractor fieldExtractor = createFieldExtractor(nameResolver);
+		FieldExtractor fieldExtractor = createFieldExtractor(nameResolver, inlinedValueResolver);
 
 		ValueAnalyzer analyzer = new ValueAnalyzer(containerDetector, fieldExtractor);
 		ValueAnalysisResult result = analyzer.analyzeDecomposed(value, pathExpression.toExpression());
@@ -491,7 +500,8 @@ public final class ManipulatorAnalyzer {
 		Map<PathExpression, @Nullable Object> valuesByPath,
 		Map<PathExpression, Integer> valueOrderByPath,
 		List<ResolutionTrace.NodeCollision> nodeCollisions,
-		@Nullable Function<Property, String> nameResolver
+		@Nullable Function<Property, String> nameResolver,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		PathExpression pathExpression = directive.path();
 		LazyArbitrary<?> lazyArbitrary = directive.lazyArbitrary();
@@ -568,7 +578,7 @@ public final class ManipulatorAnalyzer {
 
 		// Use standard container detector and property-aware field extractor for lazy values
 		ContainerDetector containerDetector = ContainerDetector.standard();
-		FieldExtractor fieldExtractor = createFieldExtractor(nameResolver);
+		FieldExtractor fieldExtractor = createFieldExtractor(nameResolver, inlinedValueResolver);
 
 		ValueAnalyzer analyzer = new ValueAnalyzer(containerDetector, fieldExtractor);
 		ValueAnalysisResult result = analyzer.analyzeDecomposed(value, pathExpression.toExpression());
@@ -676,7 +686,10 @@ public final class ManipulatorAnalyzer {
 	 * — never through {@code Property.getValue}.
 	 */
 	@SuppressWarnings({"argument", "type.argument", "methodref.return", "return"})
-	private static FieldExtractor createFieldExtractor(@Nullable Function<Property, String> nameResolver) {
+	private static FieldExtractor createFieldExtractor(
+		@Nullable Function<Property, String> nameResolver,
+		InlinedValueResolver inlinedValueResolver
+	) {
 		Function<Property, String> resolver = nameResolver != null ? nameResolver : Property::getName;
 		return new FieldExtractor() {
 			@Override
@@ -695,7 +708,11 @@ public final class ManipulatorAnalyzer {
 					String childPath = basePath + "." + name;
 					Class<?> declaredType = normalizeRawType(childProperty.getJvmType().getRawType());
 					Object fieldValue = readPropertyValue(childProperty, value);
-					result.put(childPath, new ExtractedField(fieldValue, declaredType));
+					ExtractedField extracted = new ExtractedField(fieldValue, declaredType);
+					result.put(
+						childPath,
+						inlinedValueResolver.resolve(value, childProperty.getName(), extracted)
+					);
 				}
 				return result;
 			}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/plugin/JvmTypeSystem.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/plugin/JvmTypeSystem.java
@@ -18,23 +18,68 @@
 
 package com.navercorp.fixturemonkey.plugin;
 
+import java.util.List;
+import java.util.function.UnaryOperator;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
-import com.navercorp.fixturemonkey.planner.AssemblyPlanner;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
+import com.navercorp.objectfarm.api.node.JvmNodePromoter;
+import com.navercorp.objectfarm.api.node.LeafTypeResolver;
+import com.navercorp.objectfarm.api.nodecandidate.JvmNodeCandidateGenerator;
 
 /**
  * Narrow SPI handed to {@link JvmTypeSystemPlugin#configure} that exposes only the
  * registration points a JVM language/type-system plugin needs. Hides the rest of
  * {@code FixtureMonkeyBuilder} so end users never see these hooks on the builder type.
+ * <p>
+ * A plugin registers the parts its language needs; {@code FixtureMonkeyBuilder} constructs the
+ * single {@code AssemblyPlanner} from them once every plugin has been applied. Registering parts
+ * rather than a ready-made planner is what lets several plugins contribute at the same time, and
+ * lets the builder inject configuration that is only settled at build time.
  */
 @API(since = "1.2.0", status = Status.EXPERIMENTAL)
 public interface JvmTypeSystem {
 	/**
-	 * Installs the {@link AssemblyPlanner} that the resulting {@code FixtureMonkey} uses
-	 * for JVM tree planning and assembly. Language-specific plugins typically supply a
-	 * planner pre-configured with their own {@code JvmNodePromoter}s, {@code LeafTypeResolver}s,
-	 * and {@code JvmNodeCandidateGenerator} decorators.
+	 * Registers {@link JvmNodePromoter}s that rewrite nodes while the candidate tree is built,
+	 * for language constructs the default promoters do not recognize.
+	 * <p>
+	 * Promoters from multiple plugins accumulate in registration order.
 	 */
-	void assemblyPlanner(AssemblyPlanner planner);
+	void nodePromoters(List<JvmNodePromoter> nodePromoters);
+
+	/**
+	 * Registers {@link LeafTypeResolver}s that decide which language types are leaves, meaning
+	 * they are generated as a whole instead of being expanded into child nodes.
+	 * <p>
+	 * Resolvers from multiple plugins accumulate in registration order, and the first one that
+	 * answers {@code true} wins.
+	 */
+	void leafTypeResolvers(List<LeafTypeResolver> leafTypeResolvers);
+
+	/**
+	 * Registers a decorator around the {@link JvmNodeCandidateGenerator}, typically to add a
+	 * language-specific {@code isSupported} check ahead of the default generator.
+	 * <p>
+	 * Decorators from multiple plugins compose in registration order, so the one registered last
+	 * ends up outermost.
+	 */
+	void candidateGeneratorWrapper(UnaryOperator<JvmNodeCandidateGenerator> candidateGeneratorWrapper);
+
+	/**
+	 * Installs the {@link InlinedValueResolver} applied while a value passed to {@code set(...)}
+	 * is decomposed into child paths.
+	 * <p>
+	 * Decomposition reads each field of the value off the JVM. When a language inlines a value type
+	 * into its owner's field — as Kotlin does for value classes — that read yields the underlying
+	 * value, while rebuilding the owner expects the value type. The resolver reconstructs it.
+	 * <p>
+	 * Only the read step is replaced. Decomposition happens at two points that enumerate and name
+	 * fields differently — directive analysis keys paths through the configured
+	 * {@code PropertyNameResolver}, assembly keys them by field name — and both keep doing so.
+	 * <p>
+	 * Resolvers from multiple plugins apply in registration order.
+	 */
+	void inlinedValueResolver(InlinedValueResolver inlinedValueResolver);
 }

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/plugin/JvmTypeSystemPlugin.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/plugin/JvmTypeSystemPlugin.java
@@ -26,10 +26,10 @@ import org.apiguardian.api.API.Status;
  * {@link com.navercorp.fixturemonkey.api.plugin.Plugin} cannot reach through
  * {@code FixtureMonkeyOptionsBuilder} alone.
  * <p>
- * The typical use case is supplying a customized {@code AssemblyPlanner} with
- * language-specific {@code JvmNodePromoter}s, {@code LeafTypeResolver}s, and
- * {@code JvmNodeCandidateGenerator} decorators (e.g., Kotlin value classes, Scala
- * case classes).
+ * The typical use case is registering language-specific {@code JvmNodePromoter}s,
+ * {@code LeafTypeResolver}s, and {@code JvmNodeCandidateGenerator} decorators (e.g., Kotlin
+ * value classes, Scala case classes), which {@code FixtureMonkeyBuilder} assembles into the
+ * {@code AssemblyPlanner} it builds.
  * <p>
  * Implementations are commonly combined with {@code Plugin} on the same class; a single
  * {@code FixtureMonkeyBuilder.plugin(...)} call invokes both SPIs.

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/AssembleContext.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/AssembleContext.java
@@ -41,6 +41,7 @@ import com.navercorp.fixturemonkey.planner.AnalysisResult;
 import com.navercorp.fixturemonkey.planner.RuntimeTreeFactory;
 import com.navercorp.fixturemonkey.tracing.TraceContext;
 import com.navercorp.objectfarm.api.expression.PathExpression;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
 import com.navercorp.objectfarm.api.tree.PathResolverContext;
 
 /**
@@ -155,6 +156,12 @@ public final class AssembleContext {
 	 */
 	private final Set<PathExpression> userContainerSizePaths;
 
+	/**
+	 * Resolves what each field of a value passed to {@code set(...)} holds while it is decomposed
+	 * into child paths.
+	 */
+	private final InlinedValueResolver inlinedValueResolver;
+
 	private AssembleContext(Builder builder) {
 		this.monkeyContext = builder.monkeyContext;
 		this.rootProperty = builder.rootProperty;
@@ -173,6 +180,7 @@ public final class AssembleContext {
 		this.runtimeTreeFactory = builder.runtimeTreeFactory;
 		this.pathResolverContext = builder.pathResolverContext;
 		this.nodeMetadataCache = builder.nodeMetadataCache;
+		this.inlinedValueResolver = builder.inlinedValueResolver;
 		this.userContainerSizePaths = Collections.unmodifiableSet(new HashSet<>(builder.userContainerSizePaths));
 		this.typedPathValues = Collections.unmodifiableMap(new HashMap<>(builder.typedPathValues));
 		this.typedPathOrders = Collections.unmodifiableMap(new HashMap<>(builder.typedPathOrders));
@@ -368,6 +376,16 @@ public final class AssembleContext {
 	}
 
 	/**
+	 * Returns the {@link InlinedValueResolver} applied while decomposing a set value into child
+	 * field values.
+	 *
+	 * @return the declared field resolver
+	 */
+	public InlinedValueResolver getInlinedValueResolver() {
+		return inlinedValueResolver;
+	}
+
+	/**
 	 * Returns the set of paths where the user has explicitly set container sizes.
 	 *
 	 * @return the user container size paths
@@ -406,6 +424,7 @@ public final class AssembleContext {
 		private @Nullable RuntimeTreeFactory runtimeTreeFactory;
 		private @Nullable PathResolverContext pathResolverContext;
 		private @Nullable ConcurrentHashMap<?, ?> nodeMetadataCache;
+		private InlinedValueResolver inlinedValueResolver = InlinedValueResolver.noOp();
 		private Set<PathExpression> userContainerSizePaths = Collections.emptySet();
 		private Map<PathExpression, @Nullable Object> typedPathValues = Collections.emptyMap();
 		private Map<PathExpression, Integer> typedPathOrders = Collections.emptyMap();
@@ -564,6 +583,18 @@ public final class AssembleContext {
 		 */
 		public Builder nodeMetadataCache(@Nullable ConcurrentHashMap<?, ?> nodeMetadataCache) {
 			this.nodeMetadataCache = nodeMetadataCache;
+			return this;
+		}
+
+		/**
+		 * Sets the {@link InlinedValueResolver} applied while decomposing a set value into child
+		 * field values.
+		 *
+		 * @param inlinedValueResolver the declared field resolver
+		 * @return this builder
+		 */
+		public Builder inlinedValueResolver(InlinedValueResolver inlinedValueResolver) {
+			this.inlinedValueResolver = inlinedValueResolver;
 			return this;
 		}
 

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/AssemblyState.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/AssemblyState.java
@@ -46,6 +46,9 @@ import com.navercorp.fixturemonkey.tracing.TraceContext;
 import com.navercorp.objectfarm.api.expression.PathExpression;
 import com.navercorp.objectfarm.api.expression.Segment;
 import com.navercorp.objectfarm.api.expression.TypeSelector;
+import com.navercorp.objectfarm.api.input.ContainerDetector;
+import com.navercorp.objectfarm.api.input.FieldExtractor;
+import com.navercorp.objectfarm.api.input.InlinedValueResolver;
 import com.navercorp.objectfarm.api.input.ObjectValueExtractor;
 import com.navercorp.objectfarm.api.node.JvmNode;
 import com.navercorp.objectfarm.api.tree.JvmNodeTree;
@@ -129,7 +132,8 @@ final class AssemblyState {
 		@Nullable RuntimeTreeFactory runtimeTreeFactory,
 		@Nullable PathResolverContext pathResolverContext,
 		@Nullable ConcurrentHashMap<?, ?> nodeMetadataCache,
-		Set<PathExpression> userContainerSizePaths
+		Set<PathExpression> userContainerSizePaths,
+		InlinedValueResolver inlinedValueResolver
 	) {
 		this.nodeTree = nodeTree;
 		this.candidatesByPath = candidatesByPath;
@@ -160,7 +164,7 @@ final class AssemblyState {
 			candidatesByPath,
 			limitsByPath,
 			nodeTree,
-			new ObjectValueExtractor()
+			new ObjectValueExtractor(FieldExtractor.reflection(inlinedValueResolver), ContainerDetector.standard())
 		);
 		this.userContainerSizePaths = userContainerSizePaths;
 		this.pathIndex = new PathIndex(

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/ValueProjectionAssembler.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/ValueProjectionAssembler.java
@@ -131,7 +131,8 @@ final class ValueProjectionAssembler {
 			context.getRuntimeTreeFactory(),
 			context.getPathResolverContext(),
 			context.getNodeMetadataCache(),
-			context.getUserContainerSizePaths()
+			context.getUserContainerSizePaths(),
+			context.getInlinedValueResolver()
 		);
 
 		if (state.traceContext.isEnabled()) {

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/resolver/ArbitraryResolver.java
@@ -508,6 +508,7 @@ public final class ArbitraryResolver {
 			.runtimeTreeFactory(this.assemblyPlanner)
 			.pathResolverContext(assemblyPlan.getResolverContext())
 			.nodeMetadataCache(this.assemblyPlanner.nodeMetadataCache())
+			.inlinedValueResolver(this.assemblyPlanner.inlinedValueResolver())
 			.userContainerSizePaths(userContainerSizePaths)
 			.build();
 

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/FieldExtractor.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/FieldExtractor.java
@@ -57,6 +57,17 @@ public interface FieldExtractor {
 	}
 
 	/**
+	 * Returns a field extractor that uses reflection to enumerate and key fields, passing each
+	 * field through {@code inlinedValueResolver} after reading it.
+	 *
+	 * @param inlinedValueResolver reconstructs value types the language inlined into fields
+	 * @return the reflection-based field extractor
+	 */
+	static FieldExtractor reflection(InlinedValueResolver inlinedValueResolver) {
+		return new ReflectionFieldExtractor(inlinedValueResolver);
+	}
+
+	/**
 	 * Returns a no-op extractor that doesn't extract any fields.
 	 *
 	 * @return a no-op field extractor
@@ -70,7 +81,8 @@ public interface FieldExtractor {
 	 */
 	final class ReflectionFieldExtractor implements FieldExtractor {
 
-		static final ReflectionFieldExtractor INSTANCE = new ReflectionFieldExtractor();
+		static final ReflectionFieldExtractor INSTANCE =
+			new ReflectionFieldExtractor(InlinedValueResolver.noOp());
 
 		/**
 		 * Cache for declared fields by class to avoid repeated reflection calls.
@@ -78,7 +90,10 @@ public interface FieldExtractor {
 		 */
 		private static final Map<Class<?>, Field[]> DECLARED_FIELDS_CACHE = new ConcurrentHashMap<>();
 
-		private ReflectionFieldExtractor() {
+		private final InlinedValueResolver inlinedValueResolver;
+
+		private ReflectionFieldExtractor(InlinedValueResolver inlinedValueResolver) {
+			this.inlinedValueResolver = inlinedValueResolver;
 		}
 
 		@Override
@@ -132,7 +147,8 @@ public interface FieldExtractor {
 
 				try {
 					Object fieldValue = field.get(value);
-					result.put(childPath, new ExtractedField(fieldValue, field.getType()));
+					ExtractedField extracted = new ExtractedField(fieldValue, field.getType());
+					result.put(childPath, inlinedValueResolver.resolve(value, field.getName(), extracted));
 				} catch (IllegalAccessException | SecurityException e) {
 					// Skip fields we can't access
 				}

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/InlinedValueResolver.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/InlinedValueResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.objectfarm.api.input;
+
+/**
+ * Reconstructs a value type that its language inlined into the owning member's field.
+ * <p>
+ * Some JVM languages compile a single-value wrapper away: the wrapper's underlying value is stored
+ * directly in the owner's field, and the wrapper only reappears at source-level boundaries such as
+ * constructor calls made through the language's own reflection. A Kotlin
+ * {@code @JvmInline value class} works this way, and so do Kotlin's own {@code Duration} and
+ * {@code UInt}.
+ * <p>
+ * That makes reading and writing such a member asymmetric. Reading it off the JVM yields the
+ * underlying value; writing it through the language expects the wrapper. Implementations bridge the
+ * two by rebuilding the wrapper around what was read.
+ * <p>
+ * A {@link FieldExtractor} decides which members to visit and what path to key each one by; only
+ * the read step goes through this resolver, so an extractor that applies a naming policy to its
+ * paths keeps applying it.
+ * <p>
+ * Implementations must return {@code extracted} unchanged for members they do not handle, which is
+ * the common case.
+ */
+@FunctionalInterface
+public interface InlinedValueResolver {
+	/**
+	 * Rebuilds the inlined value type of a single member, if it has one.
+	 *
+	 * @param owner      the object the member was read from
+	 * @param memberName the name of the member on {@code owner}, which is not necessarily the last
+	 *                   segment of the path it is keyed by
+	 * @param extracted  the value and type as read off the JVM
+	 * @return the reconstructed value, or {@code extracted} if this resolver does not apply
+	 */
+	ExtractedField resolve(Object owner, String memberName, ExtractedField extracted);
+
+	/**
+	 * Returns a resolver that leaves every member as read.
+	 *
+	 * @return the no-op resolver
+	 */
+	static InlinedValueResolver noOp() {
+		return (owner, memberName, extracted) -> extracted;
+	}
+}


### PR DESCRIPTION
## Summary
Rebuild inlined value types when decomposing a value passed to set(...)


## How Has This Been Tested?
* jvmTypeSystemPartsOfLaterPluginMergeWithKotlinPlugin
* inlinedValueResolverOfLaterPluginKeepsKotlinResolver
* setPrivateConstructorValueClassObject
* setValueClassOverValueClassObject
* setValueClassObjectWithRenamedProperty
* setNestedValueClassObject
* setValueClassObject

## Is the Document updated?
no
