### PR TITLE
Keep Checker Framework annotations out of the published bytecode

### DIFF
--- a/buildSrc/src/main/kotlin/com/navercorp/fixturemonkey/gradle/plugin/CheckerFrameworkConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/navercorp/fixturemonkey/gradle/plugin/CheckerFrameworkConventionsPlugin.kt
@@ -19,22 +19,55 @@
 package com.navercorp.fixturemonkey.gradle.plugin
 
 import org.checkerframework.gradle.plugin.CheckerFrameworkExtension
-import org.gradle.api.JavaVersion
+import org.checkerframework.gradle.plugin.CheckerFrameworkTaskExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
 
 class CheckerFrameworkConventionsPlugin : Plugin<Project> {
+    companion object {
+        private const val VERIFY_TASK_NAME = "checkerFrameworkMain"
+    }
+
     override fun apply(project: Project) {
         project.plugins.apply("org.checkerframework")
 
-        project.extensions.getByType<CheckerFrameworkExtension>().apply {
+        val checkerFramework = project.extensions.getByType<CheckerFrameworkExtension>().apply {
             checkers = listOf("org.checkerframework.checker.nullness.NullnessChecker")
             extraJavacArgs = listOf(
                 "-AsuppressWarnings=initialization,method.invocation,type.arguments"
             )
             excludeTests = true
         }
+
+        project.plugins.withId("java") {
+            val main = project.extensions.getByType<SourceSetContainer>().getByName("main")
+            val toolchains = project.extensions.getByType<JavaToolchainService>()
+            val java = project.extensions.getByType<JavaPluginExtension>()
+
+            val verifyNullness = project.tasks.register<JavaCompile>(VERIFY_TASK_NAME) {
+                source(main.allJava)
+                classpath = main.compileClasspath
+                javaCompiler.set(toolchains.compilerFor(java.toolchain))
+                destinationDirectory.set(project.layout.buildDirectory.dir("classes/checker-framework/main"))
+                onlyIf { !checkerFramework.skipCheckerFramework }
+            }
+
+            project.tasks.withType(JavaCompile::class.java).configureEach {
+                if (name != VERIFY_TASK_NAME) {
+                    extensions.getByType<CheckerFrameworkTaskExtension>().skipCheckerFramework = true
+                }
+            }
+
+            project.tasks.named("check") {
+                dependsOn(verifyNullness)
+            }
+        }
     }
 }
-

--- a/fixture-monkey-api/build.gradle.kts
+++ b/fixture-monkey-api/build.gradle.kts
@@ -19,9 +19,6 @@ multiReleaseVersions.forEach { releaseVersion ->
                 .replaceFirstChar { it.lowercase() }
 
             configuration.extendsFrom(configurations.getByName(defaultVersionConfigurationName))
-
-            val checkerFrameworkExtension = project.extensions.findByType<org.checkerframework.gradle.plugin.CheckerFrameworkExtension>()
-            checkerFrameworkExtension?.skipCheckerFramework = true
         }
 }
 

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/introspector/ArrayIntrospector.java
@@ -21,6 +21,7 @@ package com.navercorp.fixturemonkey.api.introspector;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -42,6 +43,7 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 		return property.getJvmType().getRawType().isArray();
 	}
 
+	@SuppressWarnings("argument")
 	@Override
 	public ArbitraryIntrospectorResult introspect(ArbitraryGeneratorContext context) {
 		ArbitraryProperty property = context.getArbitraryProperty();
@@ -57,7 +59,7 @@ public final class ArrayIntrospector implements ArbitraryIntrospector, Matcher {
 					elements -> {
 						Class<?> rawType = property.getObjectProperty().getProperty().getJvmType().getRawType();
 						ArrayBuilder arrayBuilder = new ArrayBuilder(
-							rawType.getComponentType(),
+							Objects.requireNonNull(rawType.getComponentType()),
 							elements.size()
 						);
 						for (Object element : elements) {

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositePropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/CompositePropertyGenerator.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
@@ -50,6 +51,7 @@ public final class CompositePropertyGenerator implements PropertyGenerator {
 		this.propertyGenerators = propertyGenerators;
 	}
 
+	@SuppressWarnings("argument")
 	public List<Property> generateChildProperties(Property property) {
 		Map<String, List<Property>> propertyListsByPropertyName = new HashMap<>();
 
@@ -60,8 +62,10 @@ public final class CompositePropertyGenerator implements PropertyGenerator {
 				.collect(Collectors.toList());
 
 			for (Property generatedProperty : generatedProperties) {
-				List<Property> properties =
-					propertyListsByPropertyName.computeIfAbsent(generatedProperty.getName(), name -> new ArrayList<>());
+				List<Property> properties = propertyListsByPropertyName.computeIfAbsent(
+					Objects.requireNonNull(generatedProperty.getName()),
+					name -> new ArrayList<>()
+				);
 
 				properties.add(generatedProperty);
 			}

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/FieldPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/property/FieldPropertyGenerator.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ public final class FieldPropertyGenerator implements PropertyGenerator {
 			.map(field -> {
 				Object constantValue = null;
 				try {
-					constantValue = field.get(null); // the underlying field is a static field, the argument is ignored.
+					constantValue = getStaticFieldValue(field);
 				} catch (IllegalAccessException ex) {
 					LOGGER.warn("Field {} is inaccessible.", field.getName(), ex);
 				}
@@ -89,5 +90,11 @@ public final class FieldPropertyGenerator implements PropertyGenerator {
 
 		return Stream.concat(arbitraryfieldStream, constantPropertyStream)
 			.collect(Collectors.toList());
+	}
+
+	@SuppressWarnings("argument")
+	@Nullable
+	private static Object getStaticFieldValue(Field field) throws IllegalAccessException {
+		return field.get(null); // the underlying field is a static field, the argument is ignored.
 	}
 }

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/SeedClaim.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/random/SeedClaim.java
@@ -42,8 +42,7 @@ import org.jspecify.annotations.Nullable;
  */
 @API(since = "1.2.0", status = Status.INTERNAL)
 public final class SeedClaim implements AutoCloseable {
-	@SuppressWarnings("type.argument")
-	private static final ThreadLocal<SeedClaim> ACTIVE = new ThreadLocal<>();
+	private static final ThreadLocal<@Nullable SeedClaim> ACTIVE = new ThreadLocal<>();
 
 	@Nullable
 	private final SeedClaim previous;

--- a/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
+++ b/fixture-monkey-api/src/main/java/com/navercorp/fixturemonkey/api/type/Types.java
@@ -52,6 +52,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -737,12 +738,16 @@ public abstract class Types {
 	 * @param targetSize the desired size
 	 * @return the truncated array, or the original if already small enough
 	 */
+	@SuppressWarnings("argument")
 	public static Object truncateArray(Object array, int targetSize) {
 		int length = java.lang.reflect.Array.getLength(array);
 		if (length <= targetSize) {
 			return array;
 		}
-		Object newArray = java.lang.reflect.Array.newInstance(array.getClass().getComponentType(), targetSize);
+		Object newArray = java.lang.reflect.Array.newInstance(
+			Objects.requireNonNull(array.getClass().getComponentType()),
+			targetSize
+		);
 		System.arraycopy(array, 0, newArray, 0, targetSize);
 		return newArray;
 	}

--- a/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/ValueDecomposer.java
+++ b/fixture-monkey/src/main/java/com/navercorp/fixturemonkey/projection/ValueDecomposer.java
@@ -155,9 +155,9 @@ final class ValueDecomposer {
 		Map<PathExpression, ValueCandidate> valuesToPut,
 		ValueOrder parentOrder
 	) {
-		Map<PathExpression, Object> extracted = valueExtractor.extract(value, basePath);
+		Map<PathExpression, @Nullable Object> extracted = valueExtractor.extract(value, basePath);
 
-		for (Map.Entry<PathExpression, Object> entry : extracted.entrySet()) {
+		for (Map.Entry<PathExpression, @Nullable Object> entry : extracted.entrySet()) {
 			PathExpression fieldPath = entry.getKey();
 			Object fieldValue = entry.getValue();
 
@@ -188,9 +188,9 @@ final class ValueDecomposer {
 	 * in the tree than the object's actual field value.
 	 */
 	boolean hasContainerFieldExpandedInTree(Object value, PathExpression basePath) {
-		Map<PathExpression, Object> extracted = valueExtractor.extract(value, basePath);
+		Map<PathExpression, @Nullable Object> extracted = valueExtractor.extract(value, basePath);
 
-		for (Map.Entry<PathExpression, Object> entry : extracted.entrySet()) {
+		for (Map.Entry<PathExpression, @Nullable Object> entry : extracted.entrySet()) {
 			Object fieldValue = entry.getValue();
 			if (fieldValue != null && containerDetector.isContainer(fieldValue)) {
 				JvmNode treeNode = nodeTree.resolve(entry.getKey().toExpression());
@@ -300,11 +300,11 @@ final class ValueDecomposer {
 			return;
 		}
 
-		Map<PathExpression, Object> extracted = valueExtractor.extract(container, basePath);
+		Map<PathExpression, @Nullable Object> extracted = valueExtractor.extract(container, basePath);
 
 		Set<PathExpression> skippedPrefixes = new HashSet<>();
 
-		for (Map.Entry<PathExpression, Object> entry : extracted.entrySet()) {
+		for (Map.Entry<PathExpression, @Nullable Object> entry : extracted.entrySet()) {
 			PathExpression path = entry.getKey();
 			Object value = entry.getValue();
 

--- a/object-farm-api/build.gradle.kts
+++ b/object-farm-api/build.gradle.kts
@@ -21,9 +21,6 @@ multiReleaseVersions.forEach { releaseVersion ->
                 .replaceFirstChar { it.lowercase() }
 
             configuration.extendsFrom(configurations.getByName(defaultVersionConfigurationName))
-
-            val checkerFrameworkExtension = project.extensions.findByType<org.checkerframework.gradle.plugin.CheckerFrameworkExtension>()
-            checkerFrameworkExtension?.skipCheckerFramework = true
         }
 }
 

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/JsonSchemaInputParser.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/JsonSchemaInputParser.java
@@ -179,6 +179,7 @@ public final class JsonSchemaInputParser implements TypeInputParser {
 			this.pos = 0;
 		}
 
+		@Nullable
 		Object parseValue() {
 			skipWhitespace();
 			if (pos >= input.length()) {
@@ -203,8 +204,8 @@ public final class JsonSchemaInputParser implements TypeInputParser {
 			}
 		}
 
-		private Map<String, Object> parseObject() {
-			Map<String, Object> result = new HashMap<>();
+		private Map<String, @Nullable Object> parseObject() {
+			Map<String, @Nullable Object> result = new HashMap<>();
 			expect('{');
 			skipWhitespace();
 
@@ -239,8 +240,8 @@ public final class JsonSchemaInputParser implements TypeInputParser {
 			return result;
 		}
 
-		private List<Object> parseArray() {
-			List<Object> result = new ArrayList<>();
+		private List<@Nullable Object> parseArray() {
+			List<@Nullable Object> result = new ArrayList<>();
 			expect('[');
 			skipWhitespace();
 

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/ObjectValueExtractor.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/ObjectValueExtractor.java
@@ -35,7 +35,7 @@ import com.navercorp.objectfarm.api.expression.PathExpression;
  * <p>
  * Combines {@link FieldExtractor} (for POJO field extraction) and
  * {@link ContainerDetector} (for container detection and sizing)
- * to produce a flat {@code Map<PathExpression, Object>} representing
+ * to produce a flat {@code Map<PathExpression, @Nullable Object>} representing
  * every reachable value in the object graph.
  * <p>
  * Uses identity-based visited tracking to safely handle circular references
@@ -67,8 +67,8 @@ public final class ObjectValueExtractor {
 	 * @param basePath the base path for this object (e.g., {@code PathExpression.root()} for "$")
 	 * @return a flat map of path→value for every reachable node in the object graph
 	 */
-	public Map<PathExpression, Object> extract(@Nullable Object value, PathExpression basePath) {
-		Map<PathExpression, Object> result = new LinkedHashMap<>();
+	public Map<PathExpression, @Nullable Object> extract(@Nullable Object value, PathExpression basePath) {
+		Map<PathExpression, @Nullable Object> result = new LinkedHashMap<>();
 		Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
 		extractInternal(value, basePath, result, visited);
 		return result;
@@ -77,7 +77,7 @@ public final class ObjectValueExtractor {
 	private void extractInternal(
 		@Nullable Object value,
 		PathExpression basePath,
-		Map<PathExpression, Object> result,
+		Map<PathExpression, @Nullable Object> result,
 		Set<Object> visited
 	) {
 		if (value == null) {
@@ -94,7 +94,7 @@ public final class ObjectValueExtractor {
 	private void extractObjectFields(
 		Object value,
 		PathExpression basePath,
-		Map<PathExpression, Object> result,
+		Map<PathExpression, @Nullable Object> result,
 		Set<Object> visited
 	) {
 		if (!visited.add(value)) {
@@ -121,7 +121,7 @@ public final class ObjectValueExtractor {
 	private void extractContainer(
 		Object container,
 		PathExpression basePath,
-		Map<PathExpression, Object> result,
+		Map<PathExpression, @Nullable Object> result,
 		Set<Object> visited
 	) {
 		if (container instanceof Map) {
@@ -136,7 +136,7 @@ public final class ObjectValueExtractor {
 	private void extractCollection(
 		Collection<?> collection,
 		PathExpression basePath,
-		Map<PathExpression, Object> result,
+		Map<PathExpression, @Nullable Object> result,
 		Set<Object> visited
 	) {
 		int index = 0;
@@ -153,7 +153,7 @@ public final class ObjectValueExtractor {
 	private void extractArray(
 		Object array,
 		PathExpression basePath,
-		Map<PathExpression, Object> result,
+		Map<PathExpression, @Nullable Object> result,
 		Set<Object> visited
 	) {
 		int length = Array.getLength(array);
@@ -167,7 +167,7 @@ public final class ObjectValueExtractor {
 		}
 	}
 
-	private void extractMap(Map<?, ?> map, PathExpression basePath, Map<PathExpression, Object> result) {
+	private void extractMap(Map<?, ?> map, PathExpression basePath, Map<PathExpression, @Nullable Object> result) {
 		int index = 0;
 		for (Map.Entry<?, ?> entry : map.entrySet()) {
 			PathExpression entryPath = basePath.index(index);

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/ValueAnalyzer.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/input/ValueAnalyzer.java
@@ -288,7 +288,7 @@ public final class ValueAnalyzer {
 		List<PathResolver<ContainerSizeResolver>> containerSizeResolvers,
 		List<PathResolver<InterfaceResolver>> interfaceResolvers,
 		List<PathResolver<GenericTypeResolver>> genericTypeResolvers,
-		ValueAnalysisResult.Builder builder
+		ValueAnalysisResult.@Nullable Builder builder
 	) {
 		extractContainerSizeResolverInternal(
 			value,
@@ -307,7 +307,7 @@ public final class ValueAnalyzer {
 		List<PathResolver<ContainerSizeResolver>> containerSizeResolvers,
 		List<PathResolver<InterfaceResolver>> interfaceResolvers,
 		List<PathResolver<GenericTypeResolver>> genericTypeResolvers,
-		ValueAnalysisResult.Builder builder,
+		ValueAnalysisResult.@Nullable Builder builder,
 		boolean storeContainerElements
 	) {
 		OptionalInt containerSize = containerDetector.getContainerSize(value);
@@ -578,7 +578,7 @@ public final class ValueAnalyzer {
 		List<PathResolver<ContainerSizeResolver>> containerSizeResolvers,
 		List<PathResolver<InterfaceResolver>> interfaceResolvers,
 		List<PathResolver<GenericTypeResolver>> genericTypeResolvers,
-		ValueAnalysisResult.Builder builder
+		ValueAnalysisResult.@Nullable Builder builder
 	) {
 		extractFieldContainerSizeResolversInternal(
 			value,
@@ -597,7 +597,7 @@ public final class ValueAnalyzer {
 		List<PathResolver<ContainerSizeResolver>> containerSizeResolvers,
 		List<PathResolver<InterfaceResolver>> interfaceResolvers,
 		List<PathResolver<GenericTypeResolver>> genericTypeResolvers,
-		ValueAnalysisResult.Builder builder,
+		ValueAnalysisResult.@Nullable Builder builder,
 		boolean storeContainerElements
 	) {
 		Map<String, ExtractedField> extractedFields = fieldExtractor.extractFields(value, basePath);

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/node/JavaArrayElementNodeGenerator.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/node/JavaArrayElementNodeGenerator.java
@@ -21,6 +21,7 @@ package com.navercorp.objectfarm.api.node;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.navercorp.objectfarm.api.nodecandidate.ContainerElementCreationMethod;
 import com.navercorp.objectfarm.api.nodecandidate.CreationMethod;
@@ -53,13 +54,14 @@ public final class JavaArrayElementNodeGenerator implements JvmContainerNodeGene
 	}
 
 	@Override
+	@SuppressWarnings("argument")
 	public List<JvmNode> generateContainerElements(
 		JvmNode containerNode,
 		JvmNodeContext context,
 		ContainerSizeResolver sizeResolver
 	) {
 		JvmType containerType = containerNode.getConcreteType();
-		Class<?> componentType = containerType.getRawType().getComponentType();
+		Class<?> componentType = Objects.requireNonNull(containerType.getRawType().getComponentType());
 
 		// Preserve generic type variables from the container type
 		// For GenericImplementation<String>[], the type variables [String] should be preserved

--- a/object-farm-api/src/main/java/com/navercorp/objectfarm/api/tree/JvmNodeCandidateTree.java
+++ b/object-farm-api/src/main/java/com/navercorp/objectfarm/api/tree/JvmNodeCandidateTree.java
@@ -236,8 +236,8 @@ public final class JvmNodeCandidateTree {
 		}
 
 		// Try to use cached subtree if available
-		if (treeContext != null && treeContext.isCached(jvmType)) {
-			SubtreeSnapshot snapshot = treeContext.getCachedSubtree(jvmType);
+		SubtreeSnapshot snapshot = treeContext != null ? treeContext.getCachedSubtree(jvmType) : null;
+		if (snapshot != null) {
 			// Reuse cached subtree
 			List<JvmNodeCandidate> cachedChildren = snapshot.getChildren();
 			Map<JvmNodeCandidate, List<JvmNodeCandidate>> cachedParentChildMap = snapshot.getParentChildMap();


### PR DESCRIPTION
## Summary
 Keep Checker Framework annotations out of the published bytecode

## (Optional): Description

The Checker Framework's javac writes the type qualifiers it infers into the class files it produces. We never wrote them in source, but 139 of the 147 classes in `fixture-monkey` shipped with `@UnknownKeyFor`, `@NonNull` and `@Initialized` on method returns and parameters. `checker-qual` is declared `compileOnly`, so it reaches no POM and consumers cannot resolve those annotation classes.

That went unnoticed since 1.1.16 because javac, and Kotlin through 2.3, silently drop an annotation they cannot resolve. Kotlin 2.4 reports it as an error whenever it has to infer a type that carries one, so the idiomatic calls stop compiling:
```  
e: Type annotation class 'org.checkerframework.checker.nullness.qual.UnknownKeyFor'
       of the inferred type is inaccessible.
```

Measured against `1.2.1` from Maven Central:

| Kotlin | `register(T::class.java) { it... }`, `thenApply { obj, builder -> }` |
|---|---|
| 2.0.21, 2.2.21, 2.3.0, 2.3.21 | compiles |
| 2.4.0, 2.4.20 | fails |


## How Has This Been Tested?
* existing tests

